### PR TITLE
feat: D&Dドラッグ中の時間帯を全行横断でハイライト表示

### DIFF
--- a/web/src/components/gantt/GanttChart.tsx
+++ b/web/src/components/gantt/GanttChart.tsx
@@ -3,10 +3,15 @@
 import { GanttTimeHeader } from './GanttTimeHeader';
 import { GanttRow } from './GanttRow';
 import { UnassignedSection } from './UnassignedSection';
+import { SLOT_WIDTH_PX, HELPER_NAME_WIDTH_PX, timeToColumn } from './constants';
 import type { DaySchedule } from '@/hooks/useScheduleData';
 import type { Customer, Order, StaffUnavailability } from '@/types';
 import type { ViolationMap } from '@/lib/constraints/checker';
 import type { DropZoneStatus } from '@/lib/dnd/types';
+
+/** 10分 = 2スロット（5分×2） */
+const SLOTS_PER_10MIN = 2;
+const PX_PER_10MIN = SLOTS_PER_10MIN * SLOT_WIDTH_PX;
 
 interface GanttChartProps {
   schedule: DaySchedule;
@@ -31,21 +36,39 @@ export function GanttChart({ schedule, customers, violations, onOrderClick, drop
     <div className="flex flex-col">
       <div className="overflow-x-auto border rounded-lg shadow-sm">
         <GanttTimeHeader />
-        {schedule.helperRows.map((row, index) => (
-          <GanttRow
-            key={row.helper.id}
-            row={row}
-            customers={customers}
-            violations={violations}
-            onOrderClick={onOrderClick}
-            dropZoneStatus={dropZoneStatuses?.get(row.helper.id)}
-            index={index}
-            unavailability={unavailability}
-            day={schedule.day}
-            dayDate={schedule.date}
-            activeOrder={activeOrder}
-          />
-        ))}
+        <div className="relative">
+          {schedule.helperRows.map((row, index) => (
+            <GanttRow
+              key={row.helper.id}
+              row={row}
+              customers={customers}
+              violations={violations}
+              onOrderClick={onOrderClick}
+              dropZoneStatus={dropZoneStatuses?.get(row.helper.id)}
+              index={index}
+              unavailability={unavailability}
+              day={schedule.day}
+              dayDate={schedule.date}
+              activeOrder={activeOrder}
+            />
+          ))}
+          {/* ドラッグ中の時間帯ハイライト（全行横断） */}
+          {activeOrder && (() => {
+            const startCol = timeToColumn(activeOrder.start_time);
+            const endCol = timeToColumn(activeOrder.end_time);
+            // 10分単位にスナップ
+            const startBlock = Math.floor((startCol - 1) / SLOTS_PER_10MIN);
+            const endBlock = Math.ceil((endCol - 1) / SLOTS_PER_10MIN);
+            const left = HELPER_NAME_WIDTH_PX + startBlock * PX_PER_10MIN;
+            const width = Math.max((endBlock - startBlock) * PX_PER_10MIN, PX_PER_10MIN);
+            return (
+              <div
+                className="absolute top-0 h-full pointer-events-none border-l border-r border-primary/30 bg-primary/[0.06] z-[1]"
+                style={{ left, width }}
+              />
+            );
+          })()}
+        </div>
       </div>
       <UnassignedSection
         orders={schedule.unassignedOrders}


### PR DESCRIPTION
## Summary
- ドラッグ中のオーダーの時間帯を、全ヘルパー行を縦方向に横断するハイライトオーバーレイで表示
- 10分単位にスナップし、既存のゴーストブロック（行内）と組み合わせて視認性を向上

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `GanttChart.tsx` | 行ラッパーに`relative`追加、`activeOrder`の時間帯に縦ハイライトオーバーレイ |

## Test plan
- [ ] オーダーをドラッグ開始 → 時間帯が縦方向に全行ハイライトされる
- [ ] ドロップ/キャンセルでハイライトが消える
- [ ] ハイライトが10分単位にスナップされている
- [ ] 既存のオーダーバー・ゴーストブロックと干渉しない（pointer-events: none）

🤖 Generated with [Claude Code](https://claude.ai/code)