### PR TITLE
feat: マスタ一覧の情報表示改善

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -14,6 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
 import { CustomerEditDialog } from '@/components/masters/CustomerEditDialog';
 import { DAY_OF_WEEK_ORDER } from '@/types';
 import type { Customer } from '@/types';
@@ -93,13 +94,14 @@ export default function CustomersPage() {
               <TableHead>住所</TableHead>
               <TableHead className="w-24">サ責</TableHead>
               <TableHead className="w-24 text-center">サービス日数</TableHead>
+              <TableHead className="w-28 text-center">NG/推奨</TableHead>
               <TableHead className="w-16" />
             </TableRow>
           </TableHeader>
           <TableBody>
             {filtered.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
                   {search ? '一致する利用者が見つかりません' : '利用者が登録されていません'}
                 </TableCell>
               </TableRow>
@@ -117,6 +119,21 @@ export default function CustomersPage() {
                     <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
                       {serviceDayCount(customer)}
                     </span>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex items-center justify-center gap-1">
+                      {customer.ng_staff_ids.length > 0 ? (
+                        <Badge variant="destructive" className="text-[10px] px-1.5 h-5">
+                          NG {customer.ng_staff_ids.length}
+                        </Badge>
+                      ) : null}
+                      {customer.preferred_staff_ids.length > 0 ? (
+                        <Badge variant="secondary" className="text-[10px] px-1.5 h-5">
+                          推奨 {customer.preferred_staff_ids.length}
+                        </Badge>
+                      ) : null}
+                      {customer.ng_staff_ids.length === 0 && customer.preferred_staff_ids.length === 0 && '-'}
+                    </div>
                   </TableCell>
                   {canEditCustomers && (
                     <TableCell>

--- a/web/src/app/masters/helpers/page.tsx
+++ b/web/src/app/masters/helpers/page.tsx
@@ -99,13 +99,15 @@ export default function HelpersPage() {
               <TableHead className="w-24 text-center">身体介護</TableHead>
               <TableHead className="w-20">雇用形態</TableHead>
               <TableHead className="w-20">移動手段</TableHead>
+              <TableHead className="w-20 text-center">勤務日数</TableHead>
+              <TableHead className="w-28">希望時間</TableHead>
               <TableHead className="w-16" />
             </TableRow>
           </TableHeader>
           <TableBody>
             {filtered.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
                   {search ? '一致するヘルパーが見つかりません' : 'ヘルパーが登録されていません'}
                 </TableCell>
               </TableRow>
@@ -134,6 +136,16 @@ export default function HelpersPage() {
                   </TableCell>
                   <TableCell className="text-sm">
                     {TRANSPORTATION_LABELS[helper.transportation] ?? helper.transportation}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
+                      {Object.keys(helper.weekly_availability).filter(
+                        (day) => (helper.weekly_availability as Record<string, unknown[]>)[day]?.length > 0
+                      ).length}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {helper.preferred_hours.min}〜{helper.preferred_hours.max}h
                   </TableCell>
                   {canEditHelpers && (
                     <TableCell>


### PR DESCRIPTION
## Summary
- 利用者一覧テーブルに「NG/推奨」列を追加（NGスタッフ/推奨スタッフの件数をBadgeで表示）
- ヘルパー一覧テーブルに「勤務日数」「希望時間」列を追加

## Test plan
- [ ] ビルド成功確認（`npm run build` エラーなし）
- [ ] `/masters/customers/` でNG/推奨列が表示され、件数がBadgeで表示される
- [ ] NG/推奨がどちらも0の場合は「-」が表示される
- [ ] `/masters/helpers/` で勤務日数と希望時間列が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)