### PR TITLE
fix: seedデータの週を動的に今週の月曜日に設定

### DIFF
--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -26,13 +26,19 @@ if [ ! -f web/.env.local ]; then
 fi
 
 # 2. Firebase Emulator起動
-echo "[1/3] Firebase Emulator 起動中..."
+echo "[1/4] Firebase Emulator 起動中..."
 firebase emulators:start --import=seed/emulator-data --export-on-exit=seed/emulator-data &
 EMULATOR_PID=$!
 sleep 5
 
-# 3. Optimizer API起動
-echo "[2/3] Optimizer API 起動中 (port 8081)..."
+# 3. Seedデータインポート（今週の日付で）
+echo "[2/4] Seed データインポート中（今週の日付）..."
+cd "$ROOT_DIR/seed"
+FIRESTORE_EMULATOR_HOST=localhost:8080 npx tsx scripts/import-all.ts
+cd "$ROOT_DIR"
+
+# 4. Optimizer API起動
+echo "[3/4] Optimizer API 起動中 (port 8081)..."
 cd "$ROOT_DIR/optimizer"
 ALLOW_UNAUTHENTICATED=true \
 FIRESTORE_EMULATOR_HOST=localhost:8080 \
@@ -41,7 +47,7 @@ API_PID=$!
 cd "$ROOT_DIR"
 
 # 4. Next.js dev起動
-echo "[3/3] Next.js dev 起動中 (port 3000)..."
+echo "[4/4] Next.js dev 起動中 (port 3000)..."
 cd "$ROOT_DIR/web"
 npm run dev &
 WEB_PID=$!

--- a/seed/data/staff-unavailability.csv
+++ b/seed/data/staff-unavailability.csv
@@ -1,5 +1,5 @@
-staff_id,week_start_date,date,all_day,start_time,end_time,notes
-H003,2025-01-06,2025-01-07,true,,,家族行事のため
-H008,2025-01-06,2025-01-08,false,09:00,12:00,通院のため
-H015,2025-01-06,2025-01-09,true,,,旅行のため
-H015,2025-01-06,2025-01-10,true,,,旅行のため
+staff_id,day_of_week,all_day,start_time,end_time,notes
+H003,tuesday,true,,,家族行事のため
+H008,wednesday,false,09:00,12:00,通院のため
+H015,thursday,true,,,旅行のため
+H015,friday,true,,,旅行のため

--- a/seed/scripts/import-all.ts
+++ b/seed/scripts/import-all.ts
@@ -91,7 +91,7 @@ async function main() {
   const travelTimeCount = await generateTravelTimes();
   console.log(`   travel_times: ${travelTimeCount}`);
 
-  const unavailCount = await importStaffUnavailability();
+  const unavailCount = await importStaffUnavailability(week);
   console.log(`   staff_unavailability: ${unavailCount}`);
 
   console.log('\n✅ Import complete!');

--- a/seed/scripts/import-orders.ts
+++ b/seed/scripts/import-orders.ts
@@ -15,6 +15,19 @@ const DAY_TO_OFFSET: Record<string, number> = {
   sunday: 6,
 };
 
+/** 今日を含む週の月曜日をYYYY-MM-DD形式で返す */
+function getCurrentMonday(): string {
+  const now = new Date();
+  const jst = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
+  const day = jst.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  jst.setDate(jst.getDate() + diff);
+  const y = jst.getFullYear();
+  const m = String(jst.getMonth() + 1).padStart(2, '0');
+  const d = String(jst.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
 interface ServiceRow {
   customer_id: string;
   day_of_week: string;
@@ -28,7 +41,10 @@ interface ServiceRow {
  * weekly_services からオーダーを生成
  * weekStartDate: 週の月曜日（YYYY-MM-DD）
  */
-export async function importOrders(weekStartDate: string = '2025-01-06'): Promise<number> {
+export async function importOrders(weekStartDate?: string): Promise<number> {
+  if (!weekStartDate) {
+    weekStartDate = getCurrentMonday();
+  }
   const services = parseCSV<ServiceRow>(resolve(DATA_DIR, 'customer-services.csv'));
   const now = Timestamp.now();
 

--- a/seed/scripts/import-staff-unavailability.ts
+++ b/seed/scripts/import-staff-unavailability.ts
@@ -5,35 +5,63 @@ import { batchWrite } from './utils/firestore-client.js';
 
 const DATA_DIR = resolve(import.meta.dirname, '../data');
 
+const DAY_TO_OFFSET: Record<string, number> = {
+  monday: 0,
+  tuesday: 1,
+  wednesday: 2,
+  thursday: 3,
+  friday: 4,
+  saturday: 5,
+  sunday: 6,
+};
+
 interface UnavailabilityRow {
   staff_id: string;
-  week_start_date: string;
-  date: string;
+  day_of_week: string;
   all_day: string;
   start_time: string;
   end_time: string;
   notes: string;
 }
 
-export async function importStaffUnavailability(): Promise<number> {
-  const rows = parseCSV<UnavailabilityRow>(resolve(DATA_DIR, 'staff-unavailability.csv'));
+/** 今日を含む週の月曜日をYYYY-MM-DD形式で返す */
+function getCurrentMonday(): string {
+  const now = new Date();
+  const jst = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
+  const day = jst.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  jst.setDate(jst.getDate() + diff);
+  const y = jst.getFullYear();
+  const m = String(jst.getMonth() + 1).padStart(2, '0');
+  const d = String(jst.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
 
-  // staff_id + week_start_date でグループ化
+export async function importStaffUnavailability(weekStartDate?: string): Promise<number> {
+  if (!weekStartDate) {
+    weekStartDate = getCurrentMonday();
+  }
+
+  const rows = parseCSV<UnavailabilityRow>(resolve(DATA_DIR, 'staff-unavailability.csv'));
+  const weekStart = new Date(weekStartDate + 'T00:00:00+09:00');
+  const weekStartTs = Timestamp.fromDate(weekStart);
+
+  // staff_id でグループ化
   const grouped = new Map<string, UnavailabilityRow[]>();
   for (const row of rows) {
-    const key = `${row.staff_id}_${row.week_start_date}`;
+    const key = row.staff_id;
     if (!grouped.has(key)) {
       grouped.set(key, []);
     }
     grouped.get(key)!.push(row);
   }
 
-  const docs = Array.from(grouped.entries()).map(([key, entries]) => {
-    const first = entries[0];
-    const weekStart = new Date(first.week_start_date + 'T00:00:00+09:00');
-
+  const docs = Array.from(grouped.entries()).map(([staffId, entries]) => {
     const unavailableSlots = entries.map((e) => {
-      const date = new Date(e.date + 'T00:00:00+09:00');
+      const dayOffset = DAY_TO_OFFSET[e.day_of_week] ?? 0;
+      const date = new Date(weekStart);
+      date.setDate(date.getDate() + dayOffset);
+
       const allDay = e.all_day === 'true';
       return {
         date: Timestamp.fromDate(date),
@@ -45,10 +73,10 @@ export async function importStaffUnavailability(): Promise<number> {
     const notes = entries.map((e) => e.notes).filter(Boolean).join('; ');
 
     return {
-      id: key,
+      id: `${staffId}_${weekStartDate}`,
       data: {
-        staff_id: first.staff_id,
-        week_start_date: Timestamp.fromDate(weekStart),
+        staff_id: staffId,
+        week_start_date: weekStartTs,
         unavailable_slots: unavailableSlots,
         ...(notes ? { notes } : {}),
         submitted_at: Timestamp.now(),


### PR DESCRIPTION
## Summary
- seedデータの`week_start_date`が`2025-01-06`固定のため、フロントエンドが「今週」を表示するとオーダーが0件になり、最適化しても割当不可だった問題を修正
- import-orders / import-staff-unavailability のデフォルト週を`getCurrentMonday()`（JST）に動的化
- `staff-unavailability.csv`を絶対日付→`day_of_week`形式に変更し、任意の週で利用可能に
- Python側`csv_loader.py`も新CSV形式に対応
- `dev-start.sh`で起動時にseedデータを今週の日付で自動インポート

## Test plan
- [x] Python optimizer テスト: 134/134 passed
- [x] Seed validation テスト: 9/9 passed
- [x] Frontend テスト: 43/43 passed
- [ ] `./scripts/dev-start.sh`でローカル起動し、今週のオーダーが表示されることを確認
- [ ] 最適化ボタンでスタッフ割当が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)