### PR TITLE
feat: ガントチャートD&D時間軸移動機能を追加

### DIFF
--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -103,6 +103,32 @@ export async function mockOptimizerAPI(
 }
 
 /**
+ * 同一行内で水平方向にドラッグする（時間軸移動用）。
+ * @param offsetX 水平方向のピクセル移動量（正=右=遅い時間, 負=左=早い時間）
+ */
+export async function dragOrderHorizontally(page: Page, source: Locator, offsetX: number) {
+  await source.scrollIntoViewIfNeeded();
+
+  const box = await source.boundingBox();
+  if (!box) throw new Error('Could not get bounding box for drag source');
+
+  const startX = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+  const endX = startX + offsetX;
+
+  await source.hover();
+  await page.mouse.down();
+  // distance: 5px を確実に超えるため中間点を経由
+  await page.mouse.move(startX + 10, startY, { steps: 5 });
+  await page.mouse.move(endX, startY, { steps: 15 });
+  // dragover発火用に再度move
+  await page.mouse.move(endX, startY);
+  await page.mouse.up();
+  // 非同期のhandleDragEnd（Firestore書き込み）完了を待つ
+  await page.waitForTimeout(500);
+}
+
+/**
  * sonnerトーストの表示を待機する。
  * sonnerは[data-sonner-toast]属性のli要素でトーストを表示する。
  */

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { addDays } from 'date-fns';
 import { DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { ScheduleProvider, useScheduleContext } from '@/contexts/ScheduleContext';
@@ -17,6 +17,7 @@ import { useDragAndDrop } from '@/hooks/useDragAndDrop';
 import { useOrderEdit } from '@/hooks/useOrderEdit';
 import { useAssignmentDiff } from '@/hooks/useAssignmentDiff';
 import { checkConstraints } from '@/lib/constraints/checker';
+import { SLOT_WIDTH_PX } from '@/components/gantt/constants';
 import { DAY_OF_WEEK_ORDER } from '@/types';
 import type { Order } from '@/types';
 
@@ -68,9 +69,13 @@ function SchedulePage() {
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
   );
 
+  const [slotWidth, setSlotWidth] = useState(SLOT_WIDTH_PX);
+  const handleSlotWidthChange = useCallback((sw: number) => setSlotWidth(sw), []);
+
   const {
     dropZoneStatuses,
     activeOrder,
+    previewTimes,
     handleDragStart,
     handleDragOver,
     handleDragEnd,
@@ -82,6 +87,7 @@ function SchedulePage() {
     customers,
     unavailability,
     day: selectedDay,
+    slotWidth,
   });
 
   const handleOrderClick = (order: Order) => {
@@ -142,6 +148,8 @@ function SchedulePage() {
             dropZoneStatuses={dropZoneStatuses}
             unavailability={unavailability}
             activeOrder={activeOrder}
+            onSlotWidthChange={handleSlotWidthChange}
+            previewTimes={previewTimes}
           />
         </DndContext>
       </main>

--- a/web/src/lib/firestore/updateOrder.ts
+++ b/web/src/lib/firestore/updateOrder.ts
@@ -16,3 +16,23 @@ export async function updateOrderAssignment(
     updated_at: serverTimestamp(),
   });
 }
+
+/**
+ * オーダーの割当スタッフと時刻を同時に更新する。
+ * D&D 時間軸移動時に使用。
+ */
+export async function updateOrderAssignmentAndTime(
+  orderId: string,
+  newStaffIds: string[],
+  newStartTime: string,
+  newEndTime: string,
+): Promise<void> {
+  const orderRef = doc(getDb(), 'orders', orderId);
+  await updateDoc(orderRef, {
+    assigned_staff_ids: newStaffIds,
+    start_time: newStartTime,
+    end_time: newEndTime,
+    manually_edited: true,
+    updated_at: serverTimestamp(),
+  });
+}


### PR DESCRIPTION
## Summary
- ガントチャート上でオーダーバーを水平ドラッグして時間帯を変更可能に
- 10分単位スナップ、7:00-21:00範囲クランプ、duration保持
- 同一行内の時間移動・行間移動＋時間変更の両方に対応
- validateDropで新時刻に対するバリデーション（重複・希望休・勤務時間外）
- ゴーストバー/ハイライトが移動先時刻に追従表示

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `constants.ts` | `deltaToTimeShift`, `computeShiftedTimes`等5関数追加 |
| `useDragAndDrop.ts` | delta.x→時間シフト計算、同一行時間変更対応 |
| `validation.ts` | `newStartTime`/`newEndTime`パラメータ追加 |
| `updateOrder.ts` | `updateOrderAssignmentAndTime()`追加 |
| `GanttChart.tsx` | `onSlotWidthChange`, `previewTimes`props追加 |
| `GanttRow.tsx` | ゴーストバーがpreviewTimes位置に表示 |
| `page.tsx` | slotWidth/previewTimes接続 |

## Test plan
- [x] ユニットテスト31件追加（145/145パス）
- [x] E2Eテスト2件追加（同一行水平ドラッグ、Escapeキャンセル）
- [x] TypeScriptビルド成功
- [x] ESLint通過
- [ ] 手動確認: オーダーバーを右/左にドラッグして時間変更
- [ ] 手動確認: 別行にドラッグ＋水平移動で行＋時間を同時変更
- [ ] 手動確認: 重複エラー/勤務時間外警告が正しく表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)