### PR TITLE
fix: Firestoreインデックス追加 + APIエラーハンドリング改善

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -23,6 +23,14 @@
         { "fieldPath": "staff_id", "order": "ASCENDING" },
         { "fieldPath": "week_start_date", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "optimization_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "week_start_date", "order": "ASCENDING" },
+        { "fieldPath": "executed_at", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -175,7 +175,12 @@ def list_optimization_runs(
         query = query.where("week_start_date", "==", week_start_date)
 
     query = query.limit(limit)
-    docs = query.stream()
+
+    try:
+        docs = list(query.stream())
+    except Exception as e:
+        logger.warning("Failed to query optimization_runs: %s", e)
+        return OptimizationRunListResponse(runs=[])
 
     runs = []
     for doc in docs:


### PR DESCRIPTION
## Summary
- optimization_runsコレクションの複合インデックス（week_start_date + executed_at）をfirestore.indexes.jsonに追加
- list_optimization_runs APIでFirestoreクエリ失敗時に500エラーではなく空リストを返すようエラーハンドリングを改善
- 本番環境でCloud Run再デプロイ + インデックス作成済み

## Background
本番環境で以下の問題が発生していた:
1. Cloud Runインスタンスが停止し504タイムアウト → 再デプロイで復旧
2. `/optimization-runs` APIが500エラー → Firestoreインデックス欠落が原因
3. CORSエラー → 上記2つの修正で自動解消

## Test plan
- [x] 本番テスト実行（dry_run）成功確認
- [x] 本番最適化実行（月曜30件/100%割当）成功確認
- [x] コンソールエラー0件確認
- [ ] CIテスト通過確認

🤖 Generated with [Claude Code](https://claude.ai/code)