### PR TITLE
fix: CI/CDにFirestoreルールデプロイを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,5 +87,5 @@ jobs:
           npm ci
           npm run build
       - uses: google-github-actions/setup-gcloud@v2
-      - name: Deploy to Firebase Hosting
-        run: npx firebase-tools@latest deploy --only hosting --project visitcare-shift-optimizer --token "${{ steps.auth.outputs.access_token }}"
+      - name: Deploy to Firebase Hosting + Firestore Rules
+        run: npx firebase-tools@latest deploy --only hosting,firestore:rules --project visitcare-shift-optimizer --token "${{ steps.auth.outputs.access_token }}"


### PR DESCRIPTION
## Summary
- deploy-hostingジョブで`--only hosting`のみだったため、Firestoreルール変更がデプロイされなかった
- `--only hosting,firestore:rules`に変更し、Firestoreルールも自動デプロイされるように修正

## Test plan
- [x] CI passes
- [ ] main pushでFirestoreルールが自動デプロイされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)