### PR TITLE
feat: 利用者編集ダイアログにミニマップ + 住所ジオコーディング追加

### DIFF
--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -14,3 +14,7 @@ NEXT_PUBLIC_AUTH_MODE=demo
 
 # 最適化API URL
 NEXT_PUBLIC_OPTIMIZER_API_URL=http://localhost:8081
+
+# Google Maps（ミニマップ・ジオコーディング用）
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-google-maps-api-key
+NEXT_PUBLIC_GOOGLE_MAP_ID=your-google-map-id

--- a/web/.env.production
+++ b/web/.env.production
@@ -16,3 +16,7 @@ NEXT_PUBLIC_AUTH_MODE=demo
 
 # 最適化API URL
 NEXT_PUBLIC_OPTIMIZER_API_URL=https://shift-optimizer-1045989697649.asia-northeast1.run.app
+
+# Google Maps（ミニマップ・ジオコーディング用）
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-google-maps-api-key
+NEXT_PUBLIC_GOOGLE_MAP_ID=your-google-map-id

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
+        "@vis.gl/react-google-maps": "^1.7.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -5891,6 +5892,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6485,6 +6492,20 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.7.1.tgz",
+      "integrity": "sha512-F/GJzJyri7Jqf+bkLNxoi2RcH2hCIo1I3//PyiILqQzdzglMoqZVO1DLXlHPifNdebk1/zib6dMJA3i73nwmuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.3",
@@ -8834,7 +8855,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
+    "@vis.gl/react-google-maps": "^1.7.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/web/src/components/masters/CustomerLocationPicker.tsx
+++ b/web/src/components/masters/CustomerLocationPicker.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+import {
+  Map,
+  AdvancedMarker,
+  useMap,
+} from '@vis.gl/react-google-maps';
+
+/** 鹿児島市中心部（デフォルト位置） */
+const DEFAULT_CENTER = { lat: 31.5916, lng: 130.5571 };
+const DEFAULT_ZOOM = 15;
+
+interface CustomerLocationPickerProps {
+  lat: number;
+  lng: number;
+  onLocationChange: (lat: number, lng: number) => void;
+}
+
+function isValidLocation(lat: number, lng: number): boolean {
+  return lat !== 0 && lng !== 0 && !isNaN(lat) && !isNaN(lng);
+}
+
+export function CustomerLocationPicker({
+  lat,
+  lng,
+  onLocationChange,
+}: CustomerLocationPickerProps) {
+  const map = useMap();
+  const hasValidLocation = isValidLocation(lat, lng);
+
+  const center = useMemo(
+    () => (hasValidLocation ? { lat, lng } : DEFAULT_CENTER),
+    [hasValidLocation, lat, lng]
+  );
+
+  // 座標が外部から変わったらマップの中心を追従
+  useEffect(() => {
+    if (map && hasValidLocation) {
+      map.panTo({ lat, lng });
+    }
+  }, [map, lat, lng, hasValidLocation]);
+
+  const handleDragEnd = useCallback(
+    (e: google.maps.MapMouseEvent) => {
+      if (e.latLng) {
+        onLocationChange(
+          Math.round(e.latLng.lat() * 1e6) / 1e6,
+          Math.round(e.latLng.lng() * 1e6) / 1e6
+        );
+      }
+    },
+    [onLocationChange]
+  );
+
+  return (
+    <div className="h-[200px] w-full overflow-hidden rounded-md border">
+      <Map
+        defaultCenter={center}
+        defaultZoom={DEFAULT_ZOOM}
+        mapId={process.env.NEXT_PUBLIC_GOOGLE_MAP_ID}
+        gestureHandling="cooperative"
+        disableDefaultUI
+        zoomControl
+      >
+        <AdvancedMarker
+          position={center}
+          draggable
+          onDragEnd={handleDragEnd}
+        />
+      </Map>
+    </div>
+  );
+}

--- a/web/src/lib/geocoding.ts
+++ b/web/src/lib/geocoding.ts
@@ -1,0 +1,43 @@
+/**
+ * Google Maps JavaScript API Geocoding Service を使用した住所→座標変換
+ * Static Export制約のため、クライアントサイドで実行
+ */
+
+export interface GeocodingResult {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * 住所文字列から緯度経度を取得する
+ * @returns 座標、または見つからない場合は null
+ */
+export async function geocodeAddress(
+  address: string
+): Promise<GeocodingResult | null> {
+  if (!address.trim()) return null;
+
+  if (typeof google === 'undefined' || !google.maps) {
+    console.error('Google Maps JavaScript API is not loaded');
+    return null;
+  }
+
+  const geocoder = new google.maps.Geocoder();
+
+  try {
+    const response = await geocoder.geocode({
+      address,
+      region: 'jp',
+    });
+
+    if (response.results.length === 0) return null;
+
+    const location = response.results[0].geometry.location;
+    return {
+      lat: location.lat(),
+      lng: location.lng(),
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- 利用者編集ダイアログに Google Maps ミニマップを統合し、住所からのジオコーディング（座標自動取得）機能を追加
- AdvancedMarker のドラッグで座標の微調整が可能に
- API Key 未設定時はミニマップ非表示で既存フォームのみ動作（グレースフルデグラデーション）

## 変更内容
| ファイル | 内容 |
|---------|------|
| `web/src/lib/geocoding.ts` | 新規: Google Maps Geocoder による住所→座標変換 |
| `web/src/components/masters/CustomerLocationPicker.tsx` | 新規: ミニマップ + ドラッグ可能マーカー |
| `web/src/components/masters/CustomerEditDialog.tsx` | 「住所から検索」ボタン、ミニマップ統合、座標双方向連携 |
| `web/package.json` | `@vis.gl/react-google-maps` 追加 |
| `web/.env.*` | Google Maps API Key / Map ID 環境変数追加 |

## マージ後の必要作業（GCPコンソール）
1. Maps JavaScript API + Geocoding API を有効化
2. フロントエンド用 API Key 作成（リファラ制限: `visitcare-shift-optimizer.web.app/*`, `localhost:3000/*`）
3. Map ID 作成（Map Management → Create Map ID）
4. `.env.local` / `.env.production` に値を設定

## Test plan
- [x] `npm run build` — ビルド成功
- [x] `npm run test:run` — 102テスト全パス
- [ ] ローカル起動 → 利用者編集ダイアログで住所入力 → 「住所から検索」→ 座標自動入力を確認
- [ ] ミニマップにピン表示、ドラッグで座標更新を確認
- [ ] 手動で緯度経度変更 → ピン位置追従を確認
- [ ] API Key 未設定時にミニマップが非表示で既存機能が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)