### PR TITLE
feat: 最適化実行結果の保存・履歴閲覧機能を追加

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -122,6 +122,13 @@ service cloud.firestore {
         && (hasNoRole() || isManagerOrAbove() || isOwnStaffData(resource.data.staff_id));
     }
 
+    // 最適化実行履歴: 読み取りのみ（Admin SDKで書き込み）
+    match /optimization_runs/{runId} {
+      allow read: if isAuthenticated()
+        && (hasNoRole() || isManagerOrAbove());
+      allow write: if false;
+    }
+
     // オーダー: admin + service_manager が割当編集可
     match /orders/{orderId} {
       allow read: if isAuthenticated();

--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -1,22 +1,34 @@
 """APIルーティング"""
 
 import logging
-from datetime import date
+from datetime import UTC, date, datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from optimizer.api.auth import require_manager_or_above
 from optimizer.api.schemas import (
     AssignmentResponse,
     ErrorResponse,
+    OptimizationParametersResponse,
+    OptimizationRunDetailResponse,
+    OptimizationRunListResponse,
+    OptimizationRunResponse,
     OptimizeRequest,
     OptimizeResponse,
 )
 from optimizer.data.firestore_loader import get_firestore_client, load_optimization_input
-from optimizer.data.firestore_writer import write_assignments
+from optimizer.data.firestore_writer import save_optimization_run, write_assignments
 from optimizer.engine.solver import solve
+from optimizer.models import Assignment, OptimizationParameters, OptimizationRunRecord
 
 logger = logging.getLogger(__name__)
+
+
+def _serialize_executed_at(value: object) -> str:
+    """Firestore Timestamp/datetimeをISO 8601文字列に変換"""
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value) if value else ""
 
 router = APIRouter()
 
@@ -91,6 +103,35 @@ def optimize(req: OptimizeRequest, _auth: dict | None = Depends(require_manager_
             ) from e
         logger.info("Firestore書き戻し完了: %d件", orders_updated)
 
+    # 最適化実行記録を保存
+    executed_by = ""
+    if _auth:
+        executed_by = _auth.get("uid", "")
+
+    run_record = OptimizationRunRecord(
+        id="",  # save_optimization_run内で生成
+        week_start_date=req.week_start_date,
+        executed_at=datetime.now(UTC),
+        executed_by=executed_by,
+        dry_run=req.dry_run,
+        status=result.status,
+        objective_value=result.objective_value,
+        solve_time_seconds=result.solve_time_seconds,
+        total_orders=len(inp.orders),
+        assigned_count=len(result.assignments),
+        assignments=result.assignments,
+        parameters=OptimizationParameters(
+            time_limit_seconds=req.time_limit_seconds,
+        ),
+    )
+
+    try:
+        run_id = save_optimization_run(db, run_record)
+        logger.info("最適化実行記録保存完了: id=%s", run_id)
+    except Exception as e:
+        logger.error("最適化実行記録の保存失敗: %s", e, exc_info=True)
+        # 実行記録の保存失敗はAPIレスポンスには影響させない
+
     return OptimizeResponse(
         assignments=[
             AssignmentResponse(order_id=a.order_id, staff_ids=a.staff_ids)
@@ -102,4 +143,96 @@ def optimize(req: OptimizeRequest, _auth: dict | None = Depends(require_manager_
         orders_updated=orders_updated,
         total_orders=len(inp.orders),
         assigned_count=len(result.assignments),
+    )
+
+
+@router.get(
+    "/optimization-runs",
+    response_model=OptimizationRunListResponse,
+)
+def list_optimization_runs(
+    week_start_date: str | None = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    limit: int = Query(20, ge=1, le=100),
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> OptimizationRunListResponse:
+    """最適化実行履歴一覧を取得"""
+    db = get_firestore_client()
+    query = db.collection("optimization_runs").order_by(
+        "executed_at", direction="DESCENDING"
+    )
+
+    if week_start_date:
+        query = query.where("week_start_date", "==", week_start_date)
+
+    query = query.limit(limit)
+    docs = query.stream()
+
+    runs = []
+    for doc in docs:
+        data = doc.to_dict()
+        params = data.get("parameters", {})
+
+        runs.append(
+            OptimizationRunResponse(
+                id=data.get("id", doc.id),
+                week_start_date=data.get("week_start_date", ""),
+                executed_at=_serialize_executed_at(data.get("executed_at")),
+                executed_by=data.get("executed_by", ""),
+                dry_run=data.get("dry_run", False),
+                status=data.get("status", ""),
+                objective_value=data.get("objective_value", 0.0),
+                solve_time_seconds=data.get("solve_time_seconds", 0.0),
+                total_orders=data.get("total_orders", 0),
+                assigned_count=data.get("assigned_count", 0),
+                parameters=OptimizationParametersResponse(
+                    time_limit_seconds=params.get("time_limit_seconds", 180),
+                ),
+            )
+        )
+
+    return OptimizationRunListResponse(runs=runs)
+
+
+@router.get(
+    "/optimization-runs/{run_id}",
+    response_model=OptimizationRunDetailResponse,
+    responses={404: {"model": ErrorResponse}},
+)
+def get_optimization_run(
+    run_id: str,
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> OptimizationRunDetailResponse:
+    """最適化実行記録の詳細を取得"""
+    db = get_firestore_client()
+    doc = db.collection("optimization_runs").document(run_id).get()
+
+    if not doc.exists:
+        raise HTTPException(status_code=404, detail="実行記録が見つかりません")
+
+    data = doc.to_dict()
+    params = data.get("parameters", {})
+
+    assignments = [
+        AssignmentResponse(
+            order_id=a.get("order_id", ""),
+            staff_ids=a.get("staff_ids", []),
+        )
+        for a in data.get("assignments", [])
+    ]
+
+    return OptimizationRunDetailResponse(
+        id=data.get("id", doc.id),
+        week_start_date=data.get("week_start_date", ""),
+        executed_at=_serialize_executed_at(data.get("executed_at")),
+        executed_by=data.get("executed_by", ""),
+        dry_run=data.get("dry_run", False),
+        status=data.get("status", ""),
+        objective_value=data.get("objective_value", 0.0),
+        solve_time_seconds=data.get("solve_time_seconds", 0.0),
+        total_orders=data.get("total_orders", 0),
+        assigned_count=data.get("assigned_count", 0),
+        parameters=OptimizationParametersResponse(
+            time_limit_seconds=params.get("time_limit_seconds", 180),
+        ),
+        assignments=assignments,
     )

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -37,6 +37,32 @@ class OptimizeResponse(BaseModel):
     assigned_count: int = Field(description="割当成功オーダー数")
 
 
+class OptimizationParametersResponse(BaseModel):
+    time_limit_seconds: int = 180
+
+
+class OptimizationRunResponse(BaseModel):
+    id: str
+    week_start_date: str
+    executed_at: str = Field(description="ISO 8601 datetime")
+    executed_by: str
+    dry_run: bool
+    status: str
+    objective_value: float
+    solve_time_seconds: float
+    total_orders: int
+    assigned_count: int
+    parameters: OptimizationParametersResponse
+
+
+class OptimizationRunDetailResponse(OptimizationRunResponse):
+    assignments: list[AssignmentResponse]
+
+
+class OptimizationRunListResponse(BaseModel):
+    runs: list[OptimizationRunResponse]
+
+
 class ErrorResponse(BaseModel):
     error: str
     detail: str | None = None

--- a/optimizer/src/optimizer/data/firestore_writer.py
+++ b/optimizer/src/optimizer/data/firestore_writer.py
@@ -1,11 +1,12 @@
 """最適化結果のFirestore書き戻し"""
 
 import logging
+import uuid
 
 from google.cloud import firestore  # type: ignore[attr-defined]
 from google.cloud.firestore_v1 import SERVER_TIMESTAMP  # type: ignore[import-untyped]
 
-from optimizer.models import Assignment
+from optimizer.models import Assignment, OptimizationRunRecord
 
 logger = logging.getLogger(__name__)
 
@@ -45,3 +46,28 @@ def write_assignments(
         updated += len(chunk)
 
     return updated
+
+
+def save_optimization_run(
+    db: firestore.Client,
+    record: OptimizationRunRecord,
+) -> str:
+    """最適化実行記録をFirestoreに保存
+
+    Returns:
+        作成されたドキュメントのID
+    """
+    run_id = str(uuid.uuid4())
+    doc_ref = db.collection("optimization_runs").document(run_id)
+
+    doc_data = record.model_dump()
+    doc_data["id"] = run_id
+    # executed_at はサーバータイムスタンプで上書き
+    doc_data["executed_at"] = SERVER_TIMESTAMP
+    # assignments を dict リストに変換
+    doc_data["assignments"] = [a.model_dump() for a in record.assignments]
+    doc_data["parameters"] = record.parameters.model_dump()
+
+    doc_ref.set(doc_data)
+    logger.info("最適化実行記録を保存: id=%s", run_id)
+    return run_id

--- a/optimizer/src/optimizer/models/__init__.py
+++ b/optimizer/src/optimizer/models/__init__.py
@@ -16,6 +16,7 @@ from .constraint import StaffConstraint
 from .customer import Customer
 from .helper import Helper, HoursRange
 from .order import Order
+from .optimization_run import OptimizationParameters, OptimizationRunRecord
 from .problem import Assignment, OptimizationInput, OptimizationResult
 from .staff_unavailability import StaffUnavailability
 from .travel_time import TravelTime
@@ -30,7 +31,9 @@ __all__ = [
     "Helper",
     "HoursRange",
     "OptimizationInput",
+    "OptimizationParameters",
     "OptimizationResult",
+    "OptimizationRunRecord",
     "Order",
     "ServiceSlot",
     "ServiceType",

--- a/optimizer/src/optimizer/models/optimization_run.py
+++ b/optimizer/src/optimizer/models/optimization_run.py
@@ -1,0 +1,30 @@
+"""最適化実行記録モデル"""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from .problem import Assignment
+
+
+class OptimizationParameters(BaseModel):
+    """最適化パラメータ"""
+
+    time_limit_seconds: int
+
+
+class OptimizationRunRecord(BaseModel):
+    """Firestoreに保存する最適化実行記録"""
+
+    id: str
+    week_start_date: str  # YYYY-MM-DD
+    executed_at: datetime
+    executed_by: str  # Firebase Auth UID
+    dry_run: bool
+    status: str  # "Optimal", "Feasible", "Infeasible", "Not Solved"
+    objective_value: float
+    solve_time_seconds: float
+    total_orders: int
+    assigned_count: int
+    assignments: list[Assignment]
+    parameters: OptimizationParameters

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -21,3 +21,9 @@ export type { Helper } from './helper';
 export type { Order } from './order';
 export type { TravelTime } from './travel-time';
 export type { StaffUnavailability } from './staff-unavailability';
+export type {
+  AssignmentRecord,
+  OptimizationParameters,
+  OptimizationRun,
+  OptimizationStatus,
+} from './optimization-run';

--- a/shared/types/optimization-run.ts
+++ b/shared/types/optimization-run.ts
@@ -1,0 +1,31 @@
+import { Timestamp } from 'firebase-admin/firestore';
+
+/** 最適化実行ステータス */
+export type OptimizationStatus = 'Optimal' | 'Feasible' | 'Infeasible' | 'Not Solved';
+
+/** 割当結果（1オーダー） */
+export interface AssignmentRecord {
+  order_id: string;
+  staff_ids: string[];
+}
+
+/** 最適化実行パラメータ */
+export interface OptimizationParameters {
+  time_limit_seconds: number;
+}
+
+/** 最適化実行記録 */
+export interface OptimizationRun {
+  id: string;
+  week_start_date: Timestamp;
+  executed_at: Timestamp;
+  executed_by: string;
+  dry_run: boolean;
+  status: OptimizationStatus;
+  objective_value: number;
+  solve_time_seconds: number;
+  total_orders: number;
+  assigned_count: number;
+  assignments: AssignmentRecord[];
+  parameters: OptimizationParameters;
+}

--- a/web/src/app/history/page.tsx
+++ b/web/src/app/history/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import { ArrowLeft, Clock, CheckCircle2, XCircle, AlertTriangle, FlaskConical, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { Header } from '@/components/layout/Header';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { useOptimizationRuns, useOptimizationRunDetail } from '@/hooks/useOptimizationRuns';
+import { useHelpers } from '@/hooks/useHelpers';
+
+function StatusBadge({ status, dryRun }: { status: string; dryRun: boolean }) {
+  if (dryRun) {
+    return (
+      <Badge variant="secondary" className="gap-1">
+        <FlaskConical className="h-3 w-3" />
+        テスト
+      </Badge>
+    );
+  }
+  switch (status) {
+    case 'Optimal':
+      return (
+        <Badge className="gap-1 bg-emerald-600">
+          <CheckCircle2 className="h-3 w-3" />
+          最適解
+        </Badge>
+      );
+    case 'Feasible':
+      return (
+        <Badge className="gap-1 bg-amber-500">
+          <AlertTriangle className="h-3 w-3" />
+          実行可能解
+        </Badge>
+      );
+    default:
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <XCircle className="h-3 w-3" />
+          {status}
+        </Badge>
+      );
+  }
+}
+
+function RunDetailPanel({
+  runId,
+  onClose,
+}: {
+  runId: string;
+  onClose: () => void;
+}) {
+  const { detail, loading } = useOptimizationRunDetail(runId);
+  const { helpers } = useHelpers();
+
+  const helperNameMap = new Map<string, string>();
+  helpers.forEach((h, id) => helperNameMap.set(id, `${h.name.family} ${h.name.given}`));
+
+  if (loading || !detail) {
+    return (
+      <Sheet open onOpenChange={() => onClose()}>
+        <SheetContent className="w-[480px] sm:max-w-[480px] overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>実行詳細</SheetTitle>
+          </SheetHeader>
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  const executedAt = new Date(detail.executed_at);
+  const assignmentRate = detail.total_orders > 0
+    ? ((detail.assigned_count / detail.total_orders) * 100).toFixed(1)
+    : '0';
+
+  return (
+    <Sheet open onOpenChange={() => onClose()}>
+      <SheetContent className="w-[480px] sm:max-w-[480px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>実行詳細</SheetTitle>
+        </SheetHeader>
+        <div className="mt-4 space-y-4">
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <div className="space-y-1">
+              <p className="text-muted-foreground">実行日時</p>
+              <p className="font-medium">{format(executedAt, 'yyyy/M/d HH:mm:ss', { locale: ja })}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-muted-foreground">対象週</p>
+              <p className="font-medium">{detail.week_start_date}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-muted-foreground">ステータス</p>
+              <StatusBadge status={detail.status} dryRun={detail.dry_run} />
+            </div>
+            <div className="space-y-1">
+              <p className="text-muted-foreground">実行時間</p>
+              <p className="font-medium">{detail.solve_time_seconds.toFixed(1)}秒</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-muted-foreground">割当率</p>
+              <p className="font-medium">{detail.assigned_count}/{detail.total_orders} ({assignmentRate}%)</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-muted-foreground">目的関数値</p>
+              <p className="font-medium">{detail.objective_value.toFixed(2)}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-muted-foreground">制限時間</p>
+              <p className="font-medium">{detail.parameters.time_limit_seconds ?? '-'}秒</p>
+            </div>
+          </div>
+
+          <div className="border-t pt-4">
+            <h3 className="text-sm font-semibold mb-2">割当結果 ({detail.assignments.length}件)</h3>
+            <div className="max-h-[400px] overflow-y-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-xs">オーダーID</TableHead>
+                    <TableHead className="text-xs">担当スタッフ</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {detail.assignments.map((a) => (
+                    <TableRow key={a.order_id}>
+                      <TableCell className="text-xs font-mono">{a.order_id.slice(0, 8)}...</TableCell>
+                      <TableCell className="text-xs">
+                        {a.staff_ids.map((sid) => helperNameMap.get(sid) ?? sid.slice(0, 8)).join(', ')}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default function HistoryPage() {
+  const { runs, loading, error } = useOptimizationRuns();
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+
+  return (
+    <div className="flex h-screen flex-col">
+      <Header />
+      <main className="flex-1 overflow-auto p-4">
+        <div className="mb-4 flex items-center gap-3">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/">
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              戻る
+            </Link>
+          </Button>
+          <h2 className="text-lg font-semibold">最適化実行履歴</h2>
+        </div>
+
+        {loading && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            履歴の取得に失敗しました: {error.message}
+          </div>
+        )}
+
+        {!loading && !error && runs.length === 0 && (
+          <div className="rounded-md border bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+            <Clock className="mx-auto mb-2 h-8 w-8" />
+            <p>最適化の実行履歴はまだありません</p>
+            <p className="mt-1">最適化を実行すると、ここに履歴が表示されます</p>
+          </div>
+        )}
+
+        {!loading && runs.length > 0 && (
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>実行日時</TableHead>
+                  <TableHead>対象週</TableHead>
+                  <TableHead>ステータス</TableHead>
+                  <TableHead className="text-right">割当</TableHead>
+                  <TableHead className="text-right">実行時間</TableHead>
+                  <TableHead className="text-right">目的関数値</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {runs.map((run, index) => {
+                  const executedAt = new Date(run.executed_at);
+                  return (
+                    <TableRow
+                      key={run.id}
+                      className={`cursor-pointer hover:bg-muted/50 ${index % 2 === 1 ? 'bg-muted/20' : ''}`}
+                      onClick={() => setSelectedRunId(run.id)}
+                    >
+                      <TableCell className="text-sm">
+                        {format(executedAt, 'M/d HH:mm', { locale: ja })}
+                      </TableCell>
+                      <TableCell className="text-sm">{run.week_start_date}</TableCell>
+                      <TableCell>
+                        <StatusBadge status={run.status} dryRun={run.dry_run} />
+                      </TableCell>
+                      <TableCell className="text-right text-sm">
+                        {run.assigned_count}/{run.total_orders}
+                      </TableCell>
+                      <TableCell className="text-right text-sm">
+                        {run.solve_time_seconds.toFixed(1)}s
+                      </TableCell>
+                      <TableCell className="text-right text-sm font-mono">
+                        {run.objective_value.toFixed(1)}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {selectedRunId && (
+          <RunDetailPanel
+            runId={selectedRunId}
+            onClose={() => setSelectedRunId(null)}
+          />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Heart, Settings, Users, UserCog, CalendarOff, LogOut } from 'lucide-react';
+import { Heart, Settings, Users, UserCog, CalendarOff, History, LogOut } from 'lucide-react';
 import { WeekSelector } from '@/components/schedule/WeekSelector';
 import { useAuth } from '@/lib/auth/AuthProvider';
 import {
@@ -92,6 +92,14 @@ export function Header() {
                 <Link href="/masters/unavailability">
                   <CalendarOff className="mr-2 h-4 w-4" />
                   希望休管理
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>最適化</DropdownMenuLabel>
+              <DropdownMenuItem asChild>
+                <Link href="/history">
+                  <History className="mr-2 h-4 w-4" />
+                  実行履歴
                 </Link>
               </DropdownMenuItem>
               {isLoggedIn && (

--- a/web/src/hooks/useOptimizationRuns.ts
+++ b/web/src/hooks/useOptimizationRuns.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  fetchOptimizationRuns,
+  fetchOptimizationRunDetail,
+  type OptimizationRunSummaryResponse,
+  type OptimizationRunDetailResponse,
+} from '@/lib/api/optimizer';
+
+export function useOptimizationRuns(weekStartDate?: string) {
+  const [runs, setRuns] = useState<OptimizationRunSummaryResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchOptimizationRuns({
+        week_start_date: weekStartDate,
+        limit: 50,
+      });
+      setRuns(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [weekStartDate]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { runs, loading, error, refresh };
+}
+
+export function useOptimizationRunDetail(runId: string | null) {
+  const [detail, setDetail] = useState<OptimizationRunDetailResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!runId) {
+      setDetail(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    fetchOptimizationRunDetail(runId)
+      .then(setDetail)
+      .catch((err) => setError(err instanceof Error ? err : new Error(String(err))))
+      .finally(() => setLoading(false));
+  }, [runId]);
+
+  return { detail, loading, error };
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -106,3 +106,23 @@ export interface StaffUnavailability {
   notes?: string;
   submitted_at: Date;
 }
+
+export type OptimizationStatus = 'Optimal' | 'Feasible' | 'Infeasible' | 'Not Solved';
+
+export interface OptimizationRunSummary {
+  id: string;
+  week_start_date: string;
+  executed_at: string;
+  executed_by: string;
+  dry_run: boolean;
+  status: OptimizationStatus;
+  objective_value: number;
+  solve_time_seconds: number;
+  total_orders: number;
+  assigned_count: number;
+  parameters: { time_limit_seconds: number };
+}
+
+export interface OptimizationRunDetail extends OptimizationRunSummary {
+  assignments: Array<{ order_id: string; staff_ids: string[] }>;
+}


### PR DESCRIPTION
## Summary
- 最適化実行の結果をFirestore `optimization_runs` コレクションに保存
- BE: `GET /optimization-runs`（一覧）/ `GET /optimization-runs/{run_id}`（詳細）エンドポイント追加
- FE: `/history` ページで履歴一覧表示 + Sheet詳細パネルで割当結果確認
- Firestoreセキュリティルール: manager以上のみ読み取り可、FEから書き込み不可
- Firestoreルールテスト7件追加

## 変更ファイル（14ファイル）
### Backend (5ファイル)
- `optimizer/src/optimizer/models/optimization_run.py` - 新規: Pydanticモデル
- `optimizer/src/optimizer/models/__init__.py` - エクスポート追加
- `optimizer/src/optimizer/data/firestore_writer.py` - `save_optimization_run()` 追加
- `optimizer/src/optimizer/api/schemas.py` - レスポンススキーマ追加
- `optimizer/src/optimizer/api/routes.py` - 履歴APIエンドポイント + 実行記録保存

### Frontend (5ファイル)
- `web/src/app/history/page.tsx` - 新規: 履歴一覧ページ
- `web/src/hooks/useOptimizationRuns.ts` - 新規: REST APIフック
- `web/src/lib/api/optimizer.ts` - fetch関数追加
- `web/src/types/index.ts` - クライアント側型追加
- `web/src/components/layout/Header.tsx` - 履歴リンク追加

### Shared + Firebase (4ファイル)
- `shared/types/optimization-run.ts` - 新規: Firestore用型定義
- `shared/types/index.ts` - エクスポート追加
- `firebase/firestore.rules` - optimization_runsルール追加
- `firebase/__tests__/firestore.rules.test.ts` - テスト7件追加

## Test plan
- [x] BE pytest 139/139 pass
- [x] FE Next.js build 成功
- [ ] Firestoreルールテスト（エミュレータ起動時に確認）
- [ ] E2E: 最適化実行 → 履歴一覧に表示 → 詳細パネル確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)