### PR TITLE
feat: Phase 4a ドラッグ&ドロップ手動編集

### DIFF
--- a/docs/adr/ADR-011-phase4a-dnd-implementation.md
+++ b/docs/adr/ADR-011-phase4a-dnd-implementation.md
@@ -1,0 +1,67 @@
+# ADR-011: Phase 4a ドラッグ&ドロップ手動編集
+
+## ステータス
+承認済み (2026-02-14)
+
+## コンテキスト
+
+PRD核要件であるシフトの手動調整機能が未実装であった。ガントチャートでオーダーを閲覧できるが、割当変更はできない状態。実運用にはドラッグ&ドロップによるヘルパー間の割当変更が必要。
+
+## 決定
+
+### DnDライブラリ: @dnd-kit/core
+- React hooks中心の設計で既存アーキテクチャと統一的
+- Flexbox + absolute positioning レイアウトとの親和性が高い
+- タッチ対応、キーボードアクセシビリティ対応
+- 軽量（~10kb gzipped）
+
+**却下した代替案:**
+- react-beautiful-dnd: メンテナンス停止、React 19非対応
+- react-dnd: HTML5 DnD API依存でタッチ非対応
+
+### Firestore更新方法: クライアント直接 updateDoc()
+- 単一ドキュメント更新のためトランザクション不要
+- onSnapshot() リアルタイムリスナーが自動でUI反映
+- API経由にするとレイテンシ増大（不要な往復）
+
+### バリデーション戦略
+| 制約 | severity | ドロップ可否 |
+|------|----------|------------|
+| NGスタッフ | error | 拒否 |
+| 資格不適合 | error | 拒否 |
+| 時間重複 | error | 拒否 |
+| 希望休 | error | 拒否 |
+| 勤務時間外 | warning | 許可+警告 |
+
+## 実装スコープ
+
+### Phase 4aに含む
+- ヘルパー間のオーダー移動
+- 未割当→ヘルパーへの割当
+- ヘルパー→未割当への割当解除
+- リアルタイムバリデーション（ドラッグ中の視覚フィードバック）
+- トースト通知（success/warning/error）
+
+### Phase 4aに含まない
+- 時間シフト（横ドラッグ）
+- 世帯リンク一括ドラッグ
+- Undo/Redo
+
+## 影響
+
+### 新規ファイル
+- `web/src/lib/dnd/types.ts` — DnD型定義
+- `web/src/lib/dnd/validation.ts` — ドロップバリデーション
+- `web/src/lib/firestore/updateOrder.ts` — Firestore更新
+- `web/src/hooks/useDragAndDrop.ts` — DnD状態管理フック
+
+### 変更ファイル
+- `web/src/app/page.tsx` — DndContextラップ
+- `web/src/components/gantt/GanttBar.tsx` — useDraggable追加
+- `web/src/components/gantt/GanttRow.tsx` — useDroppable追加
+- `web/src/components/gantt/GanttChart.tsx` — dropZoneStatuses prop追加
+- `web/src/components/gantt/UnassignedSection.tsx` — draggable + droppable
+
+## 結果
+- PointerSensor で distance: 5px を設定し、クリック（詳細パネル表示）とドラッグを明確に区別
+- `manually_edited: true` フラグで手動編集済みオーダーを識別（最適化時の保護に利用可能）

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -748,6 +750,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -1,7 +1,10 @@
 'use client';
 
+import { useDraggable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
 import { timeToColumn, SLOT_WIDTH_PX } from './constants';
 import type { Order, Customer } from '@/types';
+import type { DragData } from '@/lib/dnd/types';
 import { cn } from '@/lib/utils';
 
 interface GanttBarProps {
@@ -10,6 +13,8 @@ interface GanttBarProps {
   hasViolation?: boolean;
   violationType?: 'error' | 'warning';
   onClick?: (order: Order) => void;
+  /** ドラッグ元のヘルパーID（null = 未割当） */
+  sourceHelperId: string | null;
 }
 
 const SERVICE_COLORS: Record<string, { bg: string; text: string }> = {
@@ -17,29 +22,45 @@ const SERVICE_COLORS: Record<string, { bg: string; text: string }> = {
   daily_living: { bg: 'bg-green-500', text: 'text-white' },
 };
 
-export function GanttBar({ order, customer, hasViolation, violationType, onClick }: GanttBarProps) {
+export function GanttBar({ order, customer, hasViolation, violationType, onClick, sourceHelperId }: GanttBarProps) {
   const startCol = timeToColumn(order.start_time);
   const endCol = timeToColumn(order.end_time);
   const width = (endCol - startCol) * SLOT_WIDTH_PX;
   const left = (startCol - 1) * SLOT_WIDTH_PX;
+
+  const dragData: DragData = { orderId: order.id, sourceHelperId };
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `order-${order.id}`,
+    data: dragData,
+  });
 
   const colors = SERVICE_COLORS[order.service_type] ?? SERVICE_COLORS.physical_care;
   const customerName = customer
     ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
     : order.customer_id;
 
+  const style = {
+    left,
+    width: Math.max(width, SLOT_WIDTH_PX * 2),
+    transform: CSS.Translate.toString(transform),
+  };
+
   return (
     <button
+      ref={setNodeRef}
       className={cn(
-        'absolute top-0.5 h-6 rounded text-[10px] leading-6 px-1 truncate cursor-pointer transition-opacity hover:opacity-80',
+        'absolute top-0.5 h-6 rounded text-[10px] leading-6 px-1 truncate cursor-grab transition-opacity hover:opacity-80',
         colors.bg,
         colors.text,
         hasViolation && violationType === 'error' && 'ring-2 ring-red-500',
-        hasViolation && violationType === 'warning' && 'ring-2 ring-yellow-500'
+        hasViolation && violationType === 'warning' && 'ring-2 ring-yellow-500',
+        isDragging && 'opacity-50 z-50 shadow-lg cursor-grabbing'
       )}
-      style={{ left, width: Math.max(width, SLOT_WIDTH_PX * 2) }}
-      onClick={() => onClick?.(order)}
+      style={style}
+      onClick={() => !isDragging && onClick?.(order)}
       title={`${customerName} ${order.start_time}-${order.end_time}`}
+      {...attributes}
+      {...listeners}
     >
       {width > 40 ? customerName : ''}
     </button>

--- a/web/src/components/gantt/GanttChart.tsx
+++ b/web/src/components/gantt/GanttChart.tsx
@@ -6,15 +6,17 @@ import { UnassignedSection } from './UnassignedSection';
 import type { DaySchedule } from '@/hooks/useScheduleData';
 import type { Customer, Order } from '@/types';
 import type { ViolationMap } from '@/lib/constraints/checker';
+import type { DropZoneStatus } from '@/lib/dnd/types';
 
 interface GanttChartProps {
   schedule: DaySchedule;
   customers: Map<string, Customer>;
   violations: ViolationMap;
   onOrderClick?: (order: Order) => void;
+  dropZoneStatuses?: Map<string, DropZoneStatus>;
 }
 
-export function GanttChart({ schedule, customers, violations, onOrderClick }: GanttChartProps) {
+export function GanttChart({ schedule, customers, violations, onOrderClick, dropZoneStatuses }: GanttChartProps) {
   if (schedule.totalOrders === 0) {
     return (
       <div className="flex items-center justify-center h-48 text-muted-foreground">
@@ -34,16 +36,16 @@ export function GanttChart({ schedule, customers, violations, onOrderClick }: Ga
             customers={customers}
             violations={violations}
             onOrderClick={onOrderClick}
+            dropZoneStatus={dropZoneStatuses?.get(row.helper.id)}
           />
         ))}
       </div>
-      {schedule.unassignedOrders.length > 0 && (
-        <UnassignedSection
-          orders={schedule.unassignedOrders}
-          customers={customers}
-          onOrderClick={onOrderClick}
-        />
-      )}
+      <UnassignedSection
+        orders={schedule.unassignedOrders}
+        customers={customers}
+        onOrderClick={onOrderClick}
+        dropZoneStatus={dropZoneStatuses?.get('unassigned-section')}
+      />
     </div>
   );
 }

--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -1,20 +1,35 @@
 'use client';
 
+import { useDroppable } from '@dnd-kit/core';
 import { GanttBar } from './GanttBar';
 import { SLOT_WIDTH_PX, TOTAL_SLOTS, HELPER_NAME_WIDTH_PX, GANTT_START_HOUR, GANTT_END_HOUR } from './constants';
 import type { Order, Customer } from '@/types';
 import type { HelperScheduleRow } from '@/hooks/useScheduleData';
 import type { ViolationMap } from '@/lib/constraints/checker';
+import type { DropZoneStatus } from '@/lib/dnd/types';
+import { cn } from '@/lib/utils';
 
 interface GanttRowProps {
   row: HelperScheduleRow;
   customers: Map<string, Customer>;
   violations: ViolationMap;
   onOrderClick?: (order: Order) => void;
+  dropZoneStatus?: DropZoneStatus;
 }
 
-export function GanttRow({ row, customers, violations, onOrderClick }: GanttRowProps) {
+const DROP_ZONE_STYLES: Record<DropZoneStatus, string> = {
+  idle: '',
+  valid: 'bg-green-50 ring-2 ring-inset ring-green-400',
+  warning: 'bg-yellow-50 ring-2 ring-inset ring-yellow-400',
+  invalid: 'bg-red-50 ring-2 ring-inset ring-red-400 cursor-not-allowed',
+};
+
+export function GanttRow({ row, customers, violations, onOrderClick, dropZoneStatus = 'idle' }: GanttRowProps) {
   const helperName = row.helper.name.short ?? `${row.helper.name.family}${row.helper.name.given}`;
+
+  const { setNodeRef, isOver } = useDroppable({
+    id: row.helper.id,
+  });
 
   return (
     <div className="flex border-b hover:bg-muted/30">
@@ -26,7 +41,11 @@ export function GanttRow({ row, customers, violations, onOrderClick }: GanttRowP
         {helperName}
       </div>
       <div
-        className="relative h-7"
+        ref={setNodeRef}
+        className={cn(
+          'relative h-7 transition-colors duration-150',
+          isOver && DROP_ZONE_STYLES[dropZoneStatus]
+        )}
         style={{ width: TOTAL_SLOTS * SLOT_WIDTH_PX }}
       >
         {/* 時間グリッド背景線 */}
@@ -50,6 +69,7 @@ export function GanttRow({ row, customers, violations, onOrderClick }: GanttRowP
               hasViolation={!!orderViolations?.length}
               violationType={hasError ? 'error' : hasWarning ? 'warning' : undefined}
               onClick={onOrderClick}
+              sourceHelperId={row.helper.id}
             />
           );
         })}

--- a/web/src/components/gantt/UnassignedSection.tsx
+++ b/web/src/components/gantt/UnassignedSection.tsx
@@ -1,12 +1,24 @@
 'use client';
 
+import { useDraggable, useDroppable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
 import { Badge } from '@/components/ui/badge';
 import type { Order, Customer } from '@/types';
+import type { DragData, DropZoneStatus } from '@/lib/dnd/types';
+import { cn } from '@/lib/utils';
+
+const DROP_ZONE_STYLES: Record<DropZoneStatus, string> = {
+  idle: '',
+  valid: 'bg-green-50 ring-2 ring-inset ring-green-400',
+  warning: 'bg-yellow-50 ring-2 ring-inset ring-yellow-400',
+  invalid: 'bg-red-50 ring-2 ring-inset ring-red-400 cursor-not-allowed',
+};
 
 interface UnassignedSectionProps {
   orders: Order[];
   customers: Map<string, Customer>;
   onOrderClick?: (order: Order) => void;
+  dropZoneStatus?: DropZoneStatus;
 }
 
 const SERVICE_LABELS: Record<string, string> = {
@@ -14,35 +26,83 @@ const SERVICE_LABELS: Record<string, string> = {
   daily_living: '生活',
 };
 
-export function UnassignedSection({ orders, customers, onOrderClick }: UnassignedSectionProps) {
+function UnassignedOrderItem({
+  order,
+  customers,
+  onOrderClick,
+}: {
+  order: Order;
+  customers: Map<string, Customer>;
+  onOrderClick?: (order: Order) => void;
+}) {
+  const customer = customers.get(order.customer_id);
+  const name = customer
+    ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+    : order.customer_id;
+
+  const dragData: DragData = { orderId: order.id, sourceHelperId: null };
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `order-${order.id}`,
+    data: dragData,
+  });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+  };
+
   return (
-    <div className="mt-4 border rounded-lg p-3">
+    <button
+      ref={setNodeRef}
+      style={style}
+      onClick={() => !isDragging && onOrderClick?.(order)}
+      className={cn(
+        'flex items-center gap-1.5 rounded-md border border-dashed px-2 py-1 text-xs hover:bg-muted transition-colors cursor-grab',
+        isDragging && 'opacity-50 shadow-lg cursor-grabbing'
+      )}
+      {...attributes}
+      {...listeners}
+    >
+      <Badge variant="outline" className="text-[10px]">
+        {SERVICE_LABELS[order.service_type] ?? order.service_type}
+      </Badge>
+      <span>{name}</span>
+      <span className="text-muted-foreground">
+        {order.start_time}-{order.end_time}
+      </span>
+    </button>
+  );
+}
+
+export function UnassignedSection({ orders, customers, onOrderClick, dropZoneStatus = 'idle' }: UnassignedSectionProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: 'unassigned-section',
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        'mt-4 border rounded-lg p-3 transition-colors duration-150',
+        isOver && DROP_ZONE_STYLES[dropZoneStatus]
+      )}
+    >
       <h3 className="text-sm font-medium text-muted-foreground mb-2">
         未割当 ({orders.length}件)
       </h3>
       <div className="flex flex-wrap gap-2">
-        {orders.map((order) => {
-          const customer = customers.get(order.customer_id);
-          const name = customer
-            ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
-            : order.customer_id;
-
-          return (
-            <button
-              key={order.id}
-              onClick={() => onOrderClick?.(order)}
-              className="flex items-center gap-1.5 rounded-md border border-dashed px-2 py-1 text-xs hover:bg-muted transition-colors"
-            >
-              <Badge variant="outline" className="text-[10px]">
-                {SERVICE_LABELS[order.service_type] ?? order.service_type}
-              </Badge>
-              <span>{name}</span>
-              <span className="text-muted-foreground">
-                {order.start_time}-{order.end_time}
-              </span>
-            </button>
-          );
-        })}
+        {orders.map((order) => (
+          <UnassignedOrderItem
+            key={order.id}
+            order={order}
+            customers={customers}
+            onOrderClick={onOrderClick}
+          />
+        ))}
+        {orders.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            オーダーをここにドロップして割当を解除
+          </p>
+        )}
       </div>
     </div>
   );

--- a/web/src/hooks/useDragAndDrop.ts
+++ b/web/src/hooks/useDragAndDrop.ts
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { DragStartEvent, DragEndEvent, DragOverEvent } from '@dnd-kit/core';
+import { toast } from 'sonner';
+import { validateDrop } from '@/lib/dnd/validation';
+import { updateOrderAssignment } from '@/lib/firestore/updateOrder';
+import type { DragData, DropZoneStatus } from '@/lib/dnd/types';
+import type { Order, Helper, Customer, StaffUnavailability, DayOfWeek } from '@/types';
+import type { HelperScheduleRow } from './useScheduleData';
+
+interface UseDragAndDropInput {
+  helperRows: HelperScheduleRow[];
+  unassignedOrders: Order[];
+  helpers: Map<string, Helper>;
+  customers: Map<string, Customer>;
+  unavailability: StaffUnavailability[];
+  day: DayOfWeek;
+}
+
+export function useDragAndDrop(input: UseDragAndDropInput) {
+  const { helperRows, unassignedOrders, helpers, customers, unavailability, day } = input;
+  const [dropZoneStatuses, setDropZoneStatuses] = useState<Map<string, DropZoneStatus>>(new Map());
+
+  const findOrder = useCallback(
+    (orderId: string): Order | undefined => {
+      for (const row of helperRows) {
+        const found = row.orders.find((o) => o.id === orderId);
+        if (found) return found;
+      }
+      return unassignedOrders.find((o) => o.id === orderId);
+    },
+    [helperRows, unassignedOrders]
+  );
+
+  const handleDragStart = useCallback((_event: DragStartEvent) => {
+    // ドラッグ開始時の処理（将来DragOverlay追加時に拡張予定）
+  }, []);
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const dragData = event.active.data.current as DragData | undefined;
+      if (!dragData || !event.over) {
+        setDropZoneStatuses(new Map());
+        return;
+      }
+
+      const targetHelperId = event.over.id as string;
+
+      // 未割当セクションへのドロップは常に許可
+      if (targetHelperId === 'unassigned-section') {
+        setDropZoneStatuses(new Map([['unassigned-section', 'valid']]));
+        return;
+      }
+
+      // 同じヘルパーへのドロップはスキップ
+      if (dragData.sourceHelperId === targetHelperId) {
+        setDropZoneStatuses(new Map([[targetHelperId, 'idle']]));
+        return;
+      }
+
+      const order = findOrder(dragData.orderId);
+      if (!order) return;
+
+      const targetRow = helperRows.find((r) => r.helper.id === targetHelperId);
+      const result = validateDrop({
+        order,
+        targetHelperId,
+        helpers,
+        customers,
+        targetHelperOrders: targetRow?.orders ?? [],
+        unavailability,
+        day,
+      });
+
+      const status: DropZoneStatus = !result.allowed
+        ? 'invalid'
+        : result.warnings.length > 0
+          ? 'warning'
+          : 'valid';
+      setDropZoneStatuses(new Map([[targetHelperId, status]]));
+    },
+    [findOrder, helperRows, helpers, customers, unavailability, day]
+  );
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      setDropZoneStatuses(new Map());
+
+      const dragData = event.active.data.current as DragData | undefined;
+      if (!dragData || !event.over) return;
+
+      const targetId = event.over.id as string;
+      const order = findOrder(dragData.orderId);
+      if (!order) return;
+
+      // 同じ場所へのドロップはスキップ
+      if (dragData.sourceHelperId === targetId) return;
+      if (dragData.sourceHelperId === null && targetId === 'unassigned-section') return;
+
+      // 未割当セクションへのドロップ → 割当解除
+      if (targetId === 'unassigned-section') {
+        try {
+          await updateOrderAssignment(order.id, []);
+          toast.success('割当を解除しました');
+        } catch (err) {
+          console.error('Failed to unassign order:', err);
+          toast.error('割当解除に失敗しました');
+        }
+        return;
+      }
+
+      // ヘルパーへのドロップ → バリデーション + 割当
+      const targetRow = helperRows.find((r) => r.helper.id === targetId);
+      const result = validateDrop({
+        order,
+        targetHelperId: targetId,
+        helpers,
+        customers,
+        targetHelperOrders: targetRow?.orders ?? [],
+        unavailability,
+        day,
+      });
+
+      if (!result.allowed) {
+        toast.error(result.reason);
+        return;
+      }
+
+      try {
+        await updateOrderAssignment(order.id, [targetId]);
+        if (result.warnings.length > 0) {
+          toast.warning(result.warnings.join('\n'));
+        } else {
+          toast.success('割当を変更しました');
+        }
+      } catch (err) {
+        console.error('Failed to update order assignment:', err);
+        toast.error('割当変更に失敗しました');
+      }
+    },
+    [findOrder, helperRows, helpers, customers, unavailability, day]
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setDropZoneStatuses(new Map());
+  }, []);
+
+  return {
+    dropZoneStatuses,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    handleDragCancel,
+  };
+}

--- a/web/src/lib/dnd/__tests__/validation.test.ts
+++ b/web/src/lib/dnd/__tests__/validation.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { validateDrop } from '../validation';
+import type { Order, Helper, Customer, StaffUnavailability, DayOfWeek } from '@/types';
+
+// --- テストヘルパー関数 ---
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 'order-1',
+    customer_id: 'cust-1',
+    week_start_date: new Date('2026-02-09'),
+    date: new Date('2026-02-09'),
+    start_time: '09:00',
+    end_time: '10:00',
+    service_type: 'physical_care',
+    assigned_staff_ids: ['helper-a'],
+    status: 'assigned',
+    manually_edited: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeHelper(overrides: Partial<Helper> = {}): Helper {
+  return {
+    id: 'helper-b',
+    name: { family: '田中', given: '太郎' },
+    qualifications: ['初任者研修'],
+    can_physical_care: true,
+    transportation: 'car',
+    weekly_availability: {
+      monday: [{ start_time: '08:00', end_time: '18:00' }],
+    },
+    preferred_hours: { min: 20, max: 40 },
+    available_hours: { min: 0, max: 40 },
+    customer_training_status: {},
+    employment_type: 'full_time',
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeCustomer(overrides: Partial<Customer> = {}): Customer {
+  return {
+    id: 'cust-1',
+    name: { family: '山田', given: '花子' },
+    address: '東京都',
+    location: { lat: 35.6, lng: 139.7 },
+    ng_staff_ids: [],
+    preferred_staff_ids: [],
+    weekly_services: {},
+    service_manager: 'mgr-1',
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function baseInput() {
+  const helper = makeHelper();
+  const customer = makeCustomer();
+  return {
+    order: makeOrder(),
+    targetHelperId: 'helper-b',
+    helpers: new Map([['helper-b', helper]]),
+    customers: new Map([['cust-1', customer]]),
+    targetHelperOrders: [] as Order[],
+    unavailability: [] as StaffUnavailability[],
+    day: 'monday' as DayOfWeek,
+  };
+}
+
+// --- テストケース ---
+
+describe('validateDrop', () => {
+  describe('成功パス', () => {
+    it('制約なしで割当可能', () => {
+      const result = validateDrop(baseInput());
+      expect(result.allowed).toBe(true);
+      if (result.allowed) {
+        expect(result.warnings).toHaveLength(0);
+      }
+    });
+  });
+
+  describe('error制約（ドロップ拒否）', () => {
+    it('NGスタッフ → 拒否', () => {
+      const input = baseInput();
+      input.customers.set('cust-1', makeCustomer({ ng_staff_ids: ['helper-b'] }));
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toContain('NG');
+      }
+    });
+
+    it('資格不適合（身体介護 + can_physical_care=false） → 拒否', () => {
+      const input = baseInput();
+      input.helpers.set('helper-b', makeHelper({ can_physical_care: false }));
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toContain('資格');
+      }
+    });
+
+    it('生活援助は資格不問 → 許可', () => {
+      const input = baseInput();
+      input.order = makeOrder({ service_type: 'daily_living' });
+      input.helpers.set('helper-b', makeHelper({ can_physical_care: false }));
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('時間重複 → 拒否', () => {
+      const input = baseInput();
+      input.targetHelperOrders = [makeOrder({ id: 'existing', start_time: '09:30', end_time: '10:30' })];
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toContain('重複');
+      }
+    });
+
+    it('時間が隣接（重複なし） → 許可', () => {
+      const input = baseInput();
+      input.targetHelperOrders = [makeOrder({ id: 'existing', start_time: '10:00', end_time: '11:00' })];
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('希望休（終日） → 拒否', () => {
+      const input = baseInput();
+      input.unavailability = [{
+        id: 'unavail-1',
+        staff_id: 'helper-b',
+        week_start_date: new Date('2026-02-09'),
+        unavailable_slots: [{ date: new Date('2026-02-09'), all_day: true }],
+        submitted_at: new Date(),
+      }];
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toContain('希望休');
+      }
+    });
+
+    it('希望休（時間帯重複） → 拒否', () => {
+      const input = baseInput();
+      input.unavailability = [{
+        id: 'unavail-2',
+        staff_id: 'helper-b',
+        week_start_date: new Date('2026-02-09'),
+        unavailable_slots: [{
+          date: new Date('2026-02-09'),
+          all_day: false,
+          start_time: '09:00',
+          end_time: '12:00',
+        }],
+        submitted_at: new Date(),
+      }];
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe('warning制約（ドロップ許可+警告）', () => {
+    it('勤務時間外 → 許可 + 警告', () => {
+      const input = baseInput();
+      // ヘルパーの勤務時間を午後のみに設定
+      input.helpers.set('helper-b', makeHelper({
+        weekly_availability: {
+          monday: [{ start_time: '13:00', end_time: '18:00' }],
+        },
+      }));
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(true);
+      if (result.allowed) {
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings[0]).toContain('勤務時間外');
+      }
+    });
+
+    it('勤務時間内 → 許可 + 警告なし', () => {
+      const input = baseInput();
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(true);
+      if (result.allowed) {
+        expect(result.warnings).toHaveLength(0);
+      }
+    });
+  });
+
+  describe('ヘルパー不在', () => {
+    it('存在しないヘルパー → 拒否', () => {
+      const input = baseInput();
+      input.targetHelperId = 'nonexistent';
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(false);
+    });
+  });
+});

--- a/web/src/lib/dnd/types.ts
+++ b/web/src/lib/dnd/types.ts
@@ -1,0 +1,20 @@
+/** DnD 型定義 */
+
+/** ドラッグ元の情報 */
+export interface DragData {
+  orderId: string;
+  sourceHelperId: string | null; // null = 未割当
+}
+
+/** ドロップ先の情報 */
+export interface DropData {
+  helperId: string | null; // null = 未割当セクション
+}
+
+/** バリデーション結果 */
+export type DropValidationResult =
+  | { allowed: true; warnings: string[] }
+  | { allowed: false; reason: string };
+
+/** ドロップゾーンの状態 */
+export type DropZoneStatus = 'idle' | 'valid' | 'warning' | 'invalid';

--- a/web/src/lib/dnd/validation.ts
+++ b/web/src/lib/dnd/validation.ts
@@ -1,0 +1,78 @@
+import type { Order, Helper, Customer, StaffUnavailability, DayOfWeek } from '@/types';
+import { isOverlapping } from '@/components/gantt/constants';
+import type { DropValidationResult } from './types';
+
+interface ValidateDropInput {
+  order: Order;
+  targetHelperId: string;
+  helpers: Map<string, Helper>;
+  customers: Map<string, Customer>;
+  /** 同じ日のターゲットヘルパーに割当済みのオーダー */
+  targetHelperOrders: Order[];
+  unavailability: StaffUnavailability[];
+  day: DayOfWeek;
+}
+
+/**
+ * ドロップ先ヘルパーへの割当可否を判定する。
+ * error 制約 → 拒否、warning 制約 → 許可+警告
+ */
+export function validateDrop(input: ValidateDropInput): DropValidationResult {
+  const { order, targetHelperId, helpers, customers, targetHelperOrders, unavailability, day } = input;
+
+  const helper = helpers.get(targetHelperId);
+  if (!helper) return { allowed: false, reason: 'ヘルパーが見つかりません' };
+
+  const customer = customers.get(order.customer_id);
+
+  // --- error 制約（ドロップ拒否） ---
+
+  // NGスタッフ
+  if (customer?.ng_staff_ids.includes(targetHelperId)) {
+    return { allowed: false, reason: `${helper.name.family} はNGスタッフです` };
+  }
+
+  // 資格不適合
+  if (order.service_type === 'physical_care' && !helper.can_physical_care) {
+    return { allowed: false, reason: `${helper.name.family} は身体介護の資格がありません` };
+  }
+
+  // 時間重複
+  for (const existing of targetHelperOrders) {
+    if (existing.id === order.id) continue;
+    if (isOverlapping(order.start_time, order.end_time, existing.start_time, existing.end_time)) {
+      return { allowed: false, reason: `${helper.name.family} の既存オーダーと時間が重複しています` };
+    }
+  }
+
+  // 希望休
+  const staffUnavail = unavailability.filter((u) => u.staff_id === targetHelperId);
+  for (const u of staffUnavail) {
+    for (const slot of u.unavailable_slots) {
+      if (slot.all_day) {
+        return { allowed: false, reason: `${helper.name.family} は希望休（終日）です` };
+      }
+      if (
+        slot.start_time && slot.end_time &&
+        isOverlapping(order.start_time, order.end_time, slot.start_time, slot.end_time)
+      ) {
+        return { allowed: false, reason: `${helper.name.family} は希望休（${slot.start_time}-${slot.end_time}）です` };
+      }
+    }
+  }
+
+  // --- warning 制約（ドロップ許可 + 警告表示） ---
+  const warnings: string[] = [];
+
+  const availability = helper.weekly_availability[day];
+  if (availability) {
+    const withinAny = availability.some(
+      (slot) => slot.start_time <= order.start_time && slot.end_time >= order.end_time
+    );
+    if (!withinAny) {
+      warnings.push(`${helper.name.family} の勤務時間外です`);
+    }
+  }
+
+  return { allowed: true, warnings };
+}

--- a/web/src/lib/firestore/updateOrder.ts
+++ b/web/src/lib/firestore/updateOrder.ts
@@ -1,0 +1,18 @@
+import { doc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { getDb } from '@/lib/firebase';
+
+/**
+ * オーダーの割当スタッフを更新する。
+ * onSnapshot リスナーが自動でUI反映するため、ローカルstate更新は不要。
+ */
+export async function updateOrderAssignment(
+  orderId: string,
+  newStaffIds: string[]
+): Promise<void> {
+  const orderRef = doc(getDb(), 'orders', orderId);
+  await updateDoc(orderRef, {
+    assigned_staff_ids: newStaffIds,
+    manually_edited: true,
+    updated_at: serverTimestamp(),
+  });
+}


### PR DESCRIPTION
## Summary
- @dnd-kit/core を導入し、ガントチャート上でオーダーバーをヘルパー間でドラッグ&ドロップして割当変更する機能を実装
- リアルタイムバリデーション付き: NGスタッフ/資格不適合/時間重複/希望休 → 拒否（赤）、勤務時間外 → 警告（黄）
- 未割当⇔ヘルパー間の双方向ドラッグ&ドロップ対応
- Firestore直接更新 + onSnapshotリアルタイム反映

## Changes
### 新規ファイル
- `web/src/lib/dnd/types.ts` — DnD型定義
- `web/src/lib/dnd/validation.ts` — ドロップバリデーション
- `web/src/lib/dnd/__tests__/validation.test.ts` — バリデーションテスト (11ケース)
- `web/src/lib/firestore/updateOrder.ts` — Firestore割当更新
- `web/src/hooks/useDragAndDrop.ts` — DnD状態管理フック
- `docs/adr/ADR-011-phase4a-dnd-implementation.md` — ADR

### 変更ファイル
- `web/package.json` — @dnd-kit依存追加
- `web/src/app/page.tsx` — DndContext + PointerSensorラップ
- `web/src/components/gantt/GanttBar.tsx` — useDraggable追加
- `web/src/components/gantt/GanttRow.tsx` — useDroppable + ドロップゾーン色分け
- `web/src/components/gantt/GanttChart.tsx` — dropZoneStatuses prop
- `web/src/components/gantt/UnassignedSection.tsx` — draggable + droppable

## Test plan
- [x] TypeScript型チェック通過
- [x] 全43テスト通過 (新規11 + 既存32)
- [x] プロダクションビルド成功
- [ ] ヘルパーA → ヘルパーBへオーダーをドラッグ → 割当変更成功
- [ ] NGスタッフの行へドラッグ → 赤ボーダー表示、ドロップ拒否
- [ ] 身体介護を無資格ヘルパーへドラッグ → ドロップ拒否
- [ ] 未割当→ヘルパーへドラッグ → 割当成功
- [ ] ヘルパー→未割当セクションへドラッグ → 割当解除
- [ ] 勤務時間外へドラッグ → 黄ボーダー + 警告トースト
- [ ] ブラウザリロード後もFirestore更新が反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)