### PR TITLE
fix: Firebase Proxy互換性とAuth初期化エラーを修正

### DIFF
--- a/web/src/hooks/useCustomers.ts
+++ b/web/src/hooks/useCustomers.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { getDb } from '@/lib/firebase';
 import { convertTimestamps } from '@/lib/firestore-converter';
 import type { Customer } from '@/types';
 
@@ -13,7 +13,7 @@ export function useCustomers() {
 
   useEffect(() => {
     const unsubscribe = onSnapshot(
-      collection(db, 'customers'),
+      collection(getDb(), 'customers'),
       (snapshot) => {
         const map = new Map<string, Customer>();
         snapshot.forEach((doc) => {

--- a/web/src/hooks/useHelpers.ts
+++ b/web/src/hooks/useHelpers.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { getDb } from '@/lib/firebase';
 import { convertTimestamps } from '@/lib/firestore-converter';
 import type { Helper } from '@/types';
 
@@ -13,7 +13,7 @@ export function useHelpers() {
 
   useEffect(() => {
     const unsubscribe = onSnapshot(
-      collection(db, 'helpers'),
+      collection(getDb(), 'helpers'),
       (snapshot) => {
         const map = new Map<string, Helper>();
         snapshot.forEach((doc) => {

--- a/web/src/hooks/useOrders.ts
+++ b/web/src/hooks/useOrders.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { collection, query, where, onSnapshot, Timestamp } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { getDb } from '@/lib/firebase';
 import { convertTimestamps } from '@/lib/firestore-converter';
 import type { Order } from '@/types';
 
@@ -14,7 +14,7 @@ export function useOrders(weekStart: Date) {
   useEffect(() => {
     const weekStartTs = Timestamp.fromDate(weekStart);
     const q = query(
-      collection(db, 'orders'),
+      collection(getDb(), 'orders'),
       where('week_start_date', '==', weekStartTs)
     );
 

--- a/web/src/hooks/useStaffUnavailability.ts
+++ b/web/src/hooks/useStaffUnavailability.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { collection, query, where, onSnapshot, Timestamp } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { getDb } from '@/lib/firebase';
 import { convertTimestamps } from '@/lib/firestore-converter';
 import type { StaffUnavailability } from '@/types';
 
@@ -14,7 +14,7 @@ export function useStaffUnavailability(weekStart: Date) {
   useEffect(() => {
     const weekStartTs = Timestamp.fromDate(weekStart);
     const q = query(
-      collection(db, 'staff_unavailability'),
+      collection(getDb(), 'staff_unavailability'),
       where('week_start_date', '==', weekStartTs)
     );
 

--- a/web/src/lib/api/__tests__/optimizer.test.ts
+++ b/web/src/lib/api/__tests__/optimizer.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Firebase authモック（optimizer.tsがimportするため先にモック）
 vi.mock('@/lib/firebase', () => ({
-  auth: { currentUser: { getIdToken: () => Promise.resolve('mock-token') } },
-  db: {},
+  getFirebaseAuth: () => ({ currentUser: { getIdToken: () => Promise.resolve('mock-token') } }),
+  getDb: () => ({}),
 }));
 
 import { runOptimize, OptimizeApiError } from '../optimizer';

--- a/web/src/lib/api/optimizer.ts
+++ b/web/src/lib/api/optimizer.ts
@@ -1,4 +1,4 @@
-import { auth } from '@/lib/firebase';
+import { getFirebaseAuth } from '@/lib/firebase';
 
 const API_URL = process.env.NEXT_PUBLIC_OPTIMIZER_API_URL ?? 'http://localhost:8081';
 
@@ -28,7 +28,7 @@ export interface OptimizeError {
 
 async function getAuthHeaders(): Promise<Record<string, string>> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  const user = auth.currentUser;
+  const user = getFirebaseAuth().currentUser;
   if (user) {
     const token = await user.getIdToken();
     headers['Authorization'] = `Bearer ${token}`;

--- a/web/src/lib/auth/AuthProvider.tsx
+++ b/web/src/lib/auth/AuthProvider.tsx
@@ -6,7 +6,7 @@ import {
   signInAnonymously,
   type User,
 } from 'firebase/auth';
-import { auth } from '@/lib/firebase';
+import { getFirebaseAuth } from '@/lib/firebase';
 
 type AuthMode = 'required' | 'demo';
 
@@ -34,7 +34,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+    const unsubscribe = onAuthStateChanged(getFirebaseAuth(), (firebaseUser) => {
       setUser(firebaseUser);
       setLoading(false);
     });
@@ -44,7 +44,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // デモモード: 未認証なら匿名サインイン
   useEffect(() => {
     if (AUTH_MODE === 'demo' && !loading && !user) {
-      signInAnonymously(auth).catch(console.error);
+      signInAnonymously(getFirebaseAuth()).catch(console.error);
     }
   }, [loading, user]);
 

--- a/web/src/lib/auth/__tests__/AuthProvider.test.tsx
+++ b/web/src/lib/auth/__tests__/AuthProvider.test.tsx
@@ -7,8 +7,8 @@ const mockOnAuthStateChanged = vi.fn();
 const mockSignInAnonymously = vi.fn();
 
 vi.mock('@/lib/firebase', () => ({
-  auth: {},
-  db: {},
+  getFirebaseAuth: () => ({}),
+  getDb: () => ({}),
 }));
 
 vi.mock('firebase/auth', () => ({

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -57,19 +57,11 @@ function initAuth(): Auth {
   return _auth;
 }
 
-// Proxyで遅延初期化（SSRビルド時にFirebase初期化を回避）
-export const db: Firestore = new Proxy({} as Firestore, {
-  get(_target, prop) {
-    const instance = initDb();
-    const value = (instance as unknown as Record<string | symbol, unknown>)[prop];
-    return typeof value === 'function' ? value.bind(instance) : value;
-  },
-});
+// 遅延初期化関数（SSRビルド時にFirebase初期化を回避）
+export function getDb(): Firestore {
+  return initDb();
+}
 
-export const auth: Auth = new Proxy({} as Auth, {
-  get(_target, prop) {
-    const instance = initAuth();
-    const value = (instance as unknown as Record<string | symbol, unknown>)[prop];
-    return typeof value === 'function' ? value.bind(instance) : value;
-  },
-});
+export function getFirebaseAuth(): Auth {
+  return initAuth();
+}


### PR DESCRIPTION
## Summary
- Firebase SDK v12の`collection()`が`instanceof`チェックで型検証するため、Proxyパターンが拒否される問題を修正
- `db`/`auth`のProxy export → `getDb()`/`getFirebaseAuth()`関数exportに変更
- GCPプロジェクトでFirebase Auth Identity Platformを初期化 + Anonymous sign-inを有効化

## Root Cause
1. **collection()エラー**: Firebase SDK v12の`collection()`は第一引数に対して`instanceof Firestore`チェックを行う。Proxyの`get`トラップだけでは`getPrototypeOf`が正しく転送されず、型チェックに失敗
2. **auth/configuration-not-found**: Firebase AuthenticationがGCPプロジェクトで未初期化だった（Identity Platform APIは有効だが設定が未作成）

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `firebase.ts` | Proxy → `getDb()`/`getFirebaseAuth()`関数 |
| `use*.ts` (4ファイル) | `collection(db, ...)` → `collection(getDb(), ...)` |
| `AuthProvider.tsx` | `auth` → `getFirebaseAuth()` |
| `optimizer.ts` | `auth.currentUser` → `getFirebaseAuth().currentUser` |
| テスト2ファイル | モックを関数形式に更新 |

## Test plan
- [x] Vitest 32件全パス
- [x] `npm run build` 成功（static export）
- [x] GCPでAuth初期化 + Anonymous sign-in有効化済み
- [ ] CI通過後、本番サイトで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)