### PR TITLE
fix: Cloud Buildカンマ区切り問題 + Firebase Hosting認証修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
         run: |
           npm ci
           npm run build
+      - uses: google-github-actions/setup-gcloud@v2
       - name: Deploy to Firebase Hosting
-        run: npx firebase-tools@latest deploy --only hosting --project visitcare-shift-optimizer
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+        run: npx firebase-tools@latest deploy --only hosting --project visitcare-shift-optimizer --token "${{ steps.auth.outputs.access_token }}"

--- a/optimizer/cloudbuild.yaml
+++ b/optimizer/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
       - '--timeout=300'
       - '--max-instances=3'
       - '--no-allow-unauthenticated'
-      - '--set-env-vars=CORS_ORIGINS=${_CORS_ORIGINS},ALLOW_UNAUTHENTICATED=${_ALLOW_UNAUTHENTICATED}'
+      - '--set-env-vars=^##^CORS_ORIGINS=${_CORS_ORIGINS}##ALLOW_UNAUTHENTICATED=${_ALLOW_UNAUTHENTICATED}'
 
 images:
   - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_IMAGE_NAME}:${SHORT_SHA}'


### PR DESCRIPTION
## Summary
- cloudbuild.yaml: `--set-env-vars` のデリミタを `^##^` に変更（`CORS_ORIGINS` のカンマがキー=値区切りと誤認される問題）
- ci.yml: `firebase-tools` に `--token` でWIFアクセストークンを渡す（ADCクレデンシャルファイル非対応の回避）

## 修正した問題
1. `ERROR: Bad syntax for dict arg: [https://visitcare-shift-optimizer.firebaseapp.com]` — gcloudがCORS_ORIGINSのカンマを辞書引数の区切りとして解釈
2. `Failed to get Firebase project` — firebase-toolsがWIF external_accountクレデンシャルファイルでFirebase APIに認証できない

## Test plan
- [ ] deploy-optimizer: Cloud Build → Docker build → Cloud Run deploy 成功
- [ ] deploy-hosting: firebase-tools deploy --only hosting 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)