### PR TITLE
feat: マスタ間タブナビゲーション + テーブルゼブラストライピング

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -104,8 +104,8 @@ export default function CustomersPage() {
                 </TableCell>
               </TableRow>
             ) : (
-              filtered.map((customer) => (
-                <TableRow key={customer.id}>
+              filtered.map((customer, index) => (
+                <TableRow key={customer.id} className={index % 2 === 1 ? 'bg-muted/30' : ''}>
                   <TableCell className="font-medium">
                     {customer.name.family} {customer.name.given}
                   </TableCell>

--- a/web/src/app/masters/helpers/page.tsx
+++ b/web/src/app/masters/helpers/page.tsx
@@ -110,8 +110,8 @@ export default function HelpersPage() {
                 </TableCell>
               </TableRow>
             ) : (
-              filtered.map((helper) => (
-                <TableRow key={helper.id}>
+              filtered.map((helper, index) => (
+                <TableRow key={helper.id} className={index % 2 === 1 ? 'bg-muted/30' : ''}>
                   <TableCell className="font-medium">
                     {helper.name.family} {helper.name.given}
                   </TableCell>

--- a/web/src/app/masters/layout.tsx
+++ b/web/src/app/masters/layout.tsx
@@ -1,15 +1,38 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
 import { Header } from '@/components/layout/Header';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+const MASTER_TABS = [
+  { value: '/masters/customers', label: '利用者マスタ' },
+  { value: '/masters/helpers', label: 'ヘルパーマスタ' },
+  { value: '/masters/unavailability', label: '希望休管理' },
+] as const;
 
 export default function MastersLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const pathname = usePathname();
+  const currentTab = MASTER_TABS.find((t) => pathname.startsWith(t.value))?.value ?? MASTER_TABS[0].value;
+
   return (
     <div className="flex h-screen flex-col">
       <Header />
+      <div className="border-b px-4 pt-2">
+        <Tabs value={currentTab}>
+          <TabsList>
+            {MASTER_TABS.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value} asChild>
+                <Link href={tab.value}>{tab.label}</Link>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
       <main className="flex-1 overflow-auto">{children}</main>
     </div>
   );

--- a/web/src/app/masters/unavailability/page.tsx
+++ b/web/src/app/masters/unavailability/page.tsx
@@ -151,10 +151,10 @@ export default function UnavailabilityPage() {
                 </TableCell>
               </TableRow>
             ) : (
-              filtered.map((u) => {
+              filtered.map((u, index) => {
                 const h = helpers.get(u.staff_id);
                 return (
-                  <TableRow key={u.id}>
+                  <TableRow key={u.id} className={index % 2 === 1 ? 'bg-muted/30' : ''}>
                     <TableCell className="font-medium">
                       {h ? `${h.name.family} ${h.name.given}` : u.staff_id}
                     </TableCell>


### PR DESCRIPTION
## Summary
- マスタ管理画面のlayout.tsxにTabsコンポーネントで3つのマスタページ間ナビゲーションを追加
- 利用者/ヘルパー/希望休の各テーブルにゼブラストライピング（偶数行に背景色）を追加
- 既存のshadcn/ui Tabsコンポーネントを活用し、usePathnameで現在タブをハイライト

## Test plan
- [ ] ビルド成功確認（`npm run build` エラーなし）
- [ ] `/masters/customers/` でタブが表示され、利用者マスタがアクティブ
- [ ] `/masters/helpers/` でヘルパーマスタタブがアクティブ
- [ ] `/masters/unavailability/` で希望休管理タブがアクティブ
- [ ] 各テーブルで偶数行にゼブラストライピングが適用されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)