### PR TITLE
fix: E2Eテストのフレイキー問題を修正（Welcomeダイアログ競合対策）

### DIFF
--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -14,19 +14,24 @@ export async function waitForAuth(page: Page) {
  * スケジュール画面（トップページ）に遷移して認証完了を待つ
  */
 export async function goToSchedule(page: Page) {
+  // Welcome ダイアログが表示されないよう、ページロード前に localStorage を設定
+  await page.addInitScript(() => {
+    localStorage.setItem('visitcare-welcome-shown', 'true');
+  });
   await page.goto('/');
-  await page.evaluate(() => localStorage.setItem('visitcare-welcome-shown', 'true'));
   await waitForAuth(page);
-  // データロード完了を待つ（「読み込み中...」が消えるまで）
-  await expect(page.getByText('読み込み中...')).toBeHidden({ timeout: 30_000 });
+  // データロード完了を待つ（並列ワーカー実行時のFirestore負荷を考慮し45秒）
+  await expect(page.getByText('読み込み中...')).toBeHidden({ timeout: 45_000 });
 }
 
 /**
  * マスタ管理画面に遷移して認証完了を待つ
  */
 export async function goToMasters(page: Page, tab: 'customers' | 'helpers' | 'unavailability') {
+  await page.addInitScript(() => {
+    localStorage.setItem('visitcare-welcome-shown', 'true');
+  });
   await page.goto(`/masters/${tab}/`);
-  await page.evaluate(() => localStorage.setItem('visitcare-welcome-shown', 'true'));
   await waitForAuth(page);
 }
 
@@ -34,8 +39,10 @@ export async function goToMasters(page: Page, tab: 'customers' | 'helpers' | 'un
  * 履歴画面に遷移して認証完了を待つ
  */
 export async function goToHistory(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('visitcare-welcome-shown', 'true');
+  });
   await page.goto('/history/');
-  await page.evaluate(() => localStorage.setItem('visitcare-welcome-shown', 'true'));
   await waitForAuth(page);
 }
 

--- a/web/e2e/masters-crud.spec.ts
+++ b/web/e2e/masters-crud.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test';
 import { goToMasters, waitForToast } from './helpers';
 
 test.describe('利用者マスタ CRUD', () => {
+  // CI・並列実行時のFirestoreデータロード遅延対策
+  test.describe.configure({ retries: 1, timeout: 60_000 });
   test('利用者を新規追加できる', async ({ page }) => {
     await goToMasters(page, 'customers');
     await expect(page.getByRole('table')).toBeVisible({ timeout: 15_000 });
@@ -56,6 +58,7 @@ test.describe('利用者マスタ CRUD', () => {
 });
 
 test.describe('ヘルパーマスタ CRUD', () => {
+  test.describe.configure({ retries: 1, timeout: 60_000 });
   test('ヘルパーを新規追加できる', async ({ page }) => {
     await goToMasters(page, 'helpers');
     await expect(page.getByRole('table')).toBeVisible({ timeout: 15_000 });
@@ -107,6 +110,7 @@ test.describe('ヘルパーマスタ CRUD', () => {
 });
 
 test.describe('希望休管理 CRUD', () => {
+  test.describe.configure({ retries: 1, timeout: 60_000 });
   test('希望休を新規追加できる', async ({ page }) => {
     await goToMasters(page, 'unavailability');
     await expect(page.getByRole('button', { name: /新規|追加/ })).toBeVisible({ timeout: 10_000 });

--- a/web/e2e/schedule-interactions.spec.ts
+++ b/web/e2e/schedule-interactions.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 import { goToSchedule, waitForGanttBars, mockOptimizerAPI, waitForToast } from './helpers';
 
 test.describe('スケジュール画面インタラクション', () => {
-  // CI環境でのFirestoreデータロード時間を考慮
-  test.describe.configure({ timeout: 60_000 });
+  // CI・並列実行時のFirestoreデータロード遅延対策
+  test.describe.configure({ retries: 2, timeout: 60_000 });
   test('ガントバーをクリックするとOrderDetailPanelが開く', async ({ page }) => {
     await goToSchedule(page);
     await waitForGanttBars(page);

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:fresh": "npx firebase-tools@latest emulators:exec --only firestore,auth --project demo-visitcare \"cd ../seed && FIRESTORE_EMULATOR_HOST=localhost:8080 npx tsx scripts/import-all.ts && cd ../web && npx playwright test\""
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- `goToSchedule` / `goToMasters` / `goToHistory` で `page.addInitScript()` を使い、ページロード前に `localStorage('visitcare-welcome-shown')` を設定するよう変更。Welcomeダイアログのオーバーレイがテスト操作をブロックする問題を解消。
- `schedule-interactions.spec.ts` に `retries: 2`、`masters-crud.spec.ts` に `retries: 1, timeout: 60_000` を追加し、CI同等のリトライ動作をローカルでも実現。
- `test:e2e:fresh` npmスクリプトを追加（`emulators:exec` によるCI同等のクリーン実行）。

## Root Cause
`goToSchedule` が `page.evaluate()` で localStorage を設定していたが、これは `page.goto('/')` の後に実行されるため、Reactの `useEffect` が先に走り Welcome ダイアログが開いてしまうレースコンディションが発生していた。`page.addInitScript()` に変更することで、ページのJavaScriptが実行される前に localStorage が設定される。

## Test plan
- [x] ローカルで `npm run test:e2e:fresh` を3回実行し、40/40 パス（リトライ含む）を確認
- [ ] CI（GitHub Actions）で全テスト通過を確認

🤖 Generated with [Claude Code](https://claude.ai/code)