### PR TITLE
feat: Firebase Custom Claims RBAC による権限制御（Phase 2）

### DIFF
--- a/docs/adr/ADR-014-rbac-custom-claims.md
+++ b/docs/adr/ADR-014-rbac-custom-claims.md
@@ -1,0 +1,112 @@
+# ADR-014: Firebase Custom Claims による RBAC
+
+## ステータス
+承認済み (2026-02-15)
+
+## コンテキスト
+
+ADR-012（Phase 1）で認証必須化 + 最小権限writeを実装した。
+現在は全認証ユーザーが同一権限を持ち、マスタ編集・最適化実行・D&D編集を全員が行える状態。
+運用上、admin / サービス提供責任者（サ責） / ヘルパーの3ロールで権限を分離する必要がある。
+
+## 決定
+
+### 認証方式
+- **本番（required モード）**: Google ソーシャルログイン（`signInWithPopup` + `GoogleAuthProvider`）
+- **デモ（demo モード）**: 匿名認証を維持（ログイン不要、seedデータで動作確認可能）
+- DRY原則: AuthProvider のコア認証ロジックは共通化し、モード分岐は最小限
+
+### ロール体系
+Firebase Custom Claims の `role` フィールドで管理（`request.auth.token.role`）。
+
+| ロール | 説明 | 対象ユーザー |
+|--------|------|-------------|
+| `admin` | 全権限 | システム管理者 |
+| `service_manager` | スケジュール管理 + マスタ編集（ヘルパー除く） | サービス提供責任者 |
+| `helper` | 自分のスケジュール閲覧 + 自分の希望休管理 | ヘルパースタッフ |
+
+### 権限マトリクス
+
+| 操作 | admin | service_manager | helper |
+|------|:-----:|:---------------:|:------:|
+| ガントチャート閲覧（全体） | ✅ | ✅ | - |
+| ガントチャート閲覧（自分のみ） | - | - | ✅ |
+| 最適化実行 | ✅ | ✅ | - |
+| D&D手動編集 | ✅ | ✅ | - |
+| 利用者マスタ閲覧 | ✅ | ✅ | - |
+| 利用者マスタ編集 | ✅ | ✅ | - |
+| ヘルパーマスタ閲覧 | ✅ | ✅ | ✅（自分のみ） |
+| ヘルパーマスタ編集 | ✅ | - | - |
+| 希望休閲覧（全体） | ✅ | ✅ | - |
+| 希望休管理（自分のみ） | ✅ | ✅ | ✅ |
+| ユーザー管理（Claims設定） | ✅ | - | - |
+
+### Custom Claims 構造
+
+```json
+{
+  "role": "admin" | "service_manager" | "helper",
+  "helper_id": "helper-xxx"  // helperロール時のみ、紐づくヘルパーID
+}
+```
+
+サイズ制限: 1000バイト以内（上記構造で十分収まる）
+
+### 実装層
+
+#### 1. Firestoreルール
+```
+request.auth.token.role == 'admin'
+request.auth.token.role == 'service_manager'
+request.auth.token.role == 'helper'
+request.auth.token.helper_id == helperId  // ヘルパー自身のドキュメント判定
+```
+
+#### 2. バックエンドAPI（FastAPI）
+- `verify_auth` のデコード済みトークンから `role` を取得
+- `/optimize` エンドポイント: admin / service_manager のみ
+
+#### 3. フロントエンド（Next.js）
+- `useAuthRole` フック: `getIdTokenResult()` から claims 取得
+- UI表示制御: ロールに基づくメニュー/ボタンの条件表示
+- ルートガード: 権限不足時のリダイレクト
+
+### Custom Claims 管理
+- Firebase Admin SDK を使用する CLI スクリプト（`scripts/set-custom-claims.ts`）
+- admin ユーザーが CLI で他ユーザーのロールを設定
+- 将来: 管理画面UIからの設定も検討
+
+### デモモードとの共存
+- デモモード: 匿名認証ユーザーには Custom Claims なし → Firestore ルールで `role == null` を許容
+- デモモード用 Firestore ルールは既存の `isAuthenticated()` のみで動作を維持
+- 環境変数 `NEXT_PUBLIC_AUTH_MODE` で demo/required を切り替え（既存仕組みを維持）
+
+## 却下した代替案
+
+### メール/パスワード認証
+- 運用負荷（パスワードリセット、アカウント管理）が高い
+- Google Workspace 連携で組織管理が容易な Google ログインを採用
+
+### Cloud Functions での認可
+- レイテンシ増大、コールドスタート問題
+- Firestore ルール + IDトークンの方がリアルタイム性を維持できる
+
+### カスタムトークン（Custom Token）
+- Custom Claims で十分な権限制御が可能
+- カスタムトークンは認証フロー全体の置き換えが必要で過剰
+
+## 影響
+
+- Firestore ルール: `isAuthenticated()` に加え `hasRole()` ヘルパー関数を追加
+- バックエンド: `verify_auth` の戻り値からロール参照を追加
+- フロントエンド: AuthProvider 拡張 + useAuthRole フック追加
+- 既存テスト: ロール別テストケースの追加が必要
+- デモモード: 影響なし（既存の匿名認証フローを維持）
+
+## PR構成
+
+| PR | 内容 | 依存 |
+|----|------|------|
+| PR 1/3 | 認証基盤 + GoogleログインUI + Custom Claims CLI + useAuthRole | - |
+| PR 2/3 | Firestoreルール + バックエンドAPI認可 | PR 1 |
+| PR 3/3 | フロントエンド権限制御UI | PR 1, 2 |

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,16 +1,43 @@
 rules_version = '2';
 
-// Phase 1: 認証必須 + マスタ編集対応 (ADR-012, ADR-013)
+// Phase 2: RBAC + Custom Claims (ADR-012, ADR-013, ADR-014)
 // バックエンド（Cloud Run）とseedスクリプトはAdmin SDKでルールをバイパス
+//
+// ロール体系:
+//   admin           — 全権限
+//   service_manager — スケジュール管理 + マスタ編集（ヘルパー除く）
+//   helper          — 自分の希望休管理のみ
+//   (なし)          — デモモード互換（匿名認証、roleなし → 全権限）
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // ヘルパー関数: 認証済みか判定
+    // ── ヘルパー関数 ────────────────────────────────
+
     function isAuthenticated() {
       return request.auth != null;
     }
 
-    // ordersのupdate時: 許可フィールドのみか判定
+    // デモモード互換: role が未設定（Custom Claims なし）なら許可
+    function hasNoRole() {
+      return !('role' in request.auth.token);
+    }
+
+    function isAdmin() {
+      return request.auth.token.role == 'admin';
+    }
+
+    function isManagerOrAbove() {
+      return request.auth.token.role == 'admin'
+          || request.auth.token.role == 'service_manager';
+    }
+
+    // 自分の希望休データか判定（helper_id で照合）
+    function isOwnStaffData(staffId) {
+      return request.auth.token.helper_id == staffId;
+    }
+
+    // ── バリデーション関数 ──────────────────────────
+
     function isValidOrderUpdate() {
       let allowedFields = ['assigned_staff_ids', 'manually_edited', 'updated_at'].toSet();
       let incomingFields = request.resource.data.diff(resource.data).affectedKeys();
@@ -19,7 +46,6 @@ service cloud.firestore {
         && request.resource.data.manually_edited is bool;
     }
 
-    // customers create/update時: 必須フィールドバリデーション
     function isValidCustomer() {
       let data = request.resource.data;
       return data.name is map
@@ -35,14 +61,6 @@ service cloud.firestore {
         && data.service_manager is string;
     }
 
-    // マスタデータ: customers は create/update 可（delete不可）
-    match /customers/{customerId} {
-      allow read: if isAuthenticated();
-      allow create, update: if isAuthenticated() && isValidCustomer();
-      allow delete: if false;
-    }
-
-    // helpers create/update時: 必須フィールドバリデーション
     function isValidHelper() {
       let data = request.resource.data;
       return data.name is map
@@ -61,19 +79,6 @@ service cloud.firestore {
         && data.employment_type is string;
     }
 
-    // マスタデータ: helpers は create/update 可（delete不可）
-    match /helpers/{helperId} {
-      allow read: if isAuthenticated();
-      allow create, update: if isAuthenticated() && isValidHelper();
-      allow delete: if false;
-    }
-
-    match /travel_times/{travelTimeId} {
-      allow read: if isAuthenticated();
-      allow write: if false;
-    }
-
-    // staff_unavailability create/update/delete時: 必須フィールドバリデーション
     function isValidUnavailability() {
       let data = request.resource.data;
       return data.staff_id is string
@@ -81,17 +86,48 @@ service cloud.firestore {
         && data.unavailable_slots is list;
     }
 
-    // 希望休: create/update/delete 可（週単位で再作成するため）
-    match /staff_unavailability/{unavailabilityId} {
+    // ── コレクションルール ──────────────────────────
+
+    // 利用者マスタ: admin + service_manager が編集可
+    match /customers/{customerId} {
       allow read: if isAuthenticated();
-      allow create, update: if isAuthenticated() && isValidUnavailability();
-      allow delete: if isAuthenticated();
+      allow create, update: if isAuthenticated()
+        && (hasNoRole() || isManagerOrAbove())
+        && isValidCustomer();
+      allow delete: if false;
     }
 
-    // orders: 認証済みユーザーは読み取り + 3フィールドのみupdate可
+    // ヘルパーマスタ: admin のみ編集可
+    match /helpers/{helperId} {
+      allow read: if isAuthenticated();
+      allow create, update: if isAuthenticated()
+        && (hasNoRole() || isAdmin())
+        && isValidHelper();
+      allow delete: if false;
+    }
+
+    // 移動時間: 読み取りのみ（Admin SDKで書き込み）
+    match /travel_times/{travelTimeId} {
+      allow read: if isAuthenticated();
+      allow write: if false;
+    }
+
+    // 希望休: admin + service_manager + 自分の希望休
+    match /staff_unavailability/{unavailabilityId} {
+      allow read: if isAuthenticated();
+      allow create, update: if isAuthenticated()
+        && (hasNoRole() || isManagerOrAbove() || isOwnStaffData(request.resource.data.staff_id))
+        && isValidUnavailability();
+      allow delete: if isAuthenticated()
+        && (hasNoRole() || isManagerOrAbove() || isOwnStaffData(resource.data.staff_id));
+    }
+
+    // オーダー: admin + service_manager が割当編集可
     match /orders/{orderId} {
       allow read: if isAuthenticated();
-      allow update: if isAuthenticated() && isValidOrderUpdate();
+      allow update: if isAuthenticated()
+        && (hasNoRole() || isManagerOrAbove())
+        && isValidOrderUpdate();
       allow create, delete: if false;
     }
   }

--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -5,7 +5,7 @@ from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from optimizer.api.auth import verify_auth
+from optimizer.api.auth import require_manager_or_above
 from optimizer.api.schemas import (
     AssignmentResponse,
     ErrorResponse,
@@ -31,7 +31,7 @@ def health() -> dict[str, str]:
     response_model=OptimizeResponse,
     responses={409: {"model": ErrorResponse}, 422: {"model": ErrorResponse}},
 )
-def optimize(req: OptimizeRequest, _auth: dict | None = Depends(verify_auth)) -> OptimizeResponse:
+def optimize(req: OptimizeRequest, _auth: dict | None = Depends(require_manager_or_above)) -> OptimizeResponse:
     """シフト最適化を実行し、結果をFirestoreに書き戻す"""
     # 日付パース
     try:

--- a/seed/scripts/set-custom-claims.ts
+++ b/seed/scripts/set-custom-claims.ts
@@ -1,0 +1,159 @@
+/**
+ * Custom Claims 設定 CLI スクリプト
+ *
+ * 使い方:
+ *   # ロール設定（admin / service_manager / helper）
+ *   SEED_TARGET=production npx tsx scripts/set-custom-claims.ts --email user@example.com --role admin
+ *
+ *   # helperロール（helper_id 紐づけ）
+ *   SEED_TARGET=production npx tsx scripts/set-custom-claims.ts --email helper@example.com --role helper --helper-id helper-001
+ *
+ *   # 現在のClaims確認
+ *   SEED_TARGET=production npx tsx scripts/set-custom-claims.ts --email user@example.com --show
+ *
+ *   # Claims削除（ロール解除）
+ *   SEED_TARGET=production npx tsx scripts/set-custom-claims.ts --email user@example.com --clear
+ *
+ * 環境変数:
+ *   SEED_TARGET=production  → 本番 Firebase Auth（ADC使用）
+ *   SEED_TARGET=emulator    → ローカル Emulator（デフォルト）
+ */
+
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+
+const VALID_ROLES = ['admin', 'service_manager', 'helper'] as const;
+type UserRole = (typeof VALID_ROLES)[number];
+
+const SEED_TARGET = process.env.SEED_TARGET ?? 'emulator';
+const PRODUCTION_PROJECT_ID = 'visitcare-shift-optimizer';
+
+function initFirebase() {
+  if (getApps().length > 0) return;
+
+  if (SEED_TARGET === 'production') {
+    console.log(`🔥 Connecting to PRODUCTION Firebase Auth (${PRODUCTION_PROJECT_ID})`);
+    initializeApp({ projectId: PRODUCTION_PROJECT_ID });
+  } else {
+    if (!process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+      process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099';
+    }
+    console.log('🧪 Connecting to Emulator Firebase Auth');
+    initializeApp({ projectId: 'demo-test' });
+  }
+}
+
+function parseArgs(): {
+  email: string;
+  role?: UserRole;
+  helperId?: string;
+  show?: boolean;
+  clear?: boolean;
+} {
+  const args = process.argv.slice(2);
+  let email = '';
+  let role: UserRole | undefined;
+  let helperId: string | undefined;
+  let show = false;
+  let clear = false;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--email':
+        email = args[++i];
+        break;
+      case '--role':
+        role = args[++i] as UserRole;
+        break;
+      case '--helper-id':
+        helperId = args[++i];
+        break;
+      case '--show':
+        show = true;
+        break;
+      case '--clear':
+        clear = true;
+        break;
+    }
+  }
+
+  if (!email) {
+    console.error('❌ --email は必須です');
+    console.error('');
+    console.error('使い方:');
+    console.error('  npx tsx scripts/set-custom-claims.ts --email user@example.com --role admin');
+    console.error('  npx tsx scripts/set-custom-claims.ts --email user@example.com --show');
+    console.error('  npx tsx scripts/set-custom-claims.ts --email user@example.com --clear');
+    process.exit(1);
+  }
+
+  if (role && !VALID_ROLES.includes(role)) {
+    console.error(`❌ 無効なロール: ${role}`);
+    console.error(`   有効なロール: ${VALID_ROLES.join(', ')}`);
+    process.exit(1);
+  }
+
+  if (role === 'helper' && !helperId) {
+    console.error('❌ helperロールには --helper-id が必須です');
+    process.exit(1);
+  }
+
+  if (!role && !show && !clear) {
+    console.error('❌ --role, --show, --clear のいずれかを指定してください');
+    process.exit(1);
+  }
+
+  return { email, role, helperId, show, clear };
+}
+
+async function main() {
+  const { email, role, helperId, show, clear } = parseArgs();
+
+  initFirebase();
+  const auth = getAuth();
+
+  // ユーザー取得
+  let user;
+  try {
+    user = await auth.getUserByEmail(email);
+  } catch {
+    console.error(`❌ ユーザーが見つかりません: ${email}`);
+    console.error('   Firebase Authentication に登録済みのメールアドレスを指定してください');
+    process.exit(1);
+  }
+
+  console.log(`👤 ユーザー: ${user.displayName ?? user.email} (uid: ${user.uid})`);
+
+  // 現在のClaims表示
+  if (show) {
+    const current = user.customClaims ?? {};
+    console.log('📋 現在の Custom Claims:');
+    console.log(JSON.stringify(current, null, 2));
+    return;
+  }
+
+  // Claims削除
+  if (clear) {
+    await auth.setCustomUserClaims(user.uid, {});
+    console.log('🗑️  Custom Claims を削除しました');
+    return;
+  }
+
+  // ロール設定
+  const claims: Record<string, unknown> = { role };
+  if (helperId) {
+    claims.helper_id = helperId;
+  }
+
+  await auth.setCustomUserClaims(user.uid, claims);
+  console.log(`✅ Custom Claims を設定しました:`);
+  console.log(JSON.stringify(claims, null, 2));
+  console.log('');
+  console.log('⚠️  ユーザーは次回トークンリフレッシュ時（最大1時間）に反映されます');
+  console.log('   即座に反映するには、ユーザーに再ログインを依頼してください');
+}
+
+main().catch((err) => {
+  console.error('❌ エラー:', err);
+  process.exit(1);
+});

--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import { Plus, Pencil, Search } from 'lucide-react';
 import { useCustomers } from '@/hooks/useCustomers';
+import { useAuthRole } from '@/lib/auth/AuthProvider';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -19,6 +20,7 @@ import type { Customer } from '@/types';
 
 export default function CustomersPage() {
   const { customers, loading } = useCustomers();
+  const { canEditCustomers } = useAuthRole();
   const [search, setSearch] = useState('');
   const [editTarget, setEditTarget] = useState<Customer | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -65,10 +67,12 @@ export default function CustomersPage() {
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold">利用者マスタ</h2>
-        <Button onClick={openNew} size="sm">
-          <Plus className="mr-1 h-4 w-4" />
-          新規追加
-        </Button>
+        {canEditCustomers && (
+          <Button onClick={openNew} size="sm">
+            <Plus className="mr-1 h-4 w-4" />
+            新規追加
+          </Button>
+        )}
       </div>
 
       <div className="relative max-w-sm">
@@ -114,16 +118,18 @@ export default function CustomersPage() {
                       {serviceDayCount(customer)}
                     </span>
                   </TableCell>
-                  <TableCell>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-8 w-8 p-0"
-                      onClick={() => openEdit(customer)}
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </Button>
-                  </TableCell>
+                  {canEditCustomers && (
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        onClick={() => openEdit(customer)}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                    </TableCell>
+                  )}
                 </TableRow>
               ))
             )}

--- a/web/src/app/masters/helpers/page.tsx
+++ b/web/src/app/masters/helpers/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import { Plus, Pencil, Search } from 'lucide-react';
 import { useHelpers } from '@/hooks/useHelpers';
+import { useAuthRole } from '@/lib/auth/AuthProvider';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -29,6 +30,7 @@ const EMPLOYMENT_LABELS: Record<string, string> = {
 
 export default function HelpersPage() {
   const { helpers, loading } = useHelpers();
+  const { canEditHelpers } = useAuthRole();
   const [search, setSearch] = useState('');
   const [editTarget, setEditTarget] = useState<Helper | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -70,10 +72,12 @@ export default function HelpersPage() {
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold">ヘルパーマスタ</h2>
-        <Button onClick={openNew} size="sm">
-          <Plus className="mr-1 h-4 w-4" />
-          新規追加
-        </Button>
+        {canEditHelpers && (
+          <Button onClick={openNew} size="sm">
+            <Plus className="mr-1 h-4 w-4" />
+            新規追加
+          </Button>
+        )}
       </div>
 
       <div className="relative max-w-sm">
@@ -131,16 +135,18 @@ export default function HelpersPage() {
                   <TableCell className="text-sm">
                     {TRANSPORTATION_LABELS[helper.transportation] ?? helper.transportation}
                   </TableCell>
-                  <TableCell>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-8 w-8 p-0"
-                      onClick={() => openEdit(helper)}
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </Button>
-                  </TableCell>
+                  {canEditHelpers && (
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        onClick={() => openEdit(helper)}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                    </TableCell>
+                  )}
                 </TableRow>
               ))
             )}

--- a/web/src/app/masters/unavailability/page.tsx
+++ b/web/src/app/masters/unavailability/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { Plus, Pencil, Search, ChevronLeft, ChevronRight } from 'lucide-react';
 import { format, addDays, addWeeks, subWeeks, startOfWeek, differenceInCalendarDays } from 'date-fns';
 import { useHelpers } from '@/hooks/useHelpers';
+import { useAuthRole } from '@/lib/auth/AuthProvider';
 import { useStaffUnavailability } from '@/hooks/useStaffUnavailability';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -28,6 +29,7 @@ export default function UnavailabilityPage() {
   const [weekStart, setWeekStart] = useState(() => getMonday(new Date()));
   const { helpers, loading: helpersLoading } = useHelpers();
   const { unavailability, loading: unavailLoading } = useStaffUnavailability(weekStart);
+  const { canEditUnavailability, isHelper, helperId } = useAuthRole();
   const [search, setSearch] = useState('');
   const [editTarget, setEditTarget] = useState<StaffUnavailability | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -84,10 +86,12 @@ export default function UnavailabilityPage() {
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold">希望休管理</h2>
-        <Button onClick={openNew} size="sm">
-          <Plus className="mr-1 h-4 w-4" />
-          新規追加
-        </Button>
+        {(canEditUnavailability || isHelper) && (
+          <Button onClick={openNew} size="sm">
+            <Plus className="mr-1 h-4 w-4" />
+            新規追加
+          </Button>
+        )}
       </div>
 
       {/* 週ナビゲーション */}
@@ -166,16 +170,18 @@ export default function UnavailabilityPage() {
                     <TableCell className="text-sm text-muted-foreground">
                       {u.notes || '-'}
                     </TableCell>
-                    <TableCell>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 w-8 p-0"
-                        onClick={() => openEdit(u)}
-                      >
-                        <Pencil className="h-3.5 w-3.5" />
-                      </Button>
-                    </TableCell>
+                    {(canEditUnavailability || (isHelper && u.staff_id === helperId)) && (
+                      <TableCell>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 w-8 p-0"
+                          onClick={() => openEdit(u)}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                      </TableCell>
+                    )}
                   </TableRow>
                 );
               })

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -2,8 +2,9 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Heart, Settings, Users, UserCog, CalendarOff } from 'lucide-react';
+import { Heart, Settings, Users, UserCog, CalendarOff, LogOut } from 'lucide-react';
 import { WeekSelector } from '@/components/schedule/WeekSelector';
+import { useAuth } from '@/lib/auth/AuthProvider';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,9 +15,18 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 
+const ROLE_LABELS: Record<string, string> = {
+  admin: '管理者',
+  service_manager: 'サ責',
+  helper: 'ヘルパー',
+};
+
 export function Header() {
   const pathname = usePathname();
   const isMasterPage = pathname?.startsWith('/masters');
+  const { user, role, authMode, signOut } = useAuth();
+
+  const isLoggedIn = authMode === 'required' && user && !user.isAnonymous;
 
   return (
     <header className="bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)] px-4 py-3 shadow-md">
@@ -38,6 +48,20 @@ export function Header() {
         </div>
         <div className="flex items-center gap-2">
           {!isMasterPage && <WeekSelector variant="header" />}
+
+          {isLoggedIn && (
+            <div className="flex items-center gap-1.5 mr-1">
+              {role && (
+                <span className="rounded-full bg-white/20 px-2 py-0.5 text-[10px] font-medium text-white">
+                  {ROLE_LABELS[role] ?? role}
+                </span>
+              )}
+              <span className="text-xs text-white/80 hidden sm:inline">
+                {user.displayName ?? user.email}
+              </span>
+            </div>
+          )}
+
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -70,6 +94,15 @@ export function Header() {
                   希望休管理
                 </Link>
               </DropdownMenuItem>
+              {isLoggedIn && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => signOut()}>
+                    <LogOut className="mr-2 h-4 w-4" />
+                    ログアウト
+                  </DropdownMenuItem>
+                </>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/web/src/lib/auth/AuthProvider.tsx
+++ b/web/src/lib/auth/AuthProvider.tsx
@@ -1,45 +1,102 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
 import {
   onAuthStateChanged,
   signInAnonymously,
+  signInWithPopup,
+  signOut as firebaseSignOut,
+  GoogleAuthProvider,
   type User,
 } from 'firebase/auth';
 import { getFirebaseAuth } from '@/lib/firebase';
 
-type AuthMode = 'required' | 'demo';
+export type AuthMode = 'required' | 'demo';
+export type UserRole = 'admin' | 'service_manager' | 'helper';
 
 interface AuthContextValue {
   user: User | null;
   loading: boolean;
+  role: UserRole | null;
+  helperId: string | null;
+  authMode: AuthMode;
   getIdToken: () => Promise<string | null>;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
   loading: true,
+  role: null,
+  helperId: null,
+  authMode: 'demo',
   getIdToken: async () => null,
+  signIn: async () => {},
+  signOut: async () => {},
 });
 
 export function useAuth() {
   return useContext(AuthContext);
 }
 
+export function useAuthRole() {
+  const { role, helperId } = useAuth();
+  const hasNoRole = role === null;
+  return {
+    role,
+    hasNoRole,
+    isAdmin: role === 'admin',
+    isServiceManager: role === 'service_manager',
+    isHelper: role === 'helper',
+    isManagerOrAbove: role === 'admin' || role === 'service_manager',
+    /** 利用者マスタ編集可: admin + service_manager + デモモード */
+    canEditCustomers: hasNoRole || role === 'admin' || role === 'service_manager',
+    /** ヘルパーマスタ編集可: admin + デモモード */
+    canEditHelpers: hasNoRole || role === 'admin',
+    /** 希望休管理可: admin + service_manager + デモモード（helperは自分のみ） */
+    canEditUnavailability: hasNoRole || role === 'admin' || role === 'service_manager',
+    helperId,
+  };
+}
+
 const AUTH_MODE: AuthMode =
   (process.env.NEXT_PUBLIC_AUTH_MODE as AuthMode) ?? 'demo';
+
+const googleProvider = new GoogleAuthProvider();
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [role, setRole] = useState<UserRole | null>(null);
+  const [helperId, setHelperId] = useState<string | null>(null);
+
+  // Custom Claims からロール情報を取得
+  const fetchClaims = useCallback(async (firebaseUser: User | null) => {
+    if (!firebaseUser) {
+      setRole(null);
+      setHelperId(null);
+      return;
+    }
+    try {
+      const result = await firebaseUser.getIdTokenResult();
+      const claims = result.claims;
+      setRole((claims.role as UserRole) ?? null);
+      setHelperId((claims.helper_id as string) ?? null);
+    } catch {
+      setRole(null);
+      setHelperId(null);
+    }
+  }, []);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(getFirebaseAuth(), (firebaseUser) => {
+    const unsubscribe = onAuthStateChanged(getFirebaseAuth(), async (firebaseUser) => {
       setUser(firebaseUser);
+      await fetchClaims(firebaseUser);
       setLoading(false);
     });
     return unsubscribe;
-  }, []);
+  }, [fetchClaims]);
 
   // デモモード: 未認証なら匿名サインイン
   useEffect(() => {
@@ -48,24 +105,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [loading, user]);
 
-  const getIdToken = async (): Promise<string | null> => {
+  const getIdToken = useCallback(async (): Promise<string | null> => {
     if (!user) return null;
     return user.getIdToken();
-  };
+  }, [user]);
 
-  // requiredモードで未認証 → ログインUI表示
+  const signIn = useCallback(async () => {
+    await signInWithPopup(getFirebaseAuth(), googleProvider);
+  }, []);
+
+  const signOut = useCallback(async () => {
+    await firebaseSignOut(getFirebaseAuth());
+  }, []);
+
+  // requiredモードで未認証 → Googleログイン画面
   if (AUTH_MODE === 'required' && !loading && !user) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <div className="text-center space-y-4">
-          <h1 className="text-2xl font-bold">VisitCare シフト最適化</h1>
-          <p className="text-muted-foreground">ログインが必要です</p>
-          <p className="text-sm text-muted-foreground">
-            管理者にアカウントの発行を依頼してください
-          </p>
-        </div>
-      </div>
-    );
+    return <LoginScreen onSignIn={signIn} />;
   }
 
   // ローディング中
@@ -78,8 +133,62 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, loading, getIdToken }}>
+    <AuthContext.Provider value={{ user, loading, role, helperId, authMode: AUTH_MODE, getIdToken, signIn, signOut }}>
       {children}
     </AuthContext.Provider>
+  );
+}
+
+function LoginScreen({ onSignIn }: { onSignIn: () => Promise<void> }) {
+  const [signingIn, setSigningIn] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSignIn = async () => {
+    setSigningIn(true);
+    setError(null);
+    try {
+      await onSignIn();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'ログインに失敗しました');
+      setSigningIn(false);
+    }
+  };
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-gradient-to-br from-[oklch(0.97_0.01_195)] to-[oklch(0.93_0.03_195)]">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-8 shadow-lg">
+        <div className="text-center space-y-2">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)]">
+            <svg className="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+            </svg>
+          </div>
+          <h1 className="text-xl font-bold text-gray-900">VisitCare</h1>
+          <p className="text-sm text-gray-500">シフト最適化システム</p>
+        </div>
+
+        <button
+          onClick={handleSignIn}
+          disabled={signingIn}
+          className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:opacity-50"
+        >
+          <svg className="h-5 w-5" viewBox="0 0 24 24">
+            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+          </svg>
+          {signingIn ? 'ログイン中...' : 'Google でログイン'}
+        </button>
+
+        {error && (
+          <p className="text-center text-sm text-red-500">{error}</p>
+        )}
+
+        <p className="text-center text-xs text-gray-400">
+          組織の Google アカウントでログインしてください
+        </p>
+      </div>
+    </div>
   );
 }

--- a/web/src/lib/auth/__tests__/AuthProvider.test.tsx
+++ b/web/src/lib/auth/__tests__/AuthProvider.test.tsx
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../AuthProvider';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { AuthProvider, useAuth, useAuthRole } from '../AuthProvider';
 
 // Firebase authモック
 const mockOnAuthStateChanged = vi.fn();
 const mockSignInAnonymously = vi.fn();
+const mockSignInWithPopup = vi.fn();
+const mockSignOut = vi.fn();
 
 vi.mock('@/lib/firebase', () => ({
   getFirebaseAuth: () => ({}),
@@ -14,6 +16,9 @@ vi.mock('@/lib/firebase', () => ({
 vi.mock('firebase/auth', () => ({
   onAuthStateChanged: (...args: unknown[]) => mockOnAuthStateChanged(...args),
   signInAnonymously: (...args: unknown[]) => mockSignInAnonymously(...args),
+  signInWithPopup: (...args: unknown[]) => mockSignInWithPopup(...args),
+  signOut: (...args: unknown[]) => mockSignOut(...args),
+  GoogleAuthProvider: vi.fn(),
   getAuth: vi.fn(),
   connectAuthEmulator: vi.fn(),
 }));
@@ -25,9 +30,36 @@ function TestConsumer() {
   return <div>user:{user.uid}</div>;
 }
 
+function TestRoleConsumer() {
+  const { role, hasNoRole, isAdmin, isServiceManager, isHelper, isManagerOrAbove, canEditCustomers, canEditHelpers, canEditUnavailability, helperId } = useAuthRole();
+  return (
+    <div>
+      <span data-testid="role">{role ?? 'none'}</span>
+      <span data-testid="hasNoRole">{String(hasNoRole)}</span>
+      <span data-testid="isAdmin">{String(isAdmin)}</span>
+      <span data-testid="isServiceManager">{String(isServiceManager)}</span>
+      <span data-testid="isHelper">{String(isHelper)}</span>
+      <span data-testid="isManagerOrAbove">{String(isManagerOrAbove)}</span>
+      <span data-testid="canEditCustomers">{String(canEditCustomers)}</span>
+      <span data-testid="canEditHelpers">{String(canEditHelpers)}</span>
+      <span data-testid="canEditUnavailability">{String(canEditUnavailability)}</span>
+      <span data-testid="helperId">{helperId ?? 'none'}</span>
+    </div>
+  );
+}
+
+function TestSignOutConsumer() {
+  const { user, signOut } = useAuth();
+  return (
+    <div>
+      {user && <span>user:{user.uid}</span>}
+      <button onClick={signOut}>ログアウト</button>
+    </div>
+  );
+}
+
 beforeEach(() => {
-  mockOnAuthStateChanged.mockReset();
-  mockSignInAnonymously.mockReset();
+  vi.resetAllMocks();
 });
 
 describe('AuthProvider', () => {
@@ -44,7 +76,11 @@ describe('AuthProvider', () => {
   });
 
   it('認証済みユーザーのコンテキスト提供', async () => {
-    const mockUser = { uid: 'test-uid', getIdToken: () => Promise.resolve('token') };
+    const mockUser = {
+      uid: 'test-uid',
+      getIdToken: () => Promise.resolve('token'),
+      getIdTokenResult: () => Promise.resolve({ claims: {} }),
+    };
     mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: unknown) => void) => {
       callback(mockUser);
       return () => {};
@@ -62,7 +98,6 @@ describe('AuthProvider', () => {
   });
 
   it('デモモードで未認証時に匿名サインイン', async () => {
-    // onAuthStateChangedで null を返す（未認証）
     mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: null) => void) => {
       callback(null);
       return () => {};
@@ -77,6 +112,153 @@ describe('AuthProvider', () => {
 
     await waitFor(() => {
       expect(mockSignInAnonymously).toHaveBeenCalled();
+    });
+  });
+
+  it('signOut を呼び出せる', async () => {
+    const mockUser = {
+      uid: 'test-uid',
+      getIdToken: () => Promise.resolve('token'),
+      getIdTokenResult: () => Promise.resolve({ claims: {} }),
+    };
+    mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: unknown) => void) => {
+      callback(mockUser);
+      return () => {};
+    });
+    mockSignOut.mockResolvedValue(undefined);
+
+    render(
+      <AuthProvider>
+        <TestSignOutConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('user:test-uid')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText('ログアウト'));
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('useAuthRole', () => {
+  it('Custom Claims からロール情報を取得（admin）', async () => {
+    const mockUser = {
+      uid: 'admin-uid',
+      getIdToken: () => Promise.resolve('token'),
+      getIdTokenResult: () => Promise.resolve({
+        claims: { role: 'admin' },
+      }),
+    };
+    mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: unknown) => void) => {
+      callback(mockUser);
+      return () => {};
+    });
+
+    render(
+      <AuthProvider>
+        <TestRoleConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role').textContent).toBe('admin');
+      expect(screen.getByTestId('isAdmin').textContent).toBe('true');
+      expect(screen.getByTestId('isManagerOrAbove').textContent).toBe('true');
+      expect(screen.getByTestId('canEditCustomers').textContent).toBe('true');
+      expect(screen.getByTestId('canEditHelpers').textContent).toBe('true');
+      expect(screen.getByTestId('canEditUnavailability').textContent).toBe('true');
+    });
+  });
+
+  it('Custom Claims からロール情報を取得（service_manager）', async () => {
+    const mockUser = {
+      uid: 'manager-uid',
+      getIdToken: () => Promise.resolve('token'),
+      getIdTokenResult: () => Promise.resolve({
+        claims: { role: 'service_manager' },
+      }),
+    };
+    mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: unknown) => void) => {
+      callback(mockUser);
+      return () => {};
+    });
+
+    render(
+      <AuthProvider>
+        <TestRoleConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role').textContent).toBe('service_manager');
+      expect(screen.getByTestId('isServiceManager').textContent).toBe('true');
+      expect(screen.getByTestId('isManagerOrAbove').textContent).toBe('true');
+      expect(screen.getByTestId('canEditCustomers').textContent).toBe('true');
+      expect(screen.getByTestId('canEditHelpers').textContent).toBe('false');
+      expect(screen.getByTestId('canEditUnavailability').textContent).toBe('true');
+    });
+  });
+
+  it('Custom Claims からロール情報を取得（helper + helper_id）', async () => {
+    const mockUser = {
+      uid: 'helper-uid',
+      getIdToken: () => Promise.resolve('token'),
+      getIdTokenResult: () => Promise.resolve({
+        claims: { role: 'helper', helper_id: 'helper-001' },
+      }),
+    };
+    mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: unknown) => void) => {
+      callback(mockUser);
+      return () => {};
+    });
+
+    render(
+      <AuthProvider>
+        <TestRoleConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role').textContent).toBe('helper');
+      expect(screen.getByTestId('isHelper').textContent).toBe('true');
+      expect(screen.getByTestId('isManagerOrAbove').textContent).toBe('false');
+      expect(screen.getByTestId('canEditCustomers').textContent).toBe('false');
+      expect(screen.getByTestId('canEditHelpers').textContent).toBe('false');
+      expect(screen.getByTestId('canEditUnavailability').textContent).toBe('false');
+      expect(screen.getByTestId('helperId').textContent).toBe('helper-001');
+    });
+  });
+
+  it('Custom Claims がない場合は role が null', async () => {
+    const mockUser = {
+      uid: 'anon-uid',
+      getIdToken: () => Promise.resolve('token'),
+      getIdTokenResult: () => Promise.resolve({ claims: {} }),
+    };
+    mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: unknown) => void) => {
+      callback(mockUser);
+      return () => {};
+    });
+
+    render(
+      <AuthProvider>
+        <TestRoleConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role').textContent).toBe('none');
+      expect(screen.getByTestId('hasNoRole').textContent).toBe('true');
+      expect(screen.getByTestId('isAdmin').textContent).toBe('false');
+      expect(screen.getByTestId('isManagerOrAbove').textContent).toBe('false');
+      expect(screen.getByTestId('canEditCustomers').textContent).toBe('true');
+      expect(screen.getByTestId('canEditHelpers').textContent).toBe('true');
+      expect(screen.getByTestId('canEditUnavailability').textContent).toBe('true');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Firebase Custom Claims による3ロール（admin / service_manager / helper）の権限制御を全レイヤーに導入
- Googleソーシャルログイン + デモモード（role未設定時は全権限維持）の共存
- ADR-014でRBAC設計を記録

## 変更内容

### 認証基盤
- `AuthProvider`: Googleログイン（`signInWithPopup`）+ Custom Claimsからロール取得
- `useAuthRole`: `canEditCustomers` / `canEditHelpers` / `canEditUnavailability` 等の権限判定フック
- `LoginScreen`: Googleログインボタン付きログイン画面（`required`モード時）
- `Header`: ロールバッジ + ユーザー名 + ログアウト表示

### Firestoreルール（RBAC対応）
- `hasNoRole()`: デモモード互換（Custom Claims未設定 → 全権限）
- 利用者マスタ: admin + service_manager が編集可
- ヘルパーマスタ: admin のみ編集可
- 希望休: admin + service_manager + 自分のデータ（helper）
- オーダー: admin + service_manager が割当編集可

### バックエンドAPI認可
- `require_manager_or_above`: `/optimize` エンドポイントを admin / service_manager に制限
- helperロールは403、roleなし（デモ互換）は許可

### フロントエンド権限制御UI
- 利用者マスタ: 新規追加/編集ボタンを admin + service_manager に限定
- ヘルパーマスタ: 新規追加/編集ボタンを admin に限定
- 希望休管理: helperは自分のデータのみ編集可

### CLIツール
- `seed/scripts/set-custom-claims.ts`: ロール設定/確認/削除スクリプト

## テスト結果
- Web: 48/48 passed
- Backend: 139/139 passed（新規5件: ロール検証テスト）
- Firestore Rules: 62/62 passed（新規17件: RBAC権限テスト）
- Next.js Build: success

## Test plan
- [ ] デモモード（匿名認証）で全機能が従来通り動作すること
- [ ] Googleログイン → admin / service_manager / helper 各ロールで権限が正しく制御されること
- [ ] helperが自分の希望休のみ編集可能、他人分は編集ボタン非表示
- [ ] helperが /optimize API を呼ぶと403
- [ ] Custom Claims CLI でロール設定/確認/削除が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)