### PR TITLE
feat: 時間目盛り10分単位化 & ゴーストブロック表示

### DIFF
--- a/web/src/components/gantt/GanttTimeHeader.tsx
+++ b/web/src/components/gantt/GanttTimeHeader.tsx
@@ -22,16 +22,29 @@ export function GanttTimeHeader() {
       >
         {hours.map((hour) => {
           const slotsPerHour = 60 / 5;
-          const left = (hour - GANTT_START_HOUR) * slotsPerHour * SLOT_WIDTH_PX;
+          const hourLeft = (hour - GANTT_START_HOUR) * slotsPerHour * SLOT_WIDTH_PX;
           return (
-            <div
-              key={hour}
-              className="absolute top-0 h-full border-l border-border/40"
-              style={{ left }}
-            >
-              <span className="px-1 text-[10px] font-medium text-muted-foreground">
-                {hour}:00
-              </span>
+            <div key={hour}>
+              {/* 正時の線 + ラベル */}
+              <div
+                className="absolute top-0 h-full border-l border-border/40"
+                style={{ left: hourLeft }}
+              >
+                <span className="px-1 text-[10px] font-medium text-muted-foreground">
+                  {hour}:00
+                </span>
+              </div>
+              {/* 10分刻みのサブ目盛り（:10, :20, :30, :40, :50） */}
+              {[10, 20, 30, 40, 50].map((min) => {
+                const subLeft = hourLeft + (min / 5) * SLOT_WIDTH_PX;
+                return (
+                  <div
+                    key={`${hour}:${min}`}
+                    className={`absolute h-full border-l ${min === 30 ? 'border-border/25' : 'border-border/10'}`}
+                    style={{ left: subLeft, top: 0 }}
+                  />
+                );
+              })}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- ガントチャートの時間目盛りを10分刻みに細分化（正時/30分/10分で線の太さを段階分け）
- ゴーストバー（D&Dドロップ先プレビュー）を10分単位の個別ブロック表示に変更

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `GanttTimeHeader.tsx` | 10分刻みのサブ目盛り線を追加 |
| `GanttRow.tsx` | グリッド線を10分単位に変更、ゴーストを10分ブロック分割表示 |

## Test plan
- [ ] 時間ヘッダーに10分ごとの目盛り線が表示される（30分は太め）
- [ ] 各ヘルパー行にも10分ごとのグリッド線が表示される
- [ ] D&Dゴーストが10分単位のブロック群として表示される
- [ ] 既存のオーダーバー表示に影響がないこと

🤖 Generated with [Claude Code](https://claude.ai/code)