### PR TITLE
feat: CI/CDをWorkload Identity Federation認証に移行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
       - uses: google-github-actions/setup-gcloud@v2
       - name: Submit Cloud Build
         working-directory: optimizer
@@ -62,8 +63,15 @@ jobs:
     needs: [test-optimizer, test-web]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -74,9 +82,5 @@ jobs:
         run: |
           npm ci
           npm run build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-          channelId: live
-          projectId: visitcare-shift-optimizer
+      - name: Deploy to Firebase Hosting
+        run: npx firebase-tools deploy --only hosting --project visitcare-shift-optimizer

--- a/docs/adr/ADR-010-workload-identity-federation.md
+++ b/docs/adr/ADR-010-workload-identity-federation.md
@@ -1,0 +1,48 @@
+# ADR-010: Workload Identity Federation によるCI/CD認証
+
+## ステータス
+Accepted
+
+## コンテキスト
+Phase 3bで構築したCI/CD（GitHub Actions）のデプロイジョブが失敗していた。原因はGitHub SecretsにGCP認証情報（`GCP_SA_KEY`, `FIREBASE_SERVICE_ACCOUNT`）が未設定だったこと。
+
+認証方式の選択肢:
+1. **JSON鍵ファイル**: SA鍵をGitHub Secretsに保存 → 鍵ローテーション管理が必要、漏洩リスク
+2. **Workload Identity Federation (WIF)**: OIDC トークン交換 → 長期鍵不要、GitHubリポジトリ単位でアクセス制御
+
+## 決定
+**Workload Identity Federation** を採用する。
+
+### 構成
+```
+GitHub Actions (OIDC Token)
+  → WIF Pool (github-actions-pool)
+    → OIDC Provider (github-oidc)
+      → attribute_condition: repository == "yasushihonda-acg/visitcare-shift-optimizer"
+  → Service Account (github-actions@visitcare-shift-optimizer.iam.gserviceaccount.com)
+    → roles/cloudbuild.builds.editor (Cloud Build submit)
+    → roles/firebasehosting.admin (Firebase Hosting deploy)
+    → roles/iam.serviceAccountUser (Cloud Run SA impersonation)
+```
+
+### CI/CD変更点
+- `credentials_json` → `workload_identity_provider` + `service_account` に変更
+- `FirebaseExtended/action-hosting-deploy@v0` → `firebase-tools` CLI に変更（WIF認証のADCを利用）
+- deploy-hosting に `permissions.id-token: write` を追加
+
+### GitHub Secrets
+| Secret名 | 用途 |
+|-----------|------|
+| `WIF_PROVIDER` | WIF OIDC プロバイダーのフルパス |
+| `WIF_SERVICE_ACCOUNT` | GitHub Actions用SAのメールアドレス |
+
+## 理由
+- 長期間有効なJSON鍵が不要でセキュリティリスクが低い
+- 鍵ローテーションの運用負荷がない
+- リポジトリ単位の`attribute_condition`で不正利用を防止
+- Google推奨のベストプラクティスに準拠
+
+## 結果
+- GCPリソース作成完了（SA, WIF Pool, OIDC Provider, バインディング）
+- GitHub Secrets設定完了（WIF_PROVIDER, WIF_SERVICE_ACCOUNT）
+- ci.yml更新完了（両デプロイジョブをWIF認証に移行）


### PR DESCRIPTION
## Summary
- CI/CDデプロイジョブの認証をJSON鍵からWorkload Identity Federation（WIF）に移行
- deploy-optimizer: `credentials_json` → WIF OIDC認証
- deploy-hosting: `FirebaseExtended/action-hosting-deploy` → `firebase-tools` CLI + WIF認証
- ADR-010としてWIF採用の設計判断を記録

## GCPリソース（作成済み）
| リソース | 名前 | 状態 |
|---------|------|------|
| Service Account | `github-actions@visitcare-shift-optimizer.iam.gserviceaccount.com` | ACTIVE |
| WIF Pool | `github-actions-pool` | ACTIVE |
| OIDC Provider | `github-oidc` (attribute_condition: リポジトリ限定) | ACTIVE |

## GitHub Secrets（設定済み）
- `WIF_PROVIDER` - WIF OIDCプロバイダーのフルパス
- `WIF_SERVICE_ACCOUNT` - GitHub Actions用SAのメールアドレス

## Test plan
- [ ] PR作成でテストジョブ（test-optimizer, test-web）が通過すること
- [ ] main mergeでdeploy-optimizerジョブがCloud Build submitに成功すること
- [ ] main mergeでdeploy-hostingジョブがFirebase Hosting deployに成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)