### PR TITLE
feat: ガントバー閾値調整 + 違反バッジ改善

### DIFF
--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -73,7 +73,7 @@ export function GanttBar({ order, customer, hasViolation, violationType, onClick
       {...attributes}
       {...listeners}
     >
-      {width > 40 ? customerName : ''}
+      {width > 20 ? customerName : ''}
     </button>
   );
 }

--- a/web/src/components/schedule/StatsBar.tsx
+++ b/web/src/components/schedule/StatsBar.tsx
@@ -80,9 +80,14 @@ export function StatsBar({ schedule, violations }: StatsBarProps) {
           <p className="text-[11px] text-muted-foreground leading-none">ヘルパー</p>
           <div className="flex items-center gap-1.5">
             <p className="text-lg font-bold leading-tight">{schedule.helperRows.length}<span className="text-xs font-normal text-muted-foreground ml-0.5">名</span></p>
-            {totalViolations > 0 && (
+            {errorCount > 0 && (
               <Badge variant="destructive" className="h-5 px-1.5 text-[10px]">
-                {errorCount > 0 ? `違反${errorCount}` : `警告${warningCount}`}
+                違反{errorCount}
+              </Badge>
+            )}
+            {warningCount > 0 && (
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px] border-yellow-500 text-yellow-600">
+                警告{warningCount}
               </Badge>
             )}
           </div>


### PR DESCRIPTION
## Summary
- ガントバーの利用者名表示閾値を40px→20pxに変更し、短いバーでも名前を表示
- StatsBarの違反バッジを改善: エラーと警告を別々のBadgeとして両方表示（従来はどちらか一方のみ）

## Test plan
- [ ] ビルド成功確認（`npm run build` エラーなし）
- [ ] ガントチャートで短いバーにも利用者名が表示される
- [ ] エラーと警告が同時に存在する場合、両方のバッジが表示される
- [ ] エラーのみ/警告のみの場合も正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)