### PR TITLE
feat: Phase 4d マスタ編集UI 基盤 + 利用者マスタCRUD

### DIFF
--- a/docs/adr/ADR-013-phase4d-master-edit-ui.md
+++ b/docs/adr/ADR-013-phase4d-master-edit-ui.md
@@ -1,0 +1,74 @@
+# ADR-013: マスタ編集UI（Phase 4d）
+
+## ステータス
+承認済み (2026-02-15)
+
+## コンテキスト
+
+現在のシステムではマスタデータ（利用者・ヘルパー・希望休）の編集手段がseedスクリプトのみ。
+運用上、UI上でのCRUD操作が必要。ADR-012のFirestoreセキュリティルールでFE Writeがブロックされているため、ルール更新が前提。
+
+## 決定
+
+### 設計判断
+
+| 判断 | 選択 | 理由 |
+|------|------|------|
+| Write方式 | Firestoreルール更新 | デモフェーズ。`updateOrder.ts`と同パターン。Phase 2 RBACで権限を絞る前提 |
+| 削除 | なし（`allow delete: if false`維持） | 誤削除防止。将来soft deleteを検討 |
+| バリデーション | react-hook-form + zod v4 | 型安全。shared/types/と整合するスキーマ |
+| ナビゲーション | ヘッダーにDropdownMenu | 既存スケジュール画面を汚さない |
+| リスト表示 | shadcn/ui Table | 50件/20件のデータに適切 |
+| 編集UI | Dialog + フォーム | OrderDetailPanel(Sheet)との差別化。状態が隔離される |
+| 週間スケジュール編集 | 開閉セクション + 動的スロット追加/削除 | 7曜日×複数枠の複雑構造に対応 |
+
+### ルーティング
+
+`output: 'export'`（静的HTML）+ Firebase SPA rewriteで動作。
+
+```
+/                        → 既存スケジュール（ガントチャート）
+/masters/customers       → 利用者マスタ
+/masters/helpers         → ヘルパーマスタ（PR 2）
+/masters/unavailability  → 希望休管理（PR 3）
+```
+
+### Firestoreルール変更
+
+ADR-012からの変更点:
+- `customers`: `allow write: if false` → `allow create, update: if isAuthenticated() && isValidCustomer(); allow delete: if false`
+- `isValidCustomer()`: name(family/given), address, location(lat/lng), ng_staff_ids(list), preferred_staff_ids(list), weekly_services(map), service_managerの型検証
+
+### データフロー
+
+```
+ユーザー操作 → Dialog内フォーム
+  → react-hook-form + zodバリデーション
+  → OK → createXxx() / updateXxx() (Firestore SDK)
+  → Firestoreルール検証
+  → ドキュメント書き込み
+  → onSnapshotリスナー発火（既存hook）
+  → useCustomers() Map更新
+  → Table自動リレンダ
+  → Dialog閉じる + toast.success
+```
+
+### PR分割
+
+3 PRに分割して段階的に実装:
+1. **PR 1**: 基盤（依存追加・ナビ・レイアウト）+ 利用者マスタCRUD
+2. **PR 2**: ヘルパーマスタCRUD
+3. **PR 3**: 希望休管理 + NG/推奨スタッフUI
+
+## 却下した代替案
+
+- **Cloud Functions経由のwrite**: デモフェーズでは過剰。直接Firestoreルールで十分
+- **ページ内インライン編集**: 複雑な週間サービス構造に不向き。Dialogのほうが状態管理がクリーン
+- **React Context/Zustandでのローカルstate管理**: onSnapshotリスナーの自動反映で不要
+
+## 影響
+
+- Firestoreセキュリティルール変更（ADR-012の拡張）
+- 新規依存追加: react-hook-form, zod, @hookform/resolvers
+- shadcn/uiコンポーネント追加: input, label, select, table, dropdown-menu, card, separator, checkbox
+- 既存スケジュール画面への影響なし（Header.tsxへのDropdownMenu追加のみ）

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,7 +1,7 @@
 # ハンドオフメモ - visitcare-shift-optimizer
 
-**最終更新**: 2026-02-15（Firestoreセキュリティルール Phase 1 本番化 PR #21 完了）
-**現在のフェーズ**: Phase 4c-security（認証必須 + 最小権限write）
+**最終更新**: 2026-02-15（Phase 4d マスタ編集UI PR 1/3 — 利用者マスタCRUD）
+**現在のフェーズ**: Phase 4d-master-edit（マスタ編集UI）
 
 ## 完了済み
 
@@ -127,6 +127,21 @@
 - **テスト結果**: Optimizer 134/134 + Web 43/43 + Firestore Rules 21/21 = **全パス**
 - **ADR作成**: `docs/adr/ADR-012-firestore-security-rules-phase1.md`
 
+### Phase 4d-master-edit PR 1/3: 基盤 + 利用者マスタCRUD（2026-02-15）
+- **ブランチ**: `feature/phase4d-master-edit-customers`
+- **Firestoreルール更新**: `customers` に `create, update` 許可 + `isValidCustomer()` バリデーション（delete不可維持）
+- **新規依存**: react-hook-form, zod v4, @hookform/resolvers
+- **shadcn/ui追加**: input, label, select, table, dropdown-menu, card, separator, checkbox
+- **ナビゲーション**: Header.tsx に DropdownMenu（マスタ管理 → 利用者/ヘルパー）
+- **利用者マスタ画面**: `/masters/customers`
+  - 一覧表示（Table + 検索フィルター） + 新規追加/編集（Dialog）
+  - WeeklyServicesEditor（7曜日×複数スロット、動的追加/削除）
+  - react-hook-form + zod バリデーション → Firestore直接書き込み → onSnapshot自動反映
+- **zodスキーマ**: customerSchema / helperSchema / unavailabilitySchema（PR 2/3で使用）
+- **Firestoreユーティリティ**: createCustomer / updateCustomer
+- **テスト**: Firestoreルール 29件（+9件追加） + Web 43件 = 全パス
+- **ADR**: `docs/adr/ADR-013-phase4d-master-edit-ui.md`
+
 ## デプロイURL
 - **Web App**: https://visitcare-shift-optimizer.web.app
 - **Optimizer API**: https://shift-optimizer-1045989697649.asia-northeast1.run.app
@@ -210,6 +225,7 @@ cd optimizer && .venv/bin/pytest tests/ -v  # pytest (134件)
 - `docs/adr/ADR-010-workload-identity-federation.md` — WIF CI/CD認証
 - `docs/adr/ADR-011-phase4a-dnd-implementation.md` — Phase 4a DnD手動編集
 - `docs/adr/ADR-012-firestore-security-rules-phase1.md` — Phase 4c Firestoreルール認証必須化
+- `docs/adr/ADR-013-phase4d-master-edit-ui.md` — Phase 4d マスタ編集UI設計判断
 - `shared/types/` — TypeScript型定義（Python Pydantic モデルの参照元）
 - `optimizer/src/optimizer/` — 最適化エンジン + API
 - `web/src/` — Next.js フロントエンド
@@ -225,7 +241,8 @@ cd seed && SEED_TARGET=production npx tsx scripts/import-all.ts --orders-only --
 
 ## 次のアクション（優先度順）
 
-1. **Phase 4d: マスタ編集UI** 🟡 — 利用者・スタッフのCRUD画面（現行allow allルール廃止後は認証必須）
+1. **Phase 4d: マスタ編集UI PR 2/3** 🟡 — ヘルパーマスタCRUD（PR 1 完了済み）
+1b. **Phase 4d: マスタ編集UI PR 3/3** 🟡 — 希望休管理 + NG/推奨スタッフUI
 2. **Phase 2（Phase 2Security）: Custom Claims RBAC** 🟠 — Phase 1→Phase 2で admin/service_manager/helper権限導入
 3. **Google Maps API実移動時間** 🟠 — ダミー→実測値（有料）
 4. **週切替UI** 🟡 — 日付ピッカーで任意の週を表示

--- a/firebase/__tests__/firestore.rules.test.ts
+++ b/firebase/__tests__/firestore.rules.test.ts
@@ -136,16 +136,9 @@ describe('認証済みユーザー - 読み取り', () => {
 });
 
 // ============================================================
-// 認証済みユーザー: マスタコレクションはwrite不可
+// 認証済みユーザー: マスタコレクション書き込み（customers以外は拒否）
 // ============================================================
-describe('認証済みユーザー - マスタコレクション書き込み拒否', () => {
-  it('customers に書き込めない', async () => {
-    const authed = testEnv.authenticatedContext('user-1');
-    await assertFails(
-      setDoc(doc(authed.firestore(), 'customers', 'customer-new'), { name: '新規' })
-    );
-  });
-
+describe('認証済みユーザー - マスタコレクション書き込み', () => {
   it('helpers に書き込めない', async () => {
     const authed = testEnv.authenticatedContext('user-1');
     await assertFails(
@@ -164,6 +157,119 @@ describe('認証済みユーザー - マスタコレクション書き込み拒�
     const authed = testEnv.authenticatedContext('user-1');
     await assertFails(
       setDoc(doc(authed.firestore(), 'staff_unavailability', 'su-new'), { reason: '希望休' })
+    );
+  });
+});
+
+// ============================================================
+// customers: create/update 許可（isValidCustomer バリデーション）
+// ============================================================
+/** isValidCustomer を満たす有効なcustomerデータ */
+const validCustomerData = {
+  name: { family: '田中', given: '太郎' },
+  address: '東京都新宿区1-1-1',
+  location: { lat: 35.6895, lng: 139.6917 },
+  ng_staff_ids: [],
+  preferred_staff_ids: [],
+  weekly_services: {},
+  service_manager: '鈴木花子',
+  created_at: serverTimestamp(),
+  updated_at: serverTimestamp(),
+};
+
+describe('認証済みユーザー - customers create', () => {
+  it('有効なデータで新規作成できる', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertSucceeds(
+      setDoc(doc(authed.firestore(), 'customers', 'customer-new'), validCustomerData)
+    );
+  });
+
+  it('name.family がない場合は拒否される', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertFails(
+      setDoc(doc(authed.firestore(), 'customers', 'customer-bad'), {
+        ...validCustomerData,
+        name: { given: '太郎' },
+      })
+    );
+  });
+
+  it('location がない場合は拒否される', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    const { location: _, ...noLocation } = validCustomerData;
+    await assertFails(
+      setDoc(doc(authed.firestore(), 'customers', 'customer-bad'), noLocation)
+    );
+  });
+
+  it('ng_staff_ids が配列でない場合は拒否される', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertFails(
+      setDoc(doc(authed.firestore(), 'customers', 'customer-bad'), {
+        ...validCustomerData,
+        ng_staff_ids: 'not-an-array',
+      })
+    );
+  });
+
+  it('service_manager がない場合は拒否される', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    const { service_manager: _, ...noSM } = validCustomerData;
+    await assertFails(
+      setDoc(doc(authed.firestore(), 'customers', 'customer-bad'), noSM)
+    );
+  });
+});
+
+describe('認証済みユーザー - customers update', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await setDoc(doc(db, 'customers', 'customer-existing'), validCustomerData);
+    });
+  });
+
+  it('有効なデータで更新できる', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertSucceeds(
+      setDoc(doc(authed.firestore(), 'customers', 'customer-existing'), {
+        ...validCustomerData,
+        address: '東京都渋谷区2-2-2',
+        notes: '住所変更',
+      })
+    );
+  });
+
+  it('必須フィールドを欠いた更新は拒否される', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertFails(
+      setDoc(doc(authed.firestore(), 'customers', 'customer-existing'), {
+        name: { family: '田中', given: '太郎' },
+      })
+    );
+  });
+});
+
+describe('認証済みユーザー - customers delete', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await setDoc(doc(db, 'customers', 'customer-to-delete'), validCustomerData);
+    });
+  });
+
+  it('customers を削除できない', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertFails(deleteDoc(doc(authed.firestore(), 'customers', 'customer-to-delete')));
+  });
+});
+
+describe('未認証ユーザー - customers write', () => {
+  it('未認証ユーザーはcustomersに書き込めない', async () => {
+    const unauthed = testEnv.unauthenticatedContext();
+    await assertFails(
+      setDoc(doc(unauthed.firestore(), 'customers', 'customer-unauth'), validCustomerData)
     );
   });
 });

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,6 +1,6 @@
 rules_version = '2';
 
-// Phase 1: 認証必須 + 最小権限write (ADR-012)
+// Phase 1: 認証必須 + マスタ編集対応 (ADR-012, ADR-013)
 // バックエンド（Cloud Run）とseedスクリプトはAdmin SDKでルールをバイパス
 service cloud.firestore {
   match /databases/{database}/documents {
@@ -19,10 +19,27 @@ service cloud.firestore {
         && request.resource.data.manually_edited is bool;
     }
 
-    // マスタデータ: 認証済みユーザーは読み取りのみ
+    // customers create/update時: 必須フィールドバリデーション
+    function isValidCustomer() {
+      let data = request.resource.data;
+      return data.name is map
+        && data.name.family is string
+        && data.name.given is string
+        && data.address is string
+        && data.location is map
+        && data.location.lat is number
+        && data.location.lng is number
+        && data.ng_staff_ids is list
+        && data.preferred_staff_ids is list
+        && data.weekly_services is map
+        && data.service_manager is string;
+    }
+
+    // マスタデータ: customers は create/update 可（delete不可）
     match /customers/{customerId} {
       allow read: if isAuthenticated();
-      allow write: if false;
+      allow create, update: if isAuthenticated() && isValidCustomer();
+      allow delete: if false;
     }
 
     match /helpers/{helperId} {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",
+        "@hookform/resolvers": "^5.2.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -20,8 +21,10 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-hook-form": "^7.71.1",
         "sonner": "^2.0.7",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2328,6 +2331,18 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -5330,6 +5345,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -12302,6 +12323,22 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.71.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
+      "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -14744,7 +14781,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
+    "@hookform/resolvers": "^5.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
@@ -23,8 +24,10 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-hook-form": "^7.71.1",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Plus, Pencil, Search } from 'lucide-react';
+import { useCustomers } from '@/hooks/useCustomers';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { CustomerEditDialog } from '@/components/masters/CustomerEditDialog';
+import { DAY_OF_WEEK_ORDER } from '@/types';
+import type { Customer } from '@/types';
+
+export default function CustomersPage() {
+  const { customers, loading } = useCustomers();
+  const [search, setSearch] = useState('');
+  const [editTarget, setEditTarget] = useState<Customer | undefined>(undefined);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const filtered = useMemo(() => {
+    const list = Array.from(customers.values());
+    if (!search.trim()) return list;
+    const q = search.trim().toLowerCase();
+    return list.filter(
+      (c) =>
+        c.name.family.toLowerCase().includes(q) ||
+        c.name.given.toLowerCase().includes(q) ||
+        c.address.toLowerCase().includes(q)
+    );
+  }, [customers, search]);
+
+  const openNew = () => {
+    setEditTarget(undefined);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (customer: Customer) => {
+    setEditTarget(customer);
+    setDialogOpen(true);
+  };
+
+  const serviceDayCount = (customer: Customer) =>
+    DAY_OF_WEEK_ORDER.filter(
+      (d) => customer.weekly_services[d] && customer.weekly_services[d]!.length > 0
+    ).length;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <div className="flex flex-col items-center gap-3">
+          <div className="h-8 w-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
+          <p className="text-sm text-muted-foreground">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold">利用者マスタ</h2>
+        <Button onClick={openNew} size="sm">
+          <Plus className="mr-1 h-4 w-4" />
+          新規追加
+        </Button>
+      </div>
+
+      <div className="relative max-w-sm">
+        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="名前・住所で検索..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-32">氏名</TableHead>
+              <TableHead>住所</TableHead>
+              <TableHead className="w-24">サ責</TableHead>
+              <TableHead className="w-24 text-center">サービス日数</TableHead>
+              <TableHead className="w-16" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                  {search ? '一致する利用者が見つかりません' : '利用者が登録されていません'}
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((customer) => (
+                <TableRow key={customer.id}>
+                  <TableCell className="font-medium">
+                    {customer.name.family} {customer.name.given}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground truncate max-w-xs">
+                    {customer.address}
+                  </TableCell>
+                  <TableCell className="text-sm">{customer.service_manager}</TableCell>
+                  <TableCell className="text-center">
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
+                      {serviceDayCount(customer)}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={() => openEdit(customer)}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        全{customers.size}件{search && `（表示: ${filtered.length}件）`}
+      </p>
+
+      <CustomerEditDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        customer={editTarget}
+      />
+    </div>
+  );
+}

--- a/web/src/app/masters/layout.tsx
+++ b/web/src/app/masters/layout.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { Header } from '@/components/layout/Header';
+
+export default function MastersLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex h-screen flex-col">
+      <Header />
+      <main className="flex-1 overflow-auto">{children}</main>
+    </div>
+  );
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,26 +1,71 @@
 'use client';
 
-import { Heart } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Heart, Settings, Users, UserCog } from 'lucide-react';
 import { WeekSelector } from '@/components/schedule/WeekSelector';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
 
 export function Header() {
+  const pathname = usePathname();
+  const isMasterPage = pathname?.startsWith('/masters');
+
   return (
     <header className="bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)] px-4 py-3 shadow-md">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2.5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/15 backdrop-blur-sm">
-            <Heart className="h-4.5 w-4.5 text-white" />
-          </div>
-          <div>
-            <h1 className="text-base font-bold tracking-tight text-white">
-              VisitCare
-            </h1>
-            <p className="text-[10px] text-white/70 leading-none">
-              シフト最適化
-            </p>
-          </div>
+          <Link href="/" className="flex items-center gap-2.5">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/15 backdrop-blur-sm">
+              <Heart className="h-4.5 w-4.5 text-white" />
+            </div>
+            <div>
+              <h1 className="text-base font-bold tracking-tight text-white">
+                VisitCare
+              </h1>
+              <p className="text-[10px] text-white/70 leading-none">
+                シフト最適化
+              </p>
+            </div>
+          </Link>
         </div>
-        <WeekSelector variant="header" />
+        <div className="flex items-center gap-2">
+          {!isMasterPage && <WeekSelector variant="header" />}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-white hover:bg-white/15"
+              >
+                <Settings className="h-4.5 w-4.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel>マスタ管理</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem asChild>
+                <Link href="/masters/customers">
+                  <Users className="mr-2 h-4 w-4" />
+                  利用者マスタ
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/masters/helpers">
+                  <UserCog className="mr-2 h-4 w-4" />
+                  ヘルパーマスタ
+                </Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
     </header>
   );

--- a/web/src/components/masters/CustomerEditDialog.tsx
+++ b/web/src/components/masters/CustomerEditDialog.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { WeeklyServicesEditor } from './WeeklyServicesEditor';
+import { customerSchema, type CustomerFormValues } from '@/lib/validation/schemas';
+import { createCustomer, updateCustomer } from '@/lib/firestore/customers';
+import type { Customer } from '@/types';
+
+interface CustomerEditDialogProps {
+  open: boolean;
+  onClose: () => void;
+  customer?: Customer;
+}
+
+export function CustomerEditDialog({
+  open,
+  onClose,
+  customer,
+}: CustomerEditDialogProps) {
+  const isNew = !customer;
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<CustomerFormValues>({
+    resolver: zodResolver(customerSchema),
+    defaultValues: getDefaults(customer),
+  });
+
+  useEffect(() => {
+    if (open) {
+      reset(getDefaults(customer));
+    }
+  }, [open, customer, reset]);
+
+  const onSubmit = async (data: CustomerFormValues) => {
+    try {
+      if (isNew) {
+        await createCustomer(data);
+        toast.success('利用者を追加しました');
+      } else {
+        await updateCustomer(customer.id, data);
+        toast.success('利用者情報を更新しました');
+      }
+      onClose();
+    } catch (err) {
+      console.error('Failed to save customer:', err);
+      toast.error('保存に失敗しました');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isNew ? '利用者を追加' : '利用者を編集'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* 氏名 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="name.family">姓</Label>
+              <Input
+                id="name.family"
+                {...register('name.family')}
+                placeholder="田中"
+              />
+              {errors.name?.family && (
+                <p className="text-xs text-destructive">
+                  {errors.name.family.message}
+                </p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="name.given">名</Label>
+              <Input
+                id="name.given"
+                {...register('name.given')}
+                placeholder="太郎"
+              />
+              {errors.name?.given && (
+                <p className="text-xs text-destructive">
+                  {errors.name.given.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* 住所 */}
+          <div className="space-y-1">
+            <Label htmlFor="address">住所</Label>
+            <Input
+              id="address"
+              {...register('address')}
+              placeholder="東京都新宿区..."
+            />
+            {errors.address && (
+              <p className="text-xs text-destructive">
+                {errors.address.message}
+              </p>
+            )}
+          </div>
+
+          {/* 座標 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="location.lat">緯度</Label>
+              <Input
+                id="location.lat"
+                type="number"
+                step="any"
+                {...register('location.lat', { valueAsNumber: true })}
+                placeholder="35.6895"
+              />
+              {errors.location?.lat && (
+                <p className="text-xs text-destructive">
+                  {errors.location.lat.message}
+                </p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="location.lng">経度</Label>
+              <Input
+                id="location.lng"
+                type="number"
+                step="any"
+                {...register('location.lng', { valueAsNumber: true })}
+                placeholder="139.6917"
+              />
+              {errors.location?.lng && (
+                <p className="text-xs text-destructive">
+                  {errors.location.lng.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* サービス提供責任者 */}
+          <div className="space-y-1">
+            <Label htmlFor="service_manager">サービス提供責任者</Label>
+            <Input
+              id="service_manager"
+              {...register('service_manager')}
+              placeholder="サ責名"
+            />
+            {errors.service_manager && (
+              <p className="text-xs text-destructive">
+                {errors.service_manager.message}
+              </p>
+            )}
+          </div>
+
+          {/* 世帯ID */}
+          <div className="space-y-1">
+            <Label htmlFor="household_id">世帯ID（任意）</Label>
+            <Input
+              id="household_id"
+              {...register('household_id')}
+              placeholder="同一世帯がある場合"
+            />
+          </div>
+
+          {/* 備考 */}
+          <div className="space-y-1">
+            <Label htmlFor="notes">備考（任意）</Label>
+            <Input id="notes" {...register('notes')} placeholder="特記事項" />
+          </div>
+
+          {/* 週間サービス */}
+          <Controller
+            name="weekly_services"
+            control={control}
+            render={({ field }) => (
+              <WeeklyServicesEditor
+                value={field.value ?? {}}
+                onChange={field.onChange}
+              />
+            )}
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '保存中...' : '保存'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function getDefaults(customer?: Customer): CustomerFormValues {
+  if (!customer) {
+    return {
+      name: { family: '', given: '' },
+      address: '',
+      location: { lat: 0, lng: 0 },
+      ng_staff_ids: [],
+      preferred_staff_ids: [],
+      weekly_services: {},
+      service_manager: '',
+      household_id: '',
+      notes: '',
+    };
+  }
+  return {
+    name: customer.name,
+    address: customer.address,
+    location: customer.location,
+    ng_staff_ids: customer.ng_staff_ids,
+    preferred_staff_ids: customer.preferred_staff_ids,
+    weekly_services: customer.weekly_services,
+    service_manager: customer.service_manager,
+    household_id: customer.household_id ?? '',
+    notes: customer.notes ?? '',
+  };
+}

--- a/web/src/components/masters/WeeklyServicesEditor.tsx
+++ b/web/src/components/masters/WeeklyServicesEditor.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { Plus, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  DAY_OF_WEEK_ORDER,
+  DAY_OF_WEEK_LABELS,
+  type DayOfWeek,
+  type ServiceSlot,
+} from '@/types';
+
+interface WeeklyServicesEditorProps {
+  value: Partial<Record<DayOfWeek, ServiceSlot[]>>;
+  onChange: (value: Partial<Record<DayOfWeek, ServiceSlot[]>>) => void;
+}
+
+const EMPTY_SLOT: ServiceSlot = {
+  start_time: '09:00',
+  end_time: '10:00',
+  service_type: 'physical_care',
+  staff_count: 1,
+};
+
+export function WeeklyServicesEditor({
+  value,
+  onChange,
+}: WeeklyServicesEditorProps) {
+  const [expandedDays, setExpandedDays] = useState<Set<DayOfWeek>>(
+    () => {
+      const days = new Set<DayOfWeek>();
+      for (const day of DAY_OF_WEEK_ORDER) {
+        if (value[day] && value[day]!.length > 0) days.add(day);
+      }
+      return days;
+    }
+  );
+
+  const toggleDay = (day: DayOfWeek) => {
+    setExpandedDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(day)) next.delete(day);
+      else next.add(day);
+      return next;
+    });
+  };
+
+  const addSlot = (day: DayOfWeek) => {
+    const current = value[day] ?? [];
+    onChange({ ...value, [day]: [...current, { ...EMPTY_SLOT }] });
+    setExpandedDays((prev) => new Set(prev).add(day));
+  };
+
+  const removeSlot = (day: DayOfWeek, index: number) => {
+    const current = value[day] ?? [];
+    const updated = current.filter((_, i) => i !== index);
+    onChange({ ...value, [day]: updated });
+  };
+
+  const updateSlot = (
+    day: DayOfWeek,
+    index: number,
+    field: keyof ServiceSlot,
+    fieldValue: string | number
+  ) => {
+    const current = value[day] ?? [];
+    const updated = current.map((slot, i) =>
+      i === index ? { ...slot, [field]: fieldValue } : slot
+    );
+    onChange({ ...value, [day]: updated });
+  };
+
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-medium">週間サービス</label>
+      <div className="space-y-1 rounded-md border p-2">
+        {DAY_OF_WEEK_ORDER.map((day) => {
+          const slots = value[day] ?? [];
+          const isExpanded = expandedDays.has(day);
+
+          return (
+            <div key={day} className="border-b last:border-b-0 pb-1 last:pb-0">
+              <div className="flex items-center justify-between py-1">
+                <button
+                  type="button"
+                  onClick={() => toggleDay(day)}
+                  className="flex items-center gap-1 text-sm font-medium hover:text-primary"
+                >
+                  {isExpanded ? (
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5" />
+                  )}
+                  {DAY_OF_WEEK_LABELS[day]}
+                  {slots.length > 0 && (
+                    <span className="ml-1 text-xs text-muted-foreground">
+                      ({slots.length}件)
+                    </span>
+                  )}
+                </button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  onClick={() => addSlot(day)}
+                >
+                  <Plus className="mr-1 h-3 w-3" />
+                  追加
+                </Button>
+              </div>
+
+              {isExpanded && slots.length > 0 && (
+                <div className="ml-4 space-y-2 pb-2">
+                  {slots.map((slot, idx) => (
+                    <div
+                      key={idx}
+                      className="flex flex-wrap items-center gap-2 rounded bg-muted/50 p-2"
+                    >
+                      <Input
+                        type="time"
+                        value={slot.start_time}
+                        onChange={(e) =>
+                          updateSlot(day, idx, 'start_time', e.target.value)
+                        }
+                        className="h-8 w-28"
+                      />
+                      <span className="text-sm text-muted-foreground">〜</span>
+                      <Input
+                        type="time"
+                        value={slot.end_time}
+                        onChange={(e) =>
+                          updateSlot(day, idx, 'end_time', e.target.value)
+                        }
+                        className="h-8 w-28"
+                      />
+                      <Select
+                        value={slot.service_type}
+                        onValueChange={(v) =>
+                          updateSlot(day, idx, 'service_type', v)
+                        }
+                      >
+                        <SelectTrigger className="h-8 w-28">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="physical_care">身体介護</SelectItem>
+                          <SelectItem value="daily_living">生活援助</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <div className="flex items-center gap-1">
+                        <Input
+                          type="number"
+                          min={1}
+                          max={3}
+                          value={slot.staff_count}
+                          onChange={(e) =>
+                            updateSlot(
+                              day,
+                              idx,
+                              'staff_count',
+                              parseInt(e.target.value) || 1
+                            )
+                          }
+                          className="h-8 w-16"
+                        />
+                        <span className="text-xs text-muted-foreground">名</span>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                        onClick={() => removeSlot(day, idx)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/web/src/components/ui/separator.tsx
+++ b/web/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/web/src/lib/firestore/customers.ts
+++ b/web/src/lib/firestore/customers.ts
@@ -1,0 +1,33 @@
+import { collection, doc, addDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { getDb } from '@/lib/firebase';
+import type { Customer } from '@/types';
+
+type CustomerInput = Omit<Customer, 'id' | 'created_at' | 'updated_at'>;
+
+/**
+ * 利用者を新規作成する。
+ * onSnapshot リスナーが自動でUI反映するため、ローカルstate更新は不要。
+ */
+export async function createCustomer(data: CustomerInput): Promise<string> {
+  const docRef = await addDoc(collection(getDb(), 'customers'), {
+    ...data,
+    created_at: serverTimestamp(),
+    updated_at: serverTimestamp(),
+  });
+  return docRef.id;
+}
+
+/**
+ * 利用者情報を更新する。
+ * onSnapshot リスナーが自動でUI反映するため、ローカルstate更新は不要。
+ */
+export async function updateCustomer(
+  id: string,
+  data: Partial<CustomerInput>
+): Promise<void> {
+  const customerRef = doc(getDb(), 'customers', id);
+  await updateDoc(customerRef, {
+    ...data,
+    updated_at: serverTimestamp(),
+  });
+}

--- a/web/src/lib/validation/schemas.ts
+++ b/web/src/lib/validation/schemas.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+const timeStringSchema = z.string().regex(/^\d{2}:\d{2}$/, '時刻はHH:MM形式で入力してください');
+
+const personNameSchema = z.object({
+  family: z.string().min(1, '姓は必須です'),
+  given: z.string().min(1, '名は必須です'),
+  short: z.string().optional(),
+});
+
+const geoLocationSchema = z.object({
+  lat: z.number({ error: '緯度は必須です' }).min(-90).max(90),
+  lng: z.number({ error: '経度は必須です' }).min(-180).max(180),
+});
+
+const serviceSlotSchema = z.object({
+  start_time: timeStringSchema,
+  end_time: timeStringSchema,
+  service_type: z.enum(['physical_care', 'daily_living'], {
+    error: 'サービス種別は必須です',
+  }),
+  staff_count: z.number().int().min(1, '必要人数は1以上です').max(3),
+});
+
+const availabilitySlotSchema = z.object({
+  start_time: timeStringSchema,
+  end_time: timeStringSchema,
+});
+
+// Partial<Record<DayOfWeek, ServiceSlot[]>> を表現
+const weeklyServicesSchema = z.record(z.string(), z.array(serviceSlotSchema));
+
+const weeklyAvailabilitySchema = z.record(z.string(), z.array(availabilitySlotSchema));
+
+// ---- Customer ----
+export const customerSchema = z.object({
+  name: personNameSchema,
+  address: z.string().min(1, '住所は必須です'),
+  location: geoLocationSchema,
+  ng_staff_ids: z.array(z.string()),
+  preferred_staff_ids: z.array(z.string()),
+  weekly_services: weeklyServicesSchema,
+  household_id: z.string().optional(),
+  service_manager: z.string().min(1, 'サービス提供責任者は必須です'),
+  notes: z.string().optional(),
+});
+
+export type CustomerFormValues = z.infer<typeof customerSchema>;
+
+// ---- Helper ----
+export const helperSchema = z.object({
+  name: personNameSchema,
+  qualifications: z.array(z.string()),
+  can_physical_care: z.boolean(),
+  transportation: z.enum(['car', 'bicycle', 'walk']),
+  weekly_availability: weeklyAvailabilitySchema,
+  preferred_hours: z.object({
+    min: z.number().min(0),
+    max: z.number().min(0),
+  }),
+  available_hours: z.object({
+    min: z.number().min(0),
+    max: z.number().min(0),
+  }),
+  employment_type: z.enum(['full_time', 'part_time']),
+});
+
+export type HelperFormValues = z.infer<typeof helperSchema>;
+
+// ---- StaffUnavailability ----
+const unavailableSlotSchema = z.object({
+  date: z.string().min(1, '日付は必須です'),
+  all_day: z.boolean(),
+  start_time: timeStringSchema.optional(),
+  end_time: timeStringSchema.optional(),
+});
+
+export const unavailabilitySchema = z.object({
+  staff_id: z.string().min(1, 'スタッフは必須です'),
+  week_start_date: z.string().min(1, '週の開始日は必須です'),
+  unavailable_slots: z.array(unavailableSlotSchema).min(1, '不在スロットは1件以上必要です'),
+  notes: z.string().optional(),
+});
+
+export type UnavailabilityFormValues = z.infer<typeof unavailabilitySchema>;


### PR DESCRIPTION
## Summary

- Firestoreルール更新: `customers` に `create/update` 許可 + `isValidCustomer()` バリデーション（`delete` は不可維持）
- 利用者マスタ画面（`/masters/customers`）: Table一覧 + 検索フィルター + Dialog編集 + WeeklyServicesEditor
- zodバリデーションスキーマ（customer/helper/unavailability）+ Firestoreユーティリティ（createCustomer/updateCustomer）
- Header.tsx にマスタ管理DropdownMenu追加、Masters共通レイアウト
- shadcn/uiコンポーネント8種追加、react-hook-form + zod v4 + @hookform/resolvers 依存追加

## 変更ファイル（21件）

### Firestoreルール
- `firebase/firestore.rules` — `isValidCustomer()` + customers create/update許可
- `firebase/__tests__/firestore.rules.test.ts` — +9テスト（create/update/delete/未認証バリデーション）

### 新規コンポーネント
- `web/src/app/masters/layout.tsx` — Masters共通レイアウト
- `web/src/app/masters/customers/page.tsx` — 利用者一覧ページ
- `web/src/components/masters/CustomerEditDialog.tsx` — 編集ダイアログ
- `web/src/components/masters/WeeklyServicesEditor.tsx` — 週間サービス編集

### ユーティリティ
- `web/src/lib/firestore/customers.ts` — createCustomer/updateCustomer
- `web/src/lib/validation/schemas.ts` — zodスキーマ（PR 2/3でも使用）

### UI基盤
- `web/src/components/ui/` — 8コンポーネント追加（input/label/select/table/dropdown-menu/card/separator/checkbox）
- `web/src/components/layout/Header.tsx` — DropdownMenu追加

### ドキュメント
- `docs/adr/ADR-013-phase4d-master-edit-ui.md`
- `docs/handoff/LATEST.md`

## Test plan

- [x] `cd web && npm run build` — ビルド成功
- [x] `cd web && npm run test:run` — 既存43件全パス
- [x] `firebase emulators:exec --project demo-test "cd firebase && npm test"` — Firestoreルールテスト29件全パス
- [ ] ブラウザで手動確認:
  - [ ] ヘッダーのマスタ管理メニューから `/masters/customers` に遷移
  - [ ] 一覧表示・検索フィルター動作
  - [ ] 新規追加 → バリデーション → 保存 → リアルタイム反映
  - [ ] 既存利用者編集 → 週間サービスのスロット追加/削除 → 保存
  - [ ] 既存スケジュール画面（`/`）に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)