### PR TITLE
chore: Google Maps API Key / Map ID 本番環境設定

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -18,5 +18,5 @@ NEXT_PUBLIC_AUTH_MODE=demo
 NEXT_PUBLIC_OPTIMIZER_API_URL=https://shift-optimizer-1045989697649.asia-northeast1.run.app
 
 # Google Maps（ミニマップ・ジオコーディング用）
-NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-google-maps-api-key
-NEXT_PUBLIC_GOOGLE_MAP_ID=your-google-map-id
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=AIzaSyCiF-bVYIrJIpAgqa76r7HG8TC4HcTUkJw
+NEXT_PUBLIC_GOOGLE_MAP_ID=aae3c87a8f1176c278f0a229


### PR DESCRIPTION
## Summary
- `.env.production` に Google Maps API Key と Map ID の実際の値を設定
- PR #44 で追加したミニマップ機能を本番環境で有効化

## 変更内容
- `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`: フロントエンド用キー（リファラ制限 + API制限付き）
- `NEXT_PUBLIC_GOOGLE_MAP_ID`: ベクターマップ用 Map ID

## セキュリティ
- API Keyはブラウザ用（`NEXT_PUBLIC_`）でリファラ制限済み
  - `visitcare-shift-optimizer.web.app/*`
  - `localhost:3000/*`
- API制限: Maps JavaScript API, Geocoding API のみ

## Test plan
- [x] ローカルで動作確認済み（スクリーンショット確認）

🤖 Generated with [Claude Code](https://claude.ai/code)