### PR TITLE
fix: Firestoreルールにstart_time/end_time更新許可を追加

### DIFF
--- a/firebase/__tests__/firestore.rules.test.ts
+++ b/firebase/__tests__/firestore.rules.test.ts
@@ -508,6 +508,19 @@ describe('認証済みユーザー - orders update', () => {
     );
   });
 
+  it('start_time, end_time を含む更新ができる（D&D時間軸移動）', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertSucceeds(
+      updateDoc(doc(authed.firestore(), 'orders', 'order-1'), {
+        assigned_staff_ids: ['helper-2'],
+        start_time: '2026-02-16T10:00:00+09:00',
+        end_time: '2026-02-16T11:00:00+09:00',
+        manually_edited: true,
+        updated_at: serverTimestamp(),
+      })
+    );
+  });
+
   it('不許可フィールド (service_type) を含む更新は拒否される', async () => {
     const authed = testEnv.authenticatedContext('user-1');
     await assertFails(

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -39,7 +39,7 @@ service cloud.firestore {
     // ── バリデーション関数 ──────────────────────────
 
     function isValidOrderUpdate() {
-      let allowedFields = ['assigned_staff_ids', 'manually_edited', 'updated_at'].toSet();
+      let allowedFields = ['assigned_staff_ids', 'manually_edited', 'updated_at', 'start_time', 'end_time'].toSet();
       let incomingFields = request.resource.data.diff(resource.data).affectedKeys();
       return incomingFields.hasOnly(allowedFields)
         && request.resource.data.assigned_staff_ids is list


### PR DESCRIPTION
## Summary
- D&D時間軸移動時の `FirebaseError: Missing or insufficient permissions` を修正
- `isValidOrderUpdate()` の `allowedFields` に `start_time`, `end_time` を追加

## Root Cause
`firestore.rules` の `isValidOrderUpdate()` で許可フィールドが `assigned_staff_ids`, `manually_edited`, `updated_at` の3つだけだった。PR #55（ガントチャートD&D時間軸移動機能）で `updateOrderAssignmentAndTime()` が `start_time`/`end_time` も更新するようになったが、ルール側の更新が漏れていた。

## Changes
| File | Change |
|------|--------|
| `firebase/firestore.rules` | `allowedFields` に `start_time`, `end_time` 追加 |
| `firebase/__tests__/firestore.rules.test.ts` | D&D時間変更の許可テスト追加 |

## Test plan
- [x] Firestore rules テスト 70/70 passed（新規テスト含む）
- [ ] 本番UIでD&D時間軸移動が成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)