### PR TITLE
feat: オーダー割当スタッフ変更UI + 最適化差分表示

### DIFF
--- a/web/src/components/schedule/AssignmentDiffBadge.tsx
+++ b/web/src/components/schedule/AssignmentDiffBadge.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import type { Helper } from '@/types';
+import type { AssignmentDiff } from '@/hooks/useAssignmentDiff';
+
+interface AssignmentDiffBadgeProps {
+  diff: AssignmentDiff;
+  helpers: Map<string, Helper>;
+}
+
+function staffName(id: string, helpers: Map<string, Helper>): string {
+  const h = helpers.get(id);
+  return h ? `${h.name.family} ${h.name.given}` : id;
+}
+
+export function AssignmentDiffBadge({ diff, helpers }: AssignmentDiffBadgeProps) {
+  if (!diff.isChanged) return null;
+
+  const lines: string[] = [];
+  if (diff.added.length > 0) {
+    lines.push(`追加: ${diff.added.map((id) => staffName(id, helpers)).join(', ')}`);
+  }
+  if (diff.removed.length > 0) {
+    lines.push(`削除: ${diff.removed.map((id) => staffName(id, helpers)).join(', ')}`);
+  }
+
+  return (
+    <Badge
+      variant="outline"
+      className="bg-amber-500/10 text-amber-600 border-amber-500/30 text-[10px]"
+      title={lines.join(' / ')}
+    >
+      手動変更
+    </Badge>
+  );
+}

--- a/web/src/hooks/useAssignmentDiff.ts
+++ b/web/src/hooks/useAssignmentDiff.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { format } from 'date-fns';
+import {
+  fetchOptimizationRuns,
+  fetchOptimizationRunDetail,
+} from '@/lib/api/optimizer';
+import type { Order } from '@/types';
+
+export interface AssignmentDiff {
+  added: string[];
+  removed: string[];
+  isChanged: boolean;
+}
+
+export function useAssignmentDiff(
+  weekStart: Date,
+  orders: Order[]
+) {
+  const [diffMap, setDiffMap] = useState<Map<string, AssignmentDiff>>(new Map());
+  const [loading, setLoading] = useState(false);
+
+  const computeDiff = useCallback(async () => {
+    const weekStartDate = format(weekStart, 'yyyy-MM-dd');
+    setLoading(true);
+    try {
+      const runs = await fetchOptimizationRuns({
+        week_start_date: weekStartDate,
+        limit: 1,
+      });
+      if (runs.length === 0) {
+        setDiffMap(new Map());
+        return;
+      }
+
+      const detail = await fetchOptimizationRunDetail(runs[0].id);
+      const optimizedMap = new Map<string, string[]>();
+      for (const a of detail.assignments) {
+        optimizedMap.set(a.order_id, a.staff_ids);
+      }
+
+      const newDiffMap = new Map<string, AssignmentDiff>();
+      for (const order of orders) {
+        const optimized = optimizedMap.get(order.id);
+        if (!optimized) continue;
+
+        const currentSet = new Set(order.assigned_staff_ids);
+        const optimizedSet = new Set(optimized);
+
+        const added = order.assigned_staff_ids.filter((id) => !optimizedSet.has(id));
+        const removed = optimized.filter((id) => !currentSet.has(id));
+
+        if (added.length > 0 || removed.length > 0) {
+          newDiffMap.set(order.id, { added, removed, isChanged: true });
+        }
+      }
+
+      setDiffMap(newDiffMap);
+    } catch (e) {
+      console.error('Failed to compute assignment diff:', e);
+      setDiffMap(new Map());
+    } finally {
+      setLoading(false);
+    }
+  }, [weekStart, orders]);
+
+  useEffect(() => {
+    computeDiff();
+  }, [computeDiff]);
+
+  return { diffMap, loading };
+}

--- a/web/src/hooks/useOrderEdit.ts
+++ b/web/src/hooks/useOrderEdit.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+import { updateOrderAssignment } from '@/lib/firestore/updateOrder';
+
+export function useOrderEdit() {
+  const [saving, setSaving] = useState(false);
+
+  const handleStaffChange = useCallback(
+    async (orderId: string, staffIds: string[]) => {
+      setSaving(true);
+      try {
+        await updateOrderAssignment(orderId, staffIds);
+        toast.success('割当スタッフを更新しました');
+      } catch (e) {
+        console.error('Failed to update assignment:', e);
+        toast.error('割当スタッフの更新に失敗しました');
+      } finally {
+        setSaving(false);
+      }
+    },
+    []
+  );
+
+  return { saving, handleStaffChange };
+}


### PR DESCRIPTION
## Summary
- OrderDetailPanelに`StaffMultiSelect`を統合し、オーダーの割当スタッフを直接編集可能にした
- 最適化実行時の割当と現在の割当を比較し、手動変更がある場合に「手動変更」バッジで差分を表示
- 新規フック: `useOrderEdit`（保存ロジック）、`useAssignmentDiff`（差分検出）

## 変更ファイル
### 新規（3ファイル）
- `web/src/hooks/useOrderEdit.ts` — 割当変更ロジック（saving状態 + toast通知）
- `web/src/hooks/useAssignmentDiff.ts` — 最適化結果との差分検出
- `web/src/components/schedule/AssignmentDiffBadge.tsx` — 差分バッジUI

### 変更（2ファイル）
- `web/src/components/schedule/OrderDetailPanel.tsx` — StaffMultiSelect統合 + diff表示
- `web/src/app/page.tsx` — 新フック接続 + props受け渡し

## Test plan
- [x] `vitest run` — 全98テストパス
- [x] `npm run build` — ビルド成功
- [ ] ブラウザ確認: OrderDetailPanelでスタッフ変更 → Firestoreに反映
- [ ] ブラウザ確認: 最適化実行後に手動変更 → 差分バッジ表示

🤖 Generated with [Claude Code](https://claude.ai/code)