### PR TITLE
feat: 休みの日のヘルパー行グレーアウト表示を改善

### DIFF
--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -53,6 +53,9 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
     dayDate,
   );
 
+  // 休みの日かどうか判定（非勤務日 or 終日希望休）
+  const isDayOff = unavailableBlocks.some((b) => b.type === 'day_off' || (b.type === 'unavailable' && b.label === '希望休' && b.left === 0));
+
   const { setNodeRef, isOver } = useDroppable({
     id: row.helper.id,
   });
@@ -62,15 +65,25 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
   return (
     <div className={cn(
       'flex border-b border-border/50 transition-colors duration-100',
-      isEven ? 'bg-card' : 'bg-muted/20',
-      'hover:bg-primary/[0.03]'
+      isDayOff
+        ? 'bg-muted/50'
+        : isEven ? 'bg-card' : 'bg-muted/20',
+      !isDayOff && 'hover:bg-primary/[0.03]'
     )}>
       <div
-        className="shrink-0 border-r border-border/50 px-2 py-1 text-xs font-medium truncate flex items-center"
+        className={cn(
+          'shrink-0 border-r border-border/50 px-2 py-1 text-xs font-medium truncate flex items-center gap-1',
+          isDayOff && 'text-muted-foreground/60',
+        )}
         style={{ width: HELPER_NAME_WIDTH_PX, height: 36 }}
         title={helperName}
       >
-        {helperName}
+        <span className="truncate">{helperName}</span>
+        {isDayOff && (
+          <span className="shrink-0 text-[10px] px-1 py-0.5 rounded bg-muted-foreground/15 text-muted-foreground/70 leading-none">
+            休
+          </span>
+        )}
       </div>
       <div
         ref={setNodeRef}

--- a/web/src/components/gantt/UnavailableBlocksOverlay.tsx
+++ b/web/src/components/gantt/UnavailableBlocksOverlay.tsx
@@ -1,11 +1,29 @@
 'use client';
 
 import { memo } from 'react';
-import type { UnavailableBlock } from './constants';
+import type { UnavailableBlock, UnavailableBlockType } from './constants';
 
 interface UnavailableBlocksOverlayProps {
   blocks: UnavailableBlock[];
 }
+
+const BLOCK_STYLES: Record<UnavailableBlockType, { background: string; backgroundColor: string }> = {
+  off_hours: {
+    background:
+      'repeating-linear-gradient(135deg, transparent, transparent 3px, rgba(0,0,0,0.08) 3px, rgba(0,0,0,0.08) 4px)',
+    backgroundColor: 'rgba(0,0,0,0.05)',
+  },
+  day_off: {
+    background:
+      'repeating-linear-gradient(135deg, transparent, transparent 4px, rgba(0,0,0,0.10) 4px, rgba(0,0,0,0.10) 5px)',
+    backgroundColor: 'rgba(0,0,0,0.08)',
+  },
+  unavailable: {
+    background:
+      'repeating-linear-gradient(135deg, transparent, transparent 4px, rgba(220,80,80,0.15) 4px, rgba(220,80,80,0.15) 5px)',
+    backgroundColor: 'rgba(220,80,80,0.08)',
+  },
+};
 
 export const UnavailableBlocksOverlay = memo(function UnavailableBlocksOverlay({
   blocks,
@@ -14,20 +32,22 @@ export const UnavailableBlocksOverlay = memo(function UnavailableBlocksOverlay({
 
   return (
     <>
-      {blocks.map((block, i) => (
-        <div
-          key={`${block.left}-${block.width}-${i}`}
-          className="absolute top-0 h-full pointer-events-none z-[1]"
-          style={{
-            left: block.left,
-            width: block.width,
-            background:
-              'repeating-linear-gradient(135deg, transparent, transparent 3px, rgba(0,0,0,0.06) 3px, rgba(0,0,0,0.06) 4px)',
-            backgroundColor: 'rgba(0,0,0,0.04)',
-          }}
-          title={block.label}
-        />
-      ))}
+      {blocks.map((block, i) => {
+        const style = BLOCK_STYLES[block.type];
+        return (
+          <div
+            key={`${block.left}-${block.width}-${i}`}
+            className="absolute top-0 h-full pointer-events-none z-[1]"
+            style={{
+              left: block.left,
+              width: block.width,
+              background: style.background,
+              backgroundColor: style.backgroundColor,
+            }}
+            title={block.label}
+          />
+        );
+      })}
     </>
   );
 });

--- a/web/src/components/gantt/__tests__/constants.test.ts
+++ b/web/src/components/gantt/__tests__/constants.test.ts
@@ -90,12 +90,14 @@ describe('calculateUnavailableBlocks', () => {
         left: timeToPx('07:00'),
         width: timeToPx('09:00') - timeToPx('07:00'),
         label: '勤務時間外',
+        type: 'off_hours',
       });
       // 17:00-21:00ブロック
       expect(blocks[1]).toEqual({
         left: timeToPx('17:00'),
         width: timeToPx('21:00') - timeToPx('17:00'),
         label: '勤務時間外',
+        type: 'off_hours',
       });
     });
 
@@ -110,6 +112,7 @@ describe('calculateUnavailableBlocks', () => {
         left: timeToPx('17:00'),
         width: timeToPx('21:00') - timeToPx('17:00'),
         label: '勤務時間外',
+        type: 'off_hours',
       });
     });
 
@@ -124,6 +127,7 @@ describe('calculateUnavailableBlocks', () => {
         left: timeToPx('07:00'),
         width: timeToPx('09:00') - timeToPx('07:00'),
         label: '勤務時間外',
+        type: 'off_hours',
       });
     });
 
@@ -139,6 +143,7 @@ describe('calculateUnavailableBlocks', () => {
       expect(blocks).toHaveLength(3);
       // 7:00-9:00
       expect(blocks[0].label).toBe('勤務時間外');
+      expect(blocks[0].type).toBe('off_hours');
       expect(blocks[0].left).toBe(timeToPx('07:00'));
       expect(blocks[0].width).toBe(timeToPx('09:00') - timeToPx('07:00'));
       // 12:00-14:00
@@ -158,18 +163,30 @@ describe('calculateUnavailableBlocks', () => {
     });
   });
 
-  describe('勤務時間未設定', () => {
-    it('該当曜日に勤務スロットなし → ブロックなし（表示なし）', () => {
+  describe('勤務時間未設定（非勤務日）', () => {
+    it('該当曜日に勤務スロットなし → 非勤務日ブロック（全域）', () => {
       const availability: Partial<Record<DayOfWeek, AvailabilitySlot[]>> = {
         tuesday: [{ start_time: '09:00', end_time: '17:00' }],
       };
       const blocks = calculateUnavailableBlocks(availability, [], monday, mondayDate);
-      expect(blocks).toHaveLength(0);
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]).toEqual({
+        left: timeToPx('07:00'),
+        width: timeToPx('21:00') - timeToPx('07:00'),
+        label: '非勤務日',
+        type: 'day_off',
+      });
     });
 
-    it('weekly_availability自体が空 → ブロックなし', () => {
+    it('weekly_availability自体が空 → 非勤務日ブロック（全域）', () => {
       const blocks = calculateUnavailableBlocks({}, [], monday, mondayDate);
-      expect(blocks).toHaveLength(0);
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]).toEqual({
+        left: timeToPx('07:00'),
+        width: timeToPx('21:00') - timeToPx('07:00'),
+        label: '非勤務日',
+        type: 'day_off',
+      });
     });
   });
 
@@ -207,6 +224,7 @@ describe('calculateUnavailableBlocks', () => {
         left: timeToPx('09:00'),
         width: timeToPx('12:00') - timeToPx('09:00'),
         label: '希望休',
+        type: 'unavailable',
       });
     });
 
@@ -245,6 +263,7 @@ describe('calculateUnavailableBlocks', () => {
         left: timeToPx('07:00'),
         width: timeToPx('09:00') - timeToPx('07:00'),
         label: '勤務時間外',
+        type: 'off_hours',
       });
     });
   });


### PR DESCRIPTION
## Summary
- 非勤務日（weekly_availability未設定の曜日）に全域グレーアウト表示を追加
- 希望休（終日）は赤みがかった斜線パターンで視覚的に区別
- 休みの日のヘルパー名横に「休」バッジを表示、行背景もグレーに変更
- 勤務時間外の斜線パターンの色を濃く調整（視認性向上）

## Test plan
- [x] 114/114 Webテスト全パス
- [x] ビルド成功
- [ ] CIテスト全パス確認
- [ ] 本番デプロイ後のスクリーンショット確認

🤖 Generated with [Claude Code](https://claude.ai/code)