### PR TITLE
fix: OptimizeButtonからテスト実行ボタンを削除

### DIFF
--- a/web/src/components/schedule/OptimizeButton.tsx
+++ b/web/src/components/schedule/OptimizeButton.tsx
@@ -28,16 +28,16 @@ export function OptimizeButton() {
   const [loading, setLoading] = useState(false);
   const [weights, setWeights] = useState<ConstraintWeights>({ ...DEFAULT_WEIGHTS });
 
-  const handleOptimize = async (dryRun: boolean) => {
+  const handleOptimize = async () => {
     setLoading(true);
     try {
       const result = await runOptimize({
         week_start_date: format(weekStart, 'yyyy-MM-dd'),
-        dry_run: dryRun,
+        dry_run: false,
         ...weights,
       });
       toast.success(
-        `最適化${dryRun ? '（テスト）' : ''}完了: ${result.assigned_count}/${result.total_orders}件割当 (${result.solve_time_seconds.toFixed(1)}秒)`
+        `最適化完了: ${result.assigned_count}/${result.total_orders}件割当 (${result.solve_time_seconds.toFixed(1)}秒)`
       );
       setOpen(false);
     } catch (err) {
@@ -83,11 +83,8 @@ export function OptimizeButton() {
           <Button variant="outline" onClick={() => setOpen(false)} disabled={loading}>
             キャンセル
           </Button>
-          <Button variant="secondary" onClick={() => handleOptimize(true)} disabled={loading}>
-            テスト実行
-          </Button>
           <Button
-            onClick={() => handleOptimize(false)}
+            onClick={handleOptimize}
             disabled={loading}
             className="bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)] text-white"
           >


### PR DESCRIPTION
## Summary
- OptimizeButtonの「テスト実行」(dry_run) ボタンを削除し、UIをシンプル化
- 常に `dry_run: false` で実行するよう変更
- バックエンドの `dry_run` パラメータはAPI互換のため維持

## Test plan
- [ ] TypeScript型チェック: 既存エラー以外なし確認済み
- [ ] UIで最適化ダイアログを開き、「キャンセル」と「実行」の2ボタンのみ表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)