### PR TITLE
feat: ガントチャートをレスポンシブ幅に対応

### DIFF
--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -3,7 +3,8 @@
 import { memo } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { timeToColumn, SLOT_WIDTH_PX } from './constants';
+import { timeToColumn } from './constants';
+import { useSlotWidth } from './GanttScaleContext';
 import type { Order, Customer } from '@/types';
 import type { DragData } from '@/lib/dnd/types';
 import { cn } from '@/lib/utils';
@@ -34,10 +35,11 @@ const SERVICE_COLORS: Record<string, { bar: string; hover: string }> = {
 };
 
 export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, violationType, onClick, sourceHelperId }: GanttBarProps) {
+  const slotWidth = useSlotWidth();
   const startCol = timeToColumn(order.start_time);
   const endCol = timeToColumn(order.end_time);
-  const width = (endCol - startCol) * SLOT_WIDTH_PX;
-  const left = (startCol - 1) * SLOT_WIDTH_PX;
+  const width = (endCol - startCol) * slotWidth;
+  const left = (startCol - 1) * slotWidth;
 
   const dragData: DragData = { orderId: order.id, sourceHelperId };
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
@@ -52,7 +54,7 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
 
   const style = {
     left,
-    width: Math.max(width, SLOT_WIDTH_PX * 2),
+    width: Math.max(width, slotWidth * 2),
     transform: CSS.Translate.toString(transform),
   };
 

--- a/web/src/components/gantt/GanttChart.tsx
+++ b/web/src/components/gantt/GanttChart.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useRef, useState, useLayoutEffect } from 'react';
 import { GanttTimeHeader } from './GanttTimeHeader';
 import { GanttRow } from './GanttRow';
 import { UnassignedSection } from './UnassignedSection';
-import { SLOT_WIDTH_PX, HELPER_NAME_WIDTH_PX, timeToColumn } from './constants';
+import { GanttScaleProvider } from './GanttScaleContext';
+import { SLOT_WIDTH_PX, HELPER_NAME_WIDTH_PX, TOTAL_SLOTS, timeToColumn } from './constants';
 import type { DaySchedule } from '@/hooks/useScheduleData';
 import type { Customer, Order, StaffUnavailability } from '@/types';
 import type { ViolationMap } from '@/lib/constraints/checker';
@@ -11,7 +13,6 @@ import type { DropZoneStatus } from '@/lib/dnd/types';
 
 /** 10分 = 2スロット（5分×2） */
 const SLOTS_PER_10MIN = 2;
-const PX_PER_10MIN = SLOTS_PER_10MIN * SLOT_WIDTH_PX;
 
 interface GanttChartProps {
   schedule: DaySchedule;
@@ -24,6 +25,23 @@ interface GanttChartProps {
 }
 
 export function GanttChart({ schedule, customers, violations, onOrderClick, dropZoneStatuses, unavailability, activeOrder }: GanttChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [slotWidth, setSlotWidth] = useState(SLOT_WIDTH_PX);
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => {
+      const w = el.clientWidth;
+      const sw = Math.max(SLOT_WIDTH_PX, (w - HELPER_NAME_WIDTH_PX) / TOTAL_SLOTS);
+      setSlotWidth(sw);
+    };
+    measure();
+    const ro = new ResizeObserver(() => measure());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   if (schedule.totalOrders === 0) {
     return (
       <div className="flex items-center justify-center h-48 text-muted-foreground">
@@ -32,50 +50,54 @@ export function GanttChart({ schedule, customers, violations, onOrderClick, drop
     );
   }
 
+  const pxPer10Min = SLOTS_PER_10MIN * slotWidth;
+
   return (
-    <div className="flex flex-col">
-      <div className="overflow-x-auto border rounded-lg shadow-sm">
-        <GanttTimeHeader />
-        <div className="relative">
-          {schedule.helperRows.map((row, index) => (
-            <GanttRow
-              key={row.helper.id}
-              row={row}
-              customers={customers}
-              violations={violations}
-              onOrderClick={onOrderClick}
-              dropZoneStatus={dropZoneStatuses?.get(row.helper.id)}
-              index={index}
-              unavailability={unavailability}
-              day={schedule.day}
-              dayDate={schedule.date}
-              activeOrder={activeOrder}
-            />
-          ))}
-          {/* ドラッグ中の時間帯ハイライト（全行横断） */}
-          {activeOrder && (() => {
-            const startCol = timeToColumn(activeOrder.start_time);
-            const endCol = timeToColumn(activeOrder.end_time);
-            // 10分単位にスナップ
-            const startBlock = Math.floor((startCol - 1) / SLOTS_PER_10MIN);
-            const endBlock = Math.ceil((endCol - 1) / SLOTS_PER_10MIN);
-            const left = HELPER_NAME_WIDTH_PX + startBlock * PX_PER_10MIN;
-            const width = Math.max((endBlock - startBlock) * PX_PER_10MIN, PX_PER_10MIN);
-            return (
-              <div
-                className="absolute top-0 h-full pointer-events-none border-l border-r border-primary/30 bg-primary/[0.06] z-[1]"
-                style={{ left, width }}
+    <GanttScaleProvider value={slotWidth}>
+      <div className="flex flex-col">
+        <div ref={containerRef} className="overflow-x-auto border rounded-lg shadow-sm">
+          <GanttTimeHeader />
+          <div className="relative">
+            {schedule.helperRows.map((row, index) => (
+              <GanttRow
+                key={row.helper.id}
+                row={row}
+                customers={customers}
+                violations={violations}
+                onOrderClick={onOrderClick}
+                dropZoneStatus={dropZoneStatuses?.get(row.helper.id)}
+                index={index}
+                unavailability={unavailability}
+                day={schedule.day}
+                dayDate={schedule.date}
+                activeOrder={activeOrder}
               />
-            );
-          })()}
+            ))}
+            {/* ドラッグ中の時間帯ハイライト（全行横断） */}
+            {activeOrder && (() => {
+              const startCol = timeToColumn(activeOrder.start_time);
+              const endCol = timeToColumn(activeOrder.end_time);
+              // 10分単位にスナップ
+              const startBlock = Math.floor((startCol - 1) / SLOTS_PER_10MIN);
+              const endBlock = Math.ceil((endCol - 1) / SLOTS_PER_10MIN);
+              const left = HELPER_NAME_WIDTH_PX + startBlock * pxPer10Min;
+              const width = Math.max((endBlock - startBlock) * pxPer10Min, pxPer10Min);
+              return (
+                <div
+                  className="absolute top-0 h-full pointer-events-none border-l border-r border-primary/30 bg-primary/[0.06] z-[1]"
+                  style={{ left, width }}
+                />
+              );
+            })()}
+          </div>
         </div>
+        <UnassignedSection
+          orders={schedule.unassignedOrders}
+          customers={customers}
+          onOrderClick={onOrderClick}
+          dropZoneStatus={dropZoneStatuses?.get('unassigned-section')}
+        />
       </div>
-      <UnassignedSection
-        orders={schedule.unassignedOrders}
-        customers={customers}
-        onOrderClick={onOrderClick}
-        dropZoneStatus={dropZoneStatuses?.get('unassigned-section')}
-      />
-    </div>
+    </GanttScaleProvider>
   );
 }

--- a/web/src/components/gantt/GanttScaleContext.tsx
+++ b/web/src/components/gantt/GanttScaleContext.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import { SLOT_WIDTH_PX } from './constants';
+
+const GanttScaleContext = createContext<number>(SLOT_WIDTH_PX);
+
+export const GanttScaleProvider = GanttScaleContext.Provider;
+
+export function useSlotWidth(): number {
+  return useContext(GanttScaleContext);
+}

--- a/web/src/components/gantt/GanttTimeHeader.tsx
+++ b/web/src/components/gantt/GanttTimeHeader.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { GANTT_START_HOUR, GANTT_END_HOUR, SLOT_WIDTH_PX, HELPER_NAME_WIDTH_PX, TOTAL_SLOTS } from './constants';
+import { GANTT_START_HOUR, GANTT_END_HOUR, HELPER_NAME_WIDTH_PX, TOTAL_SLOTS } from './constants';
+import { useSlotWidth } from './GanttScaleContext';
 
 export function GanttTimeHeader() {
+  const slotWidth = useSlotWidth();
   const hours = Array.from(
     { length: GANTT_END_HOUR - GANTT_START_HOUR },
     (_, i) => GANTT_START_HOUR + i
@@ -18,11 +20,11 @@ export function GanttTimeHeader() {
       </div>
       <div
         className="relative"
-        style={{ width: TOTAL_SLOTS * SLOT_WIDTH_PX }}
+        style={{ width: TOTAL_SLOTS * slotWidth }}
       >
         {hours.map((hour) => {
           const slotsPerHour = 60 / 5;
-          const hourLeft = (hour - GANTT_START_HOUR) * slotsPerHour * SLOT_WIDTH_PX;
+          const hourLeft = (hour - GANTT_START_HOUR) * slotsPerHour * slotWidth;
           return (
             <div key={hour}>
               {/* 正時の線 + ラベル */}
@@ -36,7 +38,7 @@ export function GanttTimeHeader() {
               </div>
               {/* 10分刻みのサブ目盛り（:10, :20, :30, :40, :50） */}
               {[10, 20, 30, 40, 50].map((min) => {
-                const subLeft = hourLeft + (min / 5) * SLOT_WIDTH_PX;
+                const subLeft = hourLeft + (min / 5) * slotWidth;
                 return (
                   <div
                     key={`${hour}:${min}`}

--- a/web/src/components/gantt/constants.ts
+++ b/web/src/components/gantt/constants.ts
@@ -25,9 +25,9 @@ export function timeToMinutes(time: string): number {
 }
 
 /** 分数 → ピクセル位置（ガント開始からの相対位置） */
-function minutesToPx(minutes: number): number {
+function minutesToPx(minutes: number, slotWidth: number = SLOT_WIDTH_PX): number {
   const startMinutes = GANTT_START_HOUR * 60;
-  return ((minutes - startMinutes) / MINUTES_PER_SLOT) * SLOT_WIDTH_PX;
+  return ((minutes - startMinutes) / MINUTES_PER_SLOT) * slotWidth;
 }
 
 export type UnavailableBlockType = 'off_hours' | 'day_off' | 'unavailable';
@@ -45,7 +45,9 @@ export function calculateUnavailableBlocks(
   unavailableSlots: import('@/types').UnavailableSlot[],
   day: import('@/types').DayOfWeek,
   dayDate: Date,
+  slotWidth: number = SLOT_WIDTH_PX,
 ): UnavailableBlock[] {
+  const toPx = (minutes: number) => minutesToPx(minutes, slotWidth);
   const ganttStartMin = GANTT_START_HOUR * 60;
   const ganttEndMin = GANTT_END_HOUR * 60;
   const blocks: UnavailableBlock[] = [];
@@ -65,8 +67,8 @@ export function calculateUnavailableBlocks(
 
       if (slotStart > cursor) {
         blocks.push({
-          left: minutesToPx(cursor),
-          width: minutesToPx(slotStart) - minutesToPx(cursor),
+          left: toPx(cursor),
+          width: toPx(slotStart) - toPx(cursor),
           label: '勤務時間外',
           type: 'off_hours',
         });
@@ -76,8 +78,8 @@ export function calculateUnavailableBlocks(
 
     if (cursor < ganttEndMin) {
       blocks.push({
-        left: minutesToPx(cursor),
-        width: minutesToPx(ganttEndMin) - minutesToPx(cursor),
+        left: toPx(cursor),
+        width: toPx(ganttEndMin) - toPx(cursor),
         label: '勤務時間外',
         type: 'off_hours',
       });
@@ -85,8 +87,8 @@ export function calculateUnavailableBlocks(
   } else {
     // 勤務時間未設定 → 非勤務日として全域をグレーアウト
     blocks.push({
-      left: minutesToPx(ganttStartMin),
-      width: minutesToPx(ganttEndMin) - minutesToPx(ganttStartMin),
+      left: toPx(ganttStartMin),
+      width: toPx(ganttEndMin) - toPx(ganttStartMin),
       label: '非勤務日',
       type: 'day_off',
     });
@@ -106,8 +108,8 @@ export function calculateUnavailableBlocks(
 
     if (slot.all_day) {
       blocks.push({
-        left: minutesToPx(ganttStartMin),
-        width: minutesToPx(ganttEndMin) - minutesToPx(ganttStartMin),
+        left: toPx(ganttStartMin),
+        width: toPx(ganttEndMin) - toPx(ganttStartMin),
         label: '希望休',
         type: 'unavailable',
       });
@@ -116,8 +118,8 @@ export function calculateUnavailableBlocks(
       const end = Math.min(timeToMinutes(slot.end_time), ganttEndMin);
       if (end > start) {
         blocks.push({
-          left: minutesToPx(start),
-          width: minutesToPx(end) - minutesToPx(start),
+          left: toPx(start),
+          width: toPx(end) - toPx(start),
           label: '希望休',
           type: 'unavailable',
         });


### PR DESCRIPTION
## Summary
- ResizeObserverでガントチャートのコンテナ幅を計測し、5分スロットの幅を動的に算出
- GanttScaleContext（React Context）で動的スロット幅を全コンポーネントに配信
- デスクトップ表示で画面幅いっぱいにチャートが広がるように改善
- モバイル等の小画面では従来通り最小幅（4px/スロット）でスクロール表示

## Changes
- **NEW**: `GanttScaleContext.tsx` — React Context + `useSlotWidth` hook
- **EDIT**: `constants.ts` — `calculateUnavailableBlocks` に `slotWidth` パラメータ追加（デフォルト値で後方互換維持）
- **EDIT**: `GanttChart.tsx` — ResizeObserver + GanttScaleProvider 追加
- **EDIT**: `GanttTimeHeader.tsx` — 動的 slotWidth 使用
- **EDIT**: `GanttRow.tsx` — 動的 slotWidth 使用、GRID_LINES を useMemo で動的生成
- **EDIT**: `GanttBar.tsx` — 動的 slotWidth 使用

## Test plan
- [x] 全114テストがパス（既存テストは後方互換で変更なし）
- [ ] デスクトップ幅（1920px）でチャートが画面幅いっぱいに表示される
- [ ] ブラウザリサイズ時にチャートが追従してリサイズする
- [ ] モバイル幅で従来通りスクロール表示される
- [ ] D&Dゴーストブロックが正しい位置に表示される

🤖 Generated with [Claude Code](https://claude.ai/code)