### PR TITLE
fix: Firestore日付変換のタイムゾーンをJSTに統一

### DIFF
--- a/optimizer/src/optimizer/data/firestore_loader.py
+++ b/optimizer/src/optimizer/data/firestore_loader.py
@@ -34,11 +34,13 @@ OFFSET_TO_DAY_OF_WEEK: dict[int, DayOfWeek] = {
 
 
 def _ts_to_date_str(ts: datetime | object) -> str:
-    """Firestore Timestamp/datetime → 'YYYY-MM-DD'"""
+    """Firestore Timestamp/datetime → 'YYYY-MM-DD' (JST)"""
+    JST = timezone(timedelta(hours=9))
     if isinstance(ts, datetime):
-        return ts.strftime("%Y-%m-%d")
+        return ts.astimezone(JST).strftime("%Y-%m-%d")
     if hasattr(ts, "to_pydatetime"):
-        return ts.to_pydatetime().strftime("%Y-%m-%d")  # type: ignore[union-attr]
+        dt = ts.to_pydatetime()  # type: ignore[union-attr]
+        return dt.astimezone(JST).strftime("%Y-%m-%d")
     if isinstance(ts, str):
         return ts.split("T")[0]
     raise ValueError(f"Unsupported timestamp type: {type(ts)}")


### PR DESCRIPTION
## Summary
- `_ts_to_date_str()`がFirestore Timestampを**UTCのまま**日付文字列に変換していた
- JST midnight (例: `2026-02-09T00:00:00+09:00` = `2026-02-08T15:00:00Z`) が `"2026-02-08"` と1日前の日付に変換される
- 結果、全オーダーの曜日が1日ずれ、日曜に30件集中してInfeasible（ヘルパー5名では処理不能）
- `astimezone(JST)` でJSTに変換してから日付抽出するように修正

## Before / After
| 曜日 | Before (1日ずれ) | After (CSV一致) |
|------|-----------------|----------------|
| monday | 29 | 30 |
| sunday | **30** | **4** |

修正後: **160件全Optimal割当成功** (2.8秒)

## Test plan
- [x] pytest 134件全パス
- [x] ローカルで本番Firestoreデータに対してOptimal確認
- [ ] 本番デプロイ後、最適化ボタンで正常に割当されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)