### PR TITLE
feat: D&Dゴーストバー（ドロップ先プレビュー）を追加

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -70,6 +70,7 @@ function SchedulePage() {
 
   const {
     dropZoneStatuses,
+    activeOrder,
     handleDragStart,
     handleDragOver,
     handleDragEnd,
@@ -140,6 +141,7 @@ function SchedulePage() {
             onOrderClick={handleOrderClick}
             dropZoneStatuses={dropZoneStatuses}
             unavailability={unavailability}
+            activeOrder={activeOrder}
           />
         </DndContext>
       </main>

--- a/web/src/components/gantt/GanttChart.tsx
+++ b/web/src/components/gantt/GanttChart.tsx
@@ -15,9 +15,10 @@ interface GanttChartProps {
   onOrderClick?: (order: Order) => void;
   dropZoneStatuses?: Map<string, DropZoneStatus>;
   unavailability: StaffUnavailability[];
+  activeOrder?: Order | null;
 }
 
-export function GanttChart({ schedule, customers, violations, onOrderClick, dropZoneStatuses, unavailability }: GanttChartProps) {
+export function GanttChart({ schedule, customers, violations, onOrderClick, dropZoneStatuses, unavailability, activeOrder }: GanttChartProps) {
   if (schedule.totalOrders === 0) {
     return (
       <div className="flex items-center justify-center h-48 text-muted-foreground">
@@ -42,6 +43,7 @@ export function GanttChart({ schedule, customers, violations, onOrderClick, drop
             unavailability={unavailability}
             day={schedule.day}
             dayDate={schedule.date}
+            activeOrder={activeOrder}
           />
         ))}
       </div>

--- a/web/src/hooks/useDragAndDrop.ts
+++ b/web/src/hooks/useDragAndDrop.ts
@@ -21,6 +21,7 @@ interface UseDragAndDropInput {
 export function useDragAndDrop(input: UseDragAndDropInput) {
   const { helperRows, unassignedOrders, helpers, customers, unavailability, day } = input;
   const [dropZoneStatuses, setDropZoneStatuses] = useState<Map<string, DropZoneStatus>>(new Map());
+  const [activeOrder, setActiveOrder] = useState<Order | null>(null);
 
   const findOrder = useCallback(
     (orderId: string): Order | undefined => {
@@ -33,9 +34,13 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
     [helperRows, unassignedOrders]
   );
 
-  const handleDragStart = useCallback((_event: DragStartEvent) => {
-    // ドラッグ開始時の処理（将来DragOverlay追加時に拡張予定）
-  }, []);
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const dragData = event.active.data.current as DragData | undefined;
+    if (dragData) {
+      const order = findOrder(dragData.orderId);
+      setActiveOrder(order ?? null);
+    }
+  }, [findOrder]);
 
   const handleDragOver = useCallback(
     (event: DragOverEvent) => {
@@ -86,6 +91,7 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
       setDropZoneStatuses(new Map());
+      setActiveOrder(null);
 
       const dragData = event.active.data.current as DragData | undefined;
       if (!dragData || !event.over) return;
@@ -144,10 +150,12 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
 
   const handleDragCancel = useCallback(() => {
     setDropZoneStatuses(new Map());
+    setActiveOrder(null);
   }, []);
 
   return {
     dropZoneStatuses,
+    activeOrder,
     handleDragStart,
     handleDragOver,
     handleDragEnd,


### PR DESCRIPTION
## Summary
- ドラッグ中のオーダーをヘルパー行にホバーした際、ドロップ位置に半透明のプレビューバーを表示
- サービスタイプ別に色分け（身体介護: 青系、生活援助: 緑系、予防: 紫系）
- 破線ボーダー + パルスアニメーションで視覚的に区別

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `useDragAndDrop.ts` | `activeOrder` stateでドラッグ中オーダーを追跡 |
| `page.tsx` | `activeOrder` をGanttChartに渡す |
| `GanttChart.tsx` | `activeOrder` propをGanttRowに中継 |
| `GanttRow.tsx` | ゴーストバー描画（サービスタイプ別色、破線、パルス） |

## Test plan
- [ ] オーダーをドラッグして別のヘルパー行にホバー → ゴーストバーが表示される
- [ ] invalid（赤）のドロップゾーンではゴーストバーが表示されない
- [ ] ドロップまたはキャンセルでゴーストバーが消える
- [ ] サービスタイプごとに色が異なることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)