### PR TITLE
fix: Distance Matrix API バッチサイズ修正

### DIFF
--- a/seed/scripts/utils/google-maps-client.ts
+++ b/seed/scripts/utils/google-maps-client.ts
@@ -44,8 +44,10 @@ class GoogleMapsAPIError extends Error {
   }
 }
 
-/** Distance Matrix API の1リクエストあたりの最大 origins/destinations 数 */
-const MAX_ELEMENTS_PER_REQUEST = 25;
+/** Distance Matrix API の1リクエストあたりの最大 origins/destinations 数
+ * API制限: origins × destinations ≤ 100 要素/リクエスト
+ * 10 × 10 = 100 でちょうど制限内 */
+const MAX_ELEMENTS_PER_REQUEST = 10;
 
 /** リトライ設定 */
 const MAX_RETRIES = 3;


### PR DESCRIPTION
## Summary
- Distance Matrix API の `MAX_ELEMENTS_PER_REQUEST` を 25→10 に修正
- API制限（origins × destinations ≤ 100要素/リクエスト）超過による `MAX_ELEMENTS_EXCEEDED` エラーを解消
- 本番Firestore の travel_times 2,550件を全て `source: 'google_maps'` に更新済み

## 背景
25×25=625要素でリクエストしていたが、Distance Matrix APIの制限は100要素/リクエスト。10×10=100に修正。

## Test plan
- [x] `google-maps-client.test.ts` 12件パス
- [x] 本番Seed実行: 2,550ペア全てGoogle Maps API取得成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)