### PR TITLE
fix: Firebase auth/invalid-api-key エラーを修正

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -1,3 +1,18 @@
 # 本番環境設定（ビルド時に適用）
+
+# Firebase Client SDK（公開キー - クライアントサイド用）
+NEXT_PUBLIC_FIREBASE_API_KEY=AIzaSyDo5WBnB6A_SsP5wMmFd_VGSSUF9880Ly8
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=visitcare-shift-optimizer.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=visitcare-shift-optimizer
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=visitcare-shift-optimizer.firebasestorage.app
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1045989697649
+NEXT_PUBLIC_FIREBASE_APP_ID=1:1045989697649:web:0880e1b41e4cb9bbed53d0
+
+# エミュレータ無効
+NEXT_PUBLIC_USE_EMULATOR=false
+
+# 認証モード
 NEXT_PUBLIC_AUTH_MODE=demo
+
+# 最適化API URL
 NEXT_PUBLIC_OPTIMIZER_API_URL=https://shift-optimizer-1045989697649.asia-northeast1.run.app


### PR DESCRIPTION
## Summary
- `.env.production` にFirebase SDK設定（APIキー、authDomain、projectId、appId等）が欠落していたため、本番デプロイ後にFirebase Authが `auth/invalid-api-key` で初期化に失敗していた
- Firebase Webアプリを新規登録し、取得したSDK設定を `.env.production` に追加
- ローカルビルド + 32テスト全パスを確認済み

## Root Cause
Next.jsの `output: 'export'` はビルド時に `.env.production` を読み込み、`NEXT_PUBLIC_*` 変数をバンドルに埋め込む。Firebase設定が未定義のまま静的エクスポートされたため、本番でFirebase初期化時にエラーが発生。

## Test plan
- [x] ローカル `npm run build` 成功
- [x] ビルド出力にAPIキーが含まれることを確認（`out/_next/static/chunks/` 内）
- [x] Vitest 32件全パス
- [ ] CI通過後、Firebase Hostingへのデプロイで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)