### PR TITLE
test: マスタ管理機能のバリデーション・CRUDテスト追加

### DIFF
--- a/web/src/lib/firestore/__tests__/customers.test.ts
+++ b/web/src/lib/firestore/__tests__/customers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Firestoreモック
+const mockAddDoc = vi.fn();
+const mockUpdateDoc = vi.fn();
+const mockServerTimestamp = vi.fn(() => 'MOCK_TIMESTAMP');
+const mockCollection = vi.fn(() => 'MOCK_COLLECTION_REF');
+const mockDoc = vi.fn(() => 'MOCK_DOC_REF');
+
+vi.mock('firebase/firestore', () => ({
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+  collection: (...args: unknown[]) => mockCollection(...args),
+  doc: (...args: unknown[]) => mockDoc(...args),
+}));
+
+vi.mock('@/lib/firebase', () => ({
+  getDb: () => 'MOCK_DB',
+}));
+
+import { createCustomer, updateCustomer } from '../customers';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function validCustomerInput() {
+  return {
+    name: { family: '田中', given: '一郎' },
+    address: '大阪市北区1-1',
+    location: { lat: 34.7025, lng: 135.4959 },
+    ng_staff_ids: [],
+    preferred_staff_ids: ['H001'],
+    weekly_services: {},
+    service_manager: 'SM001',
+  };
+}
+
+describe('createCustomer', () => {
+  it('正常系: addDocが呼ばれIDが返る', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'new-customer-id' });
+
+    const id = await createCustomer(validCustomerInput() as never);
+    expect(id).toBe('new-customer-id');
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('customersコレクションに対して書き込む', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'c1' });
+
+    await createCustomer(validCustomerInput() as never);
+    expect(mockCollection).toHaveBeenCalledWith('MOCK_DB', 'customers');
+  });
+
+  it('created_atとupdated_atにserverTimestampが設定される', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'c2' });
+
+    await createCustomer(validCustomerInput() as never);
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    expect(writtenData.created_at).toBe('MOCK_TIMESTAMP');
+    expect(writtenData.updated_at).toBe('MOCK_TIMESTAMP');
+  });
+
+  it('入力データがそのまま書き込まれる', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'c3' });
+    const input = validCustomerInput();
+
+    await createCustomer(input as never);
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    expect(writtenData.name).toEqual(input.name);
+    expect(writtenData.address).toBe(input.address);
+    expect(writtenData.preferred_staff_ids).toEqual(['H001']);
+  });
+});
+
+describe('updateCustomer', () => {
+  it('正常系: updateDocが呼ばれる', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateCustomer('existing-id', { address: '新住所' });
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('正しいドキュメント参照で更新する', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateCustomer('cust-123', { address: '変更先' });
+    expect(mockDoc).toHaveBeenCalledWith('MOCK_DB', 'customers', 'cust-123');
+  });
+
+  it('updated_atにserverTimestampが設定される', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateCustomer('cust-456', { address: '変更先' });
+    const writtenData = mockUpdateDoc.mock.calls[0][1];
+    expect(writtenData.updated_at).toBe('MOCK_TIMESTAMP');
+  });
+
+  it('部分更新: 指定フィールドのみ含まれる', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateCustomer('cust-789', { notes: 'テスト備考' });
+    const writtenData = mockUpdateDoc.mock.calls[0][1];
+    expect(writtenData.notes).toBe('テスト備考');
+    expect(writtenData.address).toBeUndefined();
+  });
+});

--- a/web/src/lib/firestore/__tests__/helpers.test.ts
+++ b/web/src/lib/firestore/__tests__/helpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Firestoreモック
+const mockAddDoc = vi.fn();
+const mockUpdateDoc = vi.fn();
+const mockServerTimestamp = vi.fn(() => 'MOCK_TIMESTAMP');
+const mockCollection = vi.fn(() => 'MOCK_COLLECTION_REF');
+const mockDoc = vi.fn(() => 'MOCK_DOC_REF');
+
+vi.mock('firebase/firestore', () => ({
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+  collection: (...args: unknown[]) => mockCollection(...args),
+  doc: (...args: unknown[]) => mockDoc(...args),
+}));
+
+vi.mock('@/lib/firebase', () => ({
+  getDb: () => 'MOCK_DB',
+}));
+
+import { createHelper, updateHelper } from '../helpers';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function validHelperInput() {
+  return {
+    name: { family: '鈴木', given: '次郎' },
+    qualifications: ['介護福祉士'],
+    can_physical_care: true,
+    transportation: 'car',
+    weekly_availability: {
+      monday: [{ start_time: '09:00', end_time: '17:00' }],
+    },
+    preferred_hours: { min: 20, max: 40 },
+    available_hours: { min: 8, max: 48 },
+    employment_type: 'full_time',
+  };
+}
+
+describe('createHelper', () => {
+  it('正常系: addDocが呼ばれIDが返る', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'new-helper-id' });
+
+    const id = await createHelper(validHelperInput() as never);
+    expect(id).toBe('new-helper-id');
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('helpersコレクションに対して書き込む', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'h1' });
+
+    await createHelper(validHelperInput() as never);
+    expect(mockCollection).toHaveBeenCalledWith('MOCK_DB', 'helpers');
+  });
+
+  it('customer_training_statusが空オブジェクトで初期化される', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'h2' });
+
+    await createHelper(validHelperInput() as never);
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    expect(writtenData.customer_training_status).toEqual({});
+  });
+
+  it('created_atとupdated_atにserverTimestampが設定される', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'h3' });
+
+    await createHelper(validHelperInput() as never);
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    expect(writtenData.created_at).toBe('MOCK_TIMESTAMP');
+    expect(writtenData.updated_at).toBe('MOCK_TIMESTAMP');
+  });
+});
+
+describe('updateHelper', () => {
+  it('正常系: updateDocが呼ばれる', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateHelper('helper-id', { can_physical_care: false });
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('正しいドキュメント参照で更新する', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateHelper('hlp-123', { transportation: 'bicycle' });
+    expect(mockDoc).toHaveBeenCalledWith('MOCK_DB', 'helpers', 'hlp-123');
+  });
+
+  it('updated_atにserverTimestampが設定される', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateHelper('hlp-456', { can_physical_care: false });
+    const writtenData = mockUpdateDoc.mock.calls[0][1];
+    expect(writtenData.updated_at).toBe('MOCK_TIMESTAMP');
+  });
+
+  it('部分更新: 指定フィールドのみ含まれる', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateHelper('hlp-789', { qualifications: ['実務者研修'] });
+    const writtenData = mockUpdateDoc.mock.calls[0][1];
+    expect(writtenData.qualifications).toEqual(['実務者研修']);
+    expect(writtenData.can_physical_care).toBeUndefined();
+  });
+});

--- a/web/src/lib/validation/__tests__/schemas.test.ts
+++ b/web/src/lib/validation/__tests__/schemas.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from 'vitest';
+import { customerSchema, helperSchema, unavailabilitySchema } from '../schemas';
+
+// ---- テストヘルパー ----
+
+function validCustomer() {
+  return {
+    name: { family: '山田', given: '太郎' },
+    address: '東京都新宿区1-1-1',
+    location: { lat: 35.6895, lng: 139.6917 },
+    ng_staff_ids: [],
+    preferred_staff_ids: [],
+    weekly_services: {},
+    service_manager: 'SM001',
+  };
+}
+
+function validHelper() {
+  return {
+    name: { family: '佐藤', given: '花子' },
+    qualifications: ['初任者研修'],
+    can_physical_care: true,
+    transportation: 'car' as const,
+    weekly_availability: {},
+    preferred_hours: { min: 20, max: 40 },
+    available_hours: { min: 8, max: 48 },
+    employment_type: 'full_time' as const,
+  };
+}
+
+function validUnavailability() {
+  return {
+    staff_id: 'H001',
+    week_start_date: '2026-02-09',
+    unavailable_slots: [{ date: '2026-02-10', all_day: true }],
+  };
+}
+
+// ================================================================
+// customerSchema
+// ================================================================
+describe('customerSchema', () => {
+  it('正常値でパースできる', () => {
+    const result = customerSchema.safeParse(validCustomer());
+    expect(result.success).toBe(true);
+  });
+
+  it('オプションフィールド付きでパースできる', () => {
+    const result = customerSchema.safeParse({
+      ...validCustomer(),
+      household_id: 'HH001',
+      notes: '備考テスト',
+      name: { family: '山田', given: '太郎', short: 'ヤマダ' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('姓が空文字の場合エラー', () => {
+    const data = { ...validCustomer(), name: { family: '', given: '太郎' } };
+    const result = customerSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('名が空文字の場合エラー', () => {
+    const data = { ...validCustomer(), name: { family: '山田', given: '' } };
+    const result = customerSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('住所が空文字の場合エラー', () => {
+    const data = { ...validCustomer(), address: '' };
+    const result = customerSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('サービス提供責任者が空文字の場合エラー', () => {
+    const data = { ...validCustomer(), service_manager: '' };
+    const result = customerSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('緯度の境界値: -90はOK', () => {
+    const data = { ...validCustomer(), location: { lat: -90, lng: 0 } };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('緯度の境界値: 90はOK', () => {
+    const data = { ...validCustomer(), location: { lat: 90, lng: 0 } };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('緯度の境界値: -91はエラー', () => {
+    const data = { ...validCustomer(), location: { lat: -91, lng: 0 } };
+    expect(customerSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('緯度の境界値: 91はエラー', () => {
+    const data = { ...validCustomer(), location: { lat: 91, lng: 0 } };
+    expect(customerSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('経度の境界値: -180はOK', () => {
+    const data = { ...validCustomer(), location: { lat: 0, lng: -180 } };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('経度の境界値: 181はエラー', () => {
+    const data = { ...validCustomer(), location: { lat: 0, lng: 181 } };
+    expect(customerSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('NG/推奨スタッフ配列を持てる', () => {
+    const data = {
+      ...validCustomer(),
+      ng_staff_ids: ['H001', 'H002'],
+      preferred_staff_ids: ['H003'],
+    };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('weekly_servicesにサービススロットを含められる', () => {
+    const data = {
+      ...validCustomer(),
+      weekly_services: {
+        monday: [
+          {
+            start_time: '09:00',
+            end_time: '10:00',
+            service_type: 'physical_care',
+            staff_count: 1,
+          },
+        ],
+      },
+    };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('serviceSlotのstaff_countが0の場合エラー', () => {
+    const data = {
+      ...validCustomer(),
+      weekly_services: {
+        monday: [
+          {
+            start_time: '09:00',
+            end_time: '10:00',
+            service_type: 'physical_care',
+            staff_count: 0,
+          },
+        ],
+      },
+    };
+    expect(customerSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('serviceSlotのstaff_countが4の場合エラー（上限3）', () => {
+    const data = {
+      ...validCustomer(),
+      weekly_services: {
+        monday: [
+          {
+            start_time: '09:00',
+            end_time: '10:00',
+            service_type: 'daily_living',
+            staff_count: 4,
+          },
+        ],
+      },
+    };
+    expect(customerSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('serviceSlotの不正なservice_typeはエラー', () => {
+    const data = {
+      ...validCustomer(),
+      weekly_services: {
+        monday: [
+          {
+            start_time: '09:00',
+            end_time: '10:00',
+            service_type: 'invalid_type',
+            staff_count: 1,
+          },
+        ],
+      },
+    };
+    expect(customerSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('時刻が不正な形式（H:MM）の場合エラー', () => {
+    const data = {
+      ...validCustomer(),
+      weekly_services: {
+        monday: [
+          {
+            start_time: '9:00',
+            end_time: '10:00',
+            service_type: 'physical_care',
+            staff_count: 1,
+          },
+        ],
+      },
+    };
+    expect(customerSchema.safeParse(data).success).toBe(false);
+  });
+});
+
+// ================================================================
+// helperSchema
+// ================================================================
+describe('helperSchema', () => {
+  it('正常値でパースできる', () => {
+    expect(helperSchema.safeParse(validHelper()).success).toBe(true);
+  });
+
+  it('姓が空文字の場合エラー', () => {
+    const data = { ...validHelper(), name: { family: '', given: '花子' } };
+    expect(helperSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('不正なtransportation値はエラー', () => {
+    const data = { ...validHelper(), transportation: 'train' };
+    expect(helperSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('不正なemployment_type値はエラー', () => {
+    const data = { ...validHelper(), employment_type: 'contract' };
+    expect(helperSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('preferred_hours.minが負の場合エラー', () => {
+    const data = { ...validHelper(), preferred_hours: { min: -1, max: 40 } };
+    expect(helperSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('available_hours.minが0はOK（境界値）', () => {
+    const data = { ...validHelper(), available_hours: { min: 0, max: 0 } };
+    expect(helperSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('資格配列が空でもOK', () => {
+    const data = { ...validHelper(), qualifications: [] };
+    expect(helperSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('weekly_availabilityに勤務スロットを含められる', () => {
+    const data = {
+      ...validHelper(),
+      weekly_availability: {
+        monday: [{ start_time: '09:00', end_time: '17:00' }],
+        wednesday: [{ start_time: '10:00', end_time: '15:00' }],
+      },
+    };
+    expect(helperSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('weekly_availabilityの不正な時刻形式はエラー', () => {
+    const data = {
+      ...validHelper(),
+      weekly_availability: {
+        monday: [{ start_time: '9:00', end_time: '17:00' }],
+      },
+    };
+    expect(helperSchema.safeParse(data).success).toBe(false);
+  });
+});
+
+// ================================================================
+// unavailabilitySchema
+// ================================================================
+describe('unavailabilitySchema', () => {
+  it('正常値（終日）でパースできる', () => {
+    expect(unavailabilitySchema.safeParse(validUnavailability()).success).toBe(true);
+  });
+
+  it('時間指定スロットでパースできる', () => {
+    const data = {
+      ...validUnavailability(),
+      unavailable_slots: [
+        { date: '2026-02-10', all_day: false, start_time: '09:00', end_time: '12:00' },
+      ],
+      notes: '午前のみ不在',
+    };
+    expect(unavailabilitySchema.safeParse(data).success).toBe(true);
+  });
+
+  it('staff_idが空文字の場合エラー', () => {
+    const data = { ...validUnavailability(), staff_id: '' };
+    expect(unavailabilitySchema.safeParse(data).success).toBe(false);
+  });
+
+  it('week_start_dateが空文字の場合エラー', () => {
+    const data = { ...validUnavailability(), week_start_date: '' };
+    expect(unavailabilitySchema.safeParse(data).success).toBe(false);
+  });
+
+  it('unavailable_slotsが空配列の場合エラー', () => {
+    const data = { ...validUnavailability(), unavailable_slots: [] };
+    expect(unavailabilitySchema.safeParse(data).success).toBe(false);
+  });
+
+  it('スロットのdateが空文字の場合エラー', () => {
+    const data = {
+      ...validUnavailability(),
+      unavailable_slots: [{ date: '', all_day: true }],
+    };
+    expect(unavailabilitySchema.safeParse(data).success).toBe(false);
+  });
+
+  it('複数スロットでパースできる', () => {
+    const data = {
+      ...validUnavailability(),
+      unavailable_slots: [
+        { date: '2026-02-10', all_day: true },
+        { date: '2026-02-11', all_day: false, start_time: '14:00', end_time: '18:00' },
+      ],
+    };
+    expect(unavailabilitySchema.safeParse(data).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- マスタ管理機能（利用者・ヘルパー・希望休）のテストが未実装だったため、バリデーションとCRUD層のユニットテストを追加
- 既存48テスト → 98テストへ（+50件）

## 新規テストファイル（3ファイル）

### `web/src/lib/validation/__tests__/schemas.test.ts` — 34件
| カテゴリ | テスト内容 |
|---------|---------|
| customerSchema | 正常値、必須フィールド欠落（姓/名/住所/サ責）、座標境界値（±90/±180）、NG/推奨スタッフ配列、serviceSlot（staff_count 0/4、不正service_type、不正時刻形式） |
| helperSchema | 正常値、不正transportation/employment_type、preferred_hours負値、available_hours境界(0)、空資格配列、weekly_availability時刻検証 |
| unavailabilitySchema | 正常値（終日/時間指定）、staff_id空、week_start_date空、空スロット配列、スロットdate空、複数スロット |

### `web/src/lib/firestore/__tests__/customers.test.ts` — 8件
- createCustomer: addDoc呼び出し、コレクション名、serverTimestamp設定、入力データ保持
- updateCustomer: updateDoc呼び出し、ドキュメント参照、serverTimestamp設定、部分更新

### `web/src/lib/firestore/__tests__/helpers.test.ts` — 8件
- createHelper: addDoc呼び出し、コレクション名、customer_training_status初期化、timestamp
- updateHelper: updateDoc呼び出し、ドキュメント参照、timestamp、部分更新

## Test plan
- [x] 全テスト98件パス（vitest run）
- [x] ビルド成功（npm run build）

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)