### PR TITLE
feat: ヘルパーマスタCRUD（Phase 4d PR 2/3）

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,6 +1,6 @@
 # ハンドオフメモ - visitcare-shift-optimizer
 
-**最終更新**: 2026-02-15（Phase 4d マスタ編集UI PR 1/3 — 利用者マスタCRUD）
+**最終更新**: 2026-02-15（Phase 4d マスタ編集UI PR 2/3 — ヘルパーマスタCRUD）
 **現在のフェーズ**: Phase 4d-master-edit（マスタ編集UI）
 
 ## 完了済み
@@ -239,10 +239,20 @@ cd seed && SEED_TARGET=production npx tsx scripts/import-all.ts --week 2026-02-0
 cd seed && SEED_TARGET=production npx tsx scripts/import-all.ts --orders-only --week 2026-02-16
 ```
 
+### Phase 4d-master-edit PR 2/3: ヘルパーマスタCRUD（2026-02-15）
+- **ブランチ**: `feature/phase4d-master-edit-helpers`
+- **Firestoreルール更新**: `helpers` に `create, update` 許可 + `isValidHelper()` バリデーション（delete不可維持）
+- **ヘルパーマスタ画面**: `/masters/helpers`
+  - 一覧表示（Table: 氏名/資格/身体介護可否/雇用形態/移動手段 + 検索フィルター）
+  - 新規追加/編集（Dialog） — 資格Checkbox群、身体介護可否、移動手段/雇用形態Select
+  - 希望勤務時間・対応可能時間（min/max）
+  - WeeklyAvailabilityEditor（7曜日×複数スロット、start/endのみ）
+- **Firestoreユーティリティ**: createHelper / updateHelper
+- **テスト**: Firestoreルール 38件（+10件追加） + Web 43件 = 全パス
+
 ## 次のアクション（優先度順）
 
-1. **Phase 4d: マスタ編集UI PR 2/3** 🟡 — ヘルパーマスタCRUD（PR 1 完了済み）
-1b. **Phase 4d: マスタ編集UI PR 3/3** 🟡 — 希望休管理 + NG/推奨スタッフUI
+1. **Phase 4d: マスタ編集UI PR 3/3** 🟡 — 希望休管理 + NG/推奨スタッフUI
 2. **Phase 2（Phase 2Security）: Custom Claims RBAC** 🟠 — Phase 1→Phase 2で admin/service_manager/helper権限導入
 3. **Google Maps API実移動時間** 🟠 — ダミー→実測値（有料）
 4. **週切替UI** 🟡 — 日付ピッカーで任意の週を表示

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -42,9 +42,30 @@ service cloud.firestore {
       allow delete: if false;
     }
 
+    // helpers create/update時: 必須フィールドバリデーション
+    function isValidHelper() {
+      let data = request.resource.data;
+      return data.name is map
+        && data.name.family is string
+        && data.name.given is string
+        && data.qualifications is list
+        && data.can_physical_care is bool
+        && data.transportation is string
+        && data.weekly_availability is map
+        && data.preferred_hours is map
+        && data.preferred_hours.min is number
+        && data.preferred_hours.max is number
+        && data.available_hours is map
+        && data.available_hours.min is number
+        && data.available_hours.max is number
+        && data.employment_type is string;
+    }
+
+    // マスタデータ: helpers は create/update 可（delete不可）
     match /helpers/{helperId} {
       allow read: if isAuthenticated();
-      allow write: if false;
+      allow create, update: if isAuthenticated() && isValidHelper();
+      allow delete: if false;
     }
 
     match /travel_times/{travelTimeId} {

--- a/web/src/app/masters/helpers/page.tsx
+++ b/web/src/app/masters/helpers/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Plus, Pencil, Search } from 'lucide-react';
+import { useHelpers } from '@/hooks/useHelpers';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { HelperEditDialog } from '@/components/masters/HelperEditDialog';
+import type { Helper } from '@/types';
+
+const TRANSPORTATION_LABELS: Record<string, string> = {
+  car: '車',
+  bicycle: '自転車',
+  walk: '徒歩',
+};
+
+const EMPLOYMENT_LABELS: Record<string, string> = {
+  full_time: '常勤',
+  part_time: '非常勤',
+};
+
+export default function HelpersPage() {
+  const { helpers, loading } = useHelpers();
+  const [search, setSearch] = useState('');
+  const [editTarget, setEditTarget] = useState<Helper | undefined>(undefined);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const filtered = useMemo(() => {
+    const list = Array.from(helpers.values());
+    if (!search.trim()) return list;
+    const q = search.trim().toLowerCase();
+    return list.filter(
+      (h) =>
+        h.name.family.toLowerCase().includes(q) ||
+        h.name.given.toLowerCase().includes(q) ||
+        h.qualifications.some((qual) => qual.toLowerCase().includes(q))
+    );
+  }, [helpers, search]);
+
+  const openNew = () => {
+    setEditTarget(undefined);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (helper: Helper) => {
+    setEditTarget(helper);
+    setDialogOpen(true);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <div className="flex flex-col items-center gap-3">
+          <div className="h-8 w-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
+          <p className="text-sm text-muted-foreground">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold">ヘルパーマスタ</h2>
+        <Button onClick={openNew} size="sm">
+          <Plus className="mr-1 h-4 w-4" />
+          新規追加
+        </Button>
+      </div>
+
+      <div className="relative max-w-sm">
+        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="名前・資格で検索..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-32">氏名</TableHead>
+              <TableHead>資格</TableHead>
+              <TableHead className="w-24 text-center">身体介護</TableHead>
+              <TableHead className="w-20">雇用形態</TableHead>
+              <TableHead className="w-20">移動手段</TableHead>
+              <TableHead className="w-16" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                  {search ? '一致するヘルパーが見つかりません' : 'ヘルパーが登録されていません'}
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((helper) => (
+                <TableRow key={helper.id}>
+                  <TableCell className="font-medium">
+                    {helper.name.family} {helper.name.given}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {helper.qualifications.join(', ') || '-'}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <span
+                      className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium ${
+                        helper.can_physical_care
+                          ? 'bg-green-100 text-green-700'
+                          : 'bg-gray-100 text-gray-400'
+                      }`}
+                    >
+                      {helper.can_physical_care ? '可' : '-'}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-sm">
+                    {EMPLOYMENT_LABELS[helper.employment_type] ?? helper.employment_type}
+                  </TableCell>
+                  <TableCell className="text-sm">
+                    {TRANSPORTATION_LABELS[helper.transportation] ?? helper.transportation}
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={() => openEdit(helper)}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        全{helpers.size}件{search && `（表示: ${filtered.length}件）`}
+      </p>
+
+      <HelperEditDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        helper={editTarget}
+      />
+    </div>
+  );
+}

--- a/web/src/components/masters/HelperEditDialog.tsx
+++ b/web/src/components/masters/HelperEditDialog.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { WeeklyAvailabilityEditor } from './WeeklyAvailabilityEditor';
+import { helperSchema, type HelperFormValues } from '@/lib/validation/schemas';
+import { createHelper, updateHelper } from '@/lib/firestore/helpers';
+import type { Helper } from '@/types';
+
+interface HelperEditDialogProps {
+  open: boolean;
+  onClose: () => void;
+  helper?: Helper;
+}
+
+const QUALIFICATION_OPTIONS = [
+  '介護福祉士',
+  '実務者研修',
+  '初任者研修',
+] as const;
+
+export function HelperEditDialog({
+  open,
+  onClose,
+  helper,
+}: HelperEditDialogProps) {
+  const isNew = !helper;
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<HelperFormValues>({
+    resolver: zodResolver(helperSchema),
+    defaultValues: getDefaults(helper),
+  });
+
+  useEffect(() => {
+    if (open) {
+      reset(getDefaults(helper));
+    }
+  }, [open, helper, reset]);
+
+  const qualifications = watch('qualifications');
+
+  const toggleQualification = (qual: string) => {
+    const current = qualifications ?? [];
+    if (current.includes(qual)) {
+      setValue('qualifications', current.filter((q) => q !== qual));
+    } else {
+      setValue('qualifications', [...current, qual]);
+    }
+  };
+
+  const onSubmit = async (data: HelperFormValues) => {
+    try {
+      if (isNew) {
+        await createHelper(data);
+        toast.success('ヘルパーを追加しました');
+      } else {
+        await updateHelper(helper.id, data);
+        toast.success('ヘルパー情報を更新しました');
+      }
+      onClose();
+    } catch (err) {
+      console.error('Failed to save helper:', err);
+      toast.error('保存に失敗しました');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isNew ? 'ヘルパーを追加' : 'ヘルパーを編集'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* 氏名 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="name.family">姓</Label>
+              <Input
+                id="name.family"
+                {...register('name.family')}
+                placeholder="佐藤"
+              />
+              {errors.name?.family && (
+                <p className="text-xs text-destructive">
+                  {errors.name.family.message}
+                </p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="name.given">名</Label>
+              <Input
+                id="name.given"
+                {...register('name.given')}
+                placeholder="花子"
+              />
+              {errors.name?.given && (
+                <p className="text-xs text-destructive">
+                  {errors.name.given.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* 資格 */}
+          <div className="space-y-2">
+            <Label>資格</Label>
+            <div className="flex flex-wrap gap-4">
+              {QUALIFICATION_OPTIONS.map((qual) => (
+                <label key={qual} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={qualifications?.includes(qual) ?? false}
+                    onCheckedChange={() => toggleQualification(qual)}
+                  />
+                  {qual}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* 身体介護可否 */}
+          <Controller
+            name="can_physical_care"
+            control={control}
+            render={({ field }) => (
+              <label className="flex items-center gap-2 text-sm">
+                <Checkbox
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+                身体介護対応可
+              </label>
+            )}
+          />
+
+          {/* 移動手段・雇用形態 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label>移動手段</Label>
+              <Controller
+                name="transportation"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="選択" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="car">車</SelectItem>
+                      <SelectItem value="bicycle">自転車</SelectItem>
+                      <SelectItem value="walk">徒歩</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>雇用形態</Label>
+              <Controller
+                name="employment_type"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="選択" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="full_time">常勤</SelectItem>
+                      <SelectItem value="part_time">非常勤</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+
+          {/* 希望勤務時間 */}
+          <div className="space-y-1">
+            <Label>希望勤務時間（時間/週）</Label>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.5}
+                  {...register('preferred_hours.min', { valueAsNumber: true })}
+                  placeholder="最小"
+                />
+                {errors.preferred_hours?.min && (
+                  <p className="text-xs text-destructive">
+                    {errors.preferred_hours.min.message}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-1">
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.5}
+                  {...register('preferred_hours.max', { valueAsNumber: true })}
+                  placeholder="最大"
+                />
+                {errors.preferred_hours?.max && (
+                  <p className="text-xs text-destructive">
+                    {errors.preferred_hours.max.message}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 対応可能時間 */}
+          <div className="space-y-1">
+            <Label>対応可能時間（時間/週）</Label>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.5}
+                  {...register('available_hours.min', { valueAsNumber: true })}
+                  placeholder="最小"
+                />
+                {errors.available_hours?.min && (
+                  <p className="text-xs text-destructive">
+                    {errors.available_hours.min.message}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-1">
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.5}
+                  {...register('available_hours.max', { valueAsNumber: true })}
+                  placeholder="最大"
+                />
+                {errors.available_hours?.max && (
+                  <p className="text-xs text-destructive">
+                    {errors.available_hours.max.message}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 週間勤務可能時間 */}
+          <Controller
+            name="weekly_availability"
+            control={control}
+            render={({ field }) => (
+              <WeeklyAvailabilityEditor
+                value={field.value ?? {}}
+                onChange={field.onChange}
+              />
+            )}
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '保存中...' : '保存'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function getDefaults(helper?: Helper): HelperFormValues {
+  if (!helper) {
+    return {
+      name: { family: '', given: '' },
+      qualifications: [],
+      can_physical_care: false,
+      transportation: 'bicycle',
+      weekly_availability: {},
+      preferred_hours: { min: 0, max: 40 },
+      available_hours: { min: 0, max: 40 },
+      employment_type: 'part_time',
+    };
+  }
+  return {
+    name: helper.name,
+    qualifications: helper.qualifications,
+    can_physical_care: helper.can_physical_care,
+    transportation: helper.transportation,
+    weekly_availability: helper.weekly_availability,
+    preferred_hours: helper.preferred_hours,
+    available_hours: helper.available_hours,
+    employment_type: helper.employment_type,
+  };
+}

--- a/web/src/components/masters/WeeklyAvailabilityEditor.tsx
+++ b/web/src/components/masters/WeeklyAvailabilityEditor.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { Plus, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  DAY_OF_WEEK_ORDER,
+  DAY_OF_WEEK_LABELS,
+  type DayOfWeek,
+  type AvailabilitySlot,
+} from '@/types';
+
+interface WeeklyAvailabilityEditorProps {
+  value: Partial<Record<DayOfWeek, AvailabilitySlot[]>>;
+  onChange: (value: Partial<Record<DayOfWeek, AvailabilitySlot[]>>) => void;
+}
+
+const EMPTY_SLOT: AvailabilitySlot = {
+  start_time: '09:00',
+  end_time: '18:00',
+};
+
+export function WeeklyAvailabilityEditor({
+  value,
+  onChange,
+}: WeeklyAvailabilityEditorProps) {
+  const [expandedDays, setExpandedDays] = useState<Set<DayOfWeek>>(
+    () => {
+      const days = new Set<DayOfWeek>();
+      for (const day of DAY_OF_WEEK_ORDER) {
+        if (value[day] && value[day]!.length > 0) days.add(day);
+      }
+      return days;
+    }
+  );
+
+  const toggleDay = (day: DayOfWeek) => {
+    setExpandedDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(day)) next.delete(day);
+      else next.add(day);
+      return next;
+    });
+  };
+
+  const addSlot = (day: DayOfWeek) => {
+    const current = value[day] ?? [];
+    onChange({ ...value, [day]: [...current, { ...EMPTY_SLOT }] });
+    setExpandedDays((prev) => new Set(prev).add(day));
+  };
+
+  const removeSlot = (day: DayOfWeek, index: number) => {
+    const current = value[day] ?? [];
+    const updated = current.filter((_, i) => i !== index);
+    onChange({ ...value, [day]: updated });
+  };
+
+  const updateSlot = (
+    day: DayOfWeek,
+    index: number,
+    field: keyof AvailabilitySlot,
+    fieldValue: string
+  ) => {
+    const current = value[day] ?? [];
+    const updated = current.map((slot, i) =>
+      i === index ? { ...slot, [field]: fieldValue } : slot
+    );
+    onChange({ ...value, [day]: updated });
+  };
+
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-medium">週間勤務可能時間</label>
+      <div className="space-y-1 rounded-md border p-2">
+        {DAY_OF_WEEK_ORDER.map((day) => {
+          const slots = value[day] ?? [];
+          const isExpanded = expandedDays.has(day);
+
+          return (
+            <div key={day} className="border-b last:border-b-0 pb-1 last:pb-0">
+              <div className="flex items-center justify-between py-1">
+                <button
+                  type="button"
+                  onClick={() => toggleDay(day)}
+                  className="flex items-center gap-1 text-sm font-medium hover:text-primary"
+                >
+                  {isExpanded ? (
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5" />
+                  )}
+                  {DAY_OF_WEEK_LABELS[day]}
+                  {slots.length > 0 && (
+                    <span className="ml-1 text-xs text-muted-foreground">
+                      ({slots.length}件)
+                    </span>
+                  )}
+                </button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  onClick={() => addSlot(day)}
+                >
+                  <Plus className="mr-1 h-3 w-3" />
+                  追加
+                </Button>
+              </div>
+
+              {isExpanded && slots.length > 0 && (
+                <div className="ml-4 space-y-2 pb-2">
+                  {slots.map((slot, idx) => (
+                    <div
+                      key={idx}
+                      className="flex items-center gap-2 rounded bg-muted/50 p-2"
+                    >
+                      <Input
+                        type="time"
+                        value={slot.start_time}
+                        onChange={(e) =>
+                          updateSlot(day, idx, 'start_time', e.target.value)
+                        }
+                        className="h-8 w-28"
+                      />
+                      <span className="text-sm text-muted-foreground">〜</span>
+                      <Input
+                        type="time"
+                        value={slot.end_time}
+                        onChange={(e) =>
+                          updateSlot(day, idx, 'end_time', e.target.value)
+                        }
+                        className="h-8 w-28"
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                        onClick={() => removeSlot(day, idx)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/firestore/helpers.ts
+++ b/web/src/lib/firestore/helpers.ts
@@ -1,0 +1,34 @@
+import { collection, doc, addDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { getDb } from '@/lib/firebase';
+import type { Helper } from '@/types';
+
+type HelperInput = Omit<Helper, 'id' | 'created_at' | 'updated_at' | 'customer_training_status'>;
+
+/**
+ * ヘルパーを新規作成する。
+ * onSnapshot リスナーが自動でUI反映するため、ローカルstate更新は不要。
+ */
+export async function createHelper(data: HelperInput): Promise<string> {
+  const docRef = await addDoc(collection(getDb(), 'helpers'), {
+    ...data,
+    customer_training_status: {},
+    created_at: serverTimestamp(),
+    updated_at: serverTimestamp(),
+  });
+  return docRef.id;
+}
+
+/**
+ * ヘルパー情報を更新する。
+ * onSnapshot リスナーが自動でUI反映するため、ローカルstate更新は不要。
+ */
+export async function updateHelper(
+  id: string,
+  data: Partial<HelperInput>
+): Promise<void> {
+  const helperRef = doc(getDb(), 'helpers', id);
+  await updateDoc(helperRef, {
+    ...data,
+    updated_at: serverTimestamp(),
+  });
+}


### PR DESCRIPTION
## Summary
- Firestoreルール: `helpers` に `create, update` 許可 + `isValidHelper()` バリデーション（delete不可維持）
- ヘルパーマスタ一覧ページ: `/masters/helpers`（Table + 検索フィルター + 新規追加/編集Dialog）
- `WeeklyAvailabilityEditor`: 週間勤務可能時間の編集コンポーネント（`WeeklyServicesEditor` の簡易版）
- Firestoreルールテスト: 10件追加（合計38件）

## 変更ファイル（7件）
- `firebase/firestore.rules` — `isValidHelper()` 関数追加 + ルール変更
- `firebase/__tests__/firestore.rules.test.ts` — helpers テスト10件追加
- `web/src/app/masters/helpers/page.tsx` — ヘルパー一覧ページ
- `web/src/components/masters/HelperEditDialog.tsx` — 編集Dialog
- `web/src/components/masters/WeeklyAvailabilityEditor.tsx` — 週間可用性編集
- `web/src/lib/firestore/helpers.ts` — createHelper / updateHelper
- `docs/handoff/LATEST.md` — ハンドオフメモ更新

## Test plan
- [ ] `cd web && npm run build` — ビルド成功（`/masters/helpers` ルート生成確認）
- [ ] `cd web && npm test` — 43テスト全パス
- [ ] `firebase emulators:exec` — Firestoreルールテスト38件全パス
- [ ] ブラウザ手動確認: ヘッダーのマスタ管理 → ヘルパーマスタに遷移可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)