### PR TITLE
fix: Firestoreクエリのタイムゾーンミスマッチを修正

### DIFF
--- a/optimizer/src/optimizer/data/firestore_loader.py
+++ b/optimizer/src/optimizer/data/firestore_loader.py
@@ -1,7 +1,7 @@
 """Firestore → Pydanticモデル変換ローダー"""
 
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timezone, timedelta
 
 from google.cloud import firestore  # type: ignore[attr-defined]
 
@@ -163,7 +163,9 @@ def load_orders(
     customers: list[Customer],
 ) -> list[Order]:
     """ordersコレクション → Order リスト（対象週のpending/assigned）"""
-    week_start_dt = datetime(week_start.year, week_start.month, week_start.day)
+    # seedスクリプトが JST (UTC+9) midnight で保存するため、クエリも JST で合わせる
+    JST = timezone(timedelta(hours=9))
+    week_start_dt = datetime(week_start.year, week_start.month, week_start.day, tzinfo=JST)
 
     docs = (
         db.collection("orders")
@@ -233,7 +235,8 @@ def load_staff_unavailabilities(
     week_start: date,
 ) -> list[StaffUnavailability]:
     """staff_unavailabilityコレクション → StaffUnavailability リスト（対象週）"""
-    week_start_dt = datetime(week_start.year, week_start.month, week_start.day)
+    JST = timezone(timedelta(hours=9))
+    week_start_dt = datetime(week_start.year, week_start.month, week_start.day, tzinfo=JST)
 
     docs = (
         db.collection("staff_unavailability")


### PR DESCRIPTION
## Summary
- seedスクリプト（TypeScript）は `+09:00`（JST midnight）でFirestore Timestampを保存
- Python optimizer APIは `datetime(year, month, day)`（naive = UTC扱い）でクエリ
- JST midnight = `2026-02-08T15:00:00Z` ≠ UTC midnight = `2026-02-09T00:00:00Z` でマッチせず、オーダー0件に
- `datetime` 生成時にJSTタイムゾーンを付与して修正（orders + staff_unavailability の両方）

## Test plan
- [x] pytest 134件全パス
- [ ] 本番デプロイ後、最適化ボタンでオーダーが正常に取得されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)