### PR TITLE
fix: CI/CDデプロイの権限・パラメータ修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v2
       - name: Submit Cloud Build
         working-directory: optimizer
-        run: gcloud builds submit --config=cloudbuild.yaml .
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          gcloud builds submit --config=cloudbuild.yaml --substitutions=SHORT_SHA="${SHORT_SHA}" .
 
   deploy-hosting:
     name: Deploy Hosting (Firebase)
@@ -68,10 +70,12 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
+      - id: auth
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -83,4 +87,6 @@ jobs:
           npm ci
           npm run build
       - name: Deploy to Firebase Hosting
-        run: npx firebase-tools deploy --only hosting --project visitcare-shift-optimizer
+        run: npx firebase-tools@latest deploy --only hosting --project visitcare-shift-optimizer
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}


### PR DESCRIPTION
## Summary
- deploy-optimizer: `SHORT_SHA` を `--substitutions` で明示的に渡す（Cloud Build組み込み変数は `gcloud builds submit` では自動設定されない）
- deploy-hosting: `token_format: access_token` 追加、`GOOGLE_APPLICATION_CREDENTIALS` 明示指定、`firebase-tools@latest` を使用
- IAMロール追加済み: `storage.admin`, `viewer`, `firebase.admin`, `serviceusage.serviceUsageConsumer`

## 修正した問題
1. `invalid image name "...shift-optimizer:"` — `SHORT_SHA` 変数が空のためタグ名が不正
2. `Failed to get Firebase project` — firebase-tools がWIF ADCクレデンシャルで認証できなかった

## Test plan
- [ ] deploy-optimizer: Cloud Build submitが成功すること
- [ ] deploy-hosting: Firebase Hosting deployが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)