### PR TITLE
feat: あおぞらCGブランドアラインのデザインアップデート

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -8,6 +8,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-dm-sans), var(--font-noto-sans-jp), system-ui, sans-serif;
+  --font-serif: var(--font-noto-serif-jp), serif;
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -48,26 +49,26 @@
 }
 
 :root {
-  --radius: 0.625rem;
-  /* Warm Clinical — ティール系プライマリ + 温かいニュートラル */
-  --background: oklch(0.985 0.002 90);
+  --radius: 0.75rem;
+  /* あおぞらCGブランドアライン — #00C4CC シアン基調 */
+  --background: oklch(0.99 0.002 85);
   --foreground: oklch(0.195 0.015 250);
   --card: oklch(0.995 0.001 90);
   --card-foreground: oklch(0.195 0.015 250);
   --popover: oklch(0.995 0.001 90);
   --popover-foreground: oklch(0.195 0.015 250);
-  --primary: oklch(0.50 0.12 195);
-  --primary-foreground: oklch(0.985 0.005 195);
+  --primary: oklch(0.545 0.14 192);
+  --primary-foreground: oklch(0.99 0.005 192);
   --secondary: oklch(0.955 0.015 90);
   --secondary-foreground: oklch(0.25 0.02 250);
-  --muted: oklch(0.955 0.01 90);
+  --muted: oklch(0.955 0.008 85);
   --muted-foreground: oklch(0.50 0.02 250);
-  --accent: oklch(0.75 0.14 75);
-  --accent-foreground: oklch(0.25 0.03 75);
+  --accent: oklch(0.92 0.04 192);
+  --accent-foreground: oklch(0.30 0.08 192);
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.905 0.01 90);
   --input: oklch(0.905 0.01 90);
-  --ring: oklch(0.55 0.12 195);
+  --ring: oklch(0.60 0.13 192);
   --chart-1: oklch(0.55 0.15 195);
   --chart-2: oklch(0.60 0.15 160);
   --chart-3: oklch(0.50 0.10 240);
@@ -75,20 +76,28 @@
   --chart-5: oklch(0.65 0.18 40);
   --sidebar: oklch(0.975 0.005 195);
   --sidebar-foreground: oklch(0.195 0.015 250);
-  --sidebar-primary: oklch(0.50 0.12 195);
-  --sidebar-primary-foreground: oklch(0.985 0.005 195);
+  --sidebar-primary: oklch(0.545 0.14 192);
+  --sidebar-primary-foreground: oklch(0.99 0.005 192);
   --sidebar-accent: oklch(0.94 0.02 195);
   --sidebar-accent-foreground: oklch(0.25 0.02 250);
   --sidebar-border: oklch(0.905 0.01 90);
-  --sidebar-ring: oklch(0.55 0.12 195);
+  --sidebar-ring: oklch(0.60 0.13 192);
 
-  /* サービス種別カラー */
-  --physical-care: oklch(0.55 0.15 230);
-  --physical-care-light: oklch(0.70 0.10 230);
-  --daily-living: oklch(0.55 0.15 160);
-  --daily-living-light: oklch(0.70 0.10 160);
-  --prevention: oklch(0.60 0.12 300);
-  --prevention-light: oklch(0.75 0.08 300);
+  /* ブランドシアン装飾用 */
+  --brand-cyan: oklch(0.735 0.115 192);
+  --brand-cyan-dark: oklch(0.48 0.12 200);
+
+  /* ヘッダー/CTAグラデーション用 */
+  --color-gradient-brand-from: oklch(0.50 0.13 200);
+  --color-gradient-brand-to: oklch(0.56 0.14 188);
+
+  /* サービス種別カラー（ブランド調和版） */
+  --physical-care: oklch(0.55 0.15 225);
+  --physical-care-light: oklch(0.70 0.10 225);
+  --daily-living: oklch(0.55 0.15 162);
+  --daily-living-light: oklch(0.70 0.10 162);
+  --prevention: oklch(0.60 0.12 298);
+  --prevention-light: oklch(0.75 0.08 298);
 }
 
 .dark {
@@ -123,6 +132,12 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+}
+
+@layer utilities {
+  .shadow-brand-sm { box-shadow: 0 1px 3px -1px oklch(0.40 0.08 192 / 0.12), 0 1px 2px -1px oklch(0.40 0.08 192 / 0.06); }
+  .shadow-brand    { box-shadow: 0 2px 8px -2px oklch(0.40 0.08 192 / 0.15), 0 1px 3px -1px oklch(0.40 0.08 192 / 0.08); }
+  .shadow-brand-lg { box-shadow: 0 4px 16px -4px oklch(0.40 0.08 192 / 0.18), 0 2px 6px -2px oklch(0.40 0.08 192 / 0.10); }
 }
 
 @layer base {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { DM_Sans, Noto_Sans_JP, Geist_Mono } from "next/font/google";
+import { DM_Sans, Noto_Sans_JP, Noto_Serif_JP, Geist_Mono } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
 import { Providers } from "./providers";
 import "./globals.css";
@@ -14,6 +14,12 @@ const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
+});
+
+const notoSerifJP = Noto_Serif_JP({
+  variable: "--font-noto-serif-jp",
+  subsets: ["latin"],
+  weight: ["400", "700"],
 });
 
 const geistMono = Geist_Mono({
@@ -34,7 +40,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${dmSans.variable} ${notoSansJP.variable} ${geistMono.variable} antialiased`}
+        className={`${dmSans.variable} ${notoSansJP.variable} ${notoSerifJP.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>
           {children}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -106,9 +106,9 @@ function SchedulePage() {
   if (loading) {
     return (
       <div className="flex h-screen flex-col">
-        <header className="bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)] px-4 py-3 shadow-md">
+        <header className="bg-gradient-to-r from-[oklch(0.50_0.13_200)] to-[oklch(0.56_0.14_188)] px-4 py-3 shadow-brand">
           <div className="flex items-center gap-2.5">
-            <div className="h-8 w-8 rounded-lg bg-white/15 animate-pulse" />
+            <div className="h-8 w-8 rounded-lg bg-white/20 animate-pulse" />
             <div className="h-5 w-24 rounded bg-white/20 animate-pulse" />
           </div>
         </header>

--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -21,16 +21,16 @@ interface GanttBarProps {
 
 const SERVICE_COLORS: Record<string, { bar: string; hover: string }> = {
   physical_care: {
-    bar: 'bg-gradient-to-r from-[oklch(0.55_0.15_230)] to-[oklch(0.60_0.12_210)] text-white',
-    hover: 'hover:from-[oklch(0.50_0.16_230)] hover:to-[oklch(0.55_0.13_210)]',
+    bar: 'bg-gradient-to-r from-[oklch(0.55_0.15_225)] to-[oklch(0.60_0.12_205)] text-white',
+    hover: 'hover:from-[oklch(0.50_0.16_225)] hover:to-[oklch(0.55_0.13_205)]',
   },
   daily_living: {
-    bar: 'bg-gradient-to-r from-[oklch(0.55_0.15_160)] to-[oklch(0.60_0.12_145)] text-white',
-    hover: 'hover:from-[oklch(0.50_0.16_160)] hover:to-[oklch(0.55_0.13_145)]',
+    bar: 'bg-gradient-to-r from-[oklch(0.55_0.15_162)] to-[oklch(0.60_0.12_147)] text-white',
+    hover: 'hover:from-[oklch(0.50_0.16_162)] hover:to-[oklch(0.55_0.13_147)]',
   },
   prevention: {
-    bar: 'bg-gradient-to-r from-[oklch(0.60_0.12_300)] to-[oklch(0.65_0.10_280)] text-white',
-    hover: 'hover:from-[oklch(0.55_0.13_300)] hover:to-[oklch(0.60_0.11_280)]',
+    bar: 'bg-gradient-to-r from-[oklch(0.60_0.12_298)] to-[oklch(0.65_0.10_278)] text-white',
+    hover: 'hover:from-[oklch(0.55_0.13_298)] hover:to-[oklch(0.60_0.11_278)]',
   },
 };
 
@@ -63,10 +63,10 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
       ref={setNodeRef}
       data-testid={`gantt-bar-${order.id}`}
       className={cn(
-        'absolute top-1 h-8 rounded-md text-[11px] leading-8 px-1.5 truncate cursor-grab shadow-sm transition-all duration-150',
+        'absolute top-1 h-8 rounded-lg text-[11px] leading-8 px-2 truncate cursor-grab shadow-brand-sm transition-all duration-150',
         colors.bar,
         colors.hover,
-        'hover:shadow-md hover:scale-y-105',
+        'hover:shadow-brand hover:brightness-105 hover:-translate-y-px',
         hasViolation && violationType === 'error' && 'ring-2 ring-red-500 ring-offset-1',
         hasViolation && violationType === 'warning' && 'ring-2 ring-yellow-500 ring-offset-1',
         !hasViolation && order.manually_edited && 'ring-2 ring-blue-500 ring-offset-1',

--- a/web/src/components/gantt/GanttChart.tsx
+++ b/web/src/components/gantt/GanttChart.tsx
@@ -63,7 +63,7 @@ export function GanttChart({ schedule, customers, violations, onOrderClick, drop
   return (
     <GanttScaleProvider value={slotWidth}>
       <div className="flex flex-col">
-        <div ref={containerRef} className="overflow-x-auto border rounded-lg shadow-sm">
+        <div ref={containerRef} className="overflow-x-auto border rounded-lg shadow-brand-sm">
           <GanttTimeHeader />
           <div className="relative">
             {schedule.helperRows.map((row, index) => (

--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -29,9 +29,9 @@ interface GanttRowProps {
 
 /** ゴーストバー用の薄い背景色（サービスタイプ別） */
 const GHOST_COLORS: Record<string, string> = {
-  physical_care: 'bg-[oklch(0.55_0.15_230/0.3)]',
-  daily_living: 'bg-[oklch(0.55_0.15_160/0.3)]',
-  prevention: 'bg-[oklch(0.60_0.12_300/0.3)]',
+  physical_care: 'bg-[oklch(0.55_0.15_225/0.3)]',
+  daily_living: 'bg-[oklch(0.55_0.15_162/0.3)]',
+  prevention: 'bg-[oklch(0.60_0.12_298/0.3)]',
 };
 
 const DROP_ZONE_STYLES: Record<DropZoneStatus, string> = {
@@ -71,7 +71,7 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
           key={i}
           className={cn(
             'absolute top-0 h-full border-l',
-            isHour ? 'border-border/25' : isHalf ? 'border-border/15' : 'border-border/8',
+            isHour ? 'border-border/30' : isHalf ? 'border-border/15' : 'border-border/[0.06]',
           )}
           style={{ left: i * pxPer10Min }}
         />
@@ -93,8 +93,8 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
       'flex border-b border-border/50 transition-colors duration-100',
       isDayOff
         ? 'bg-muted/50'
-        : isEven ? 'bg-card' : 'bg-muted/20',
-      !isDayOff && 'hover:bg-primary/[0.03]'
+        : isEven ? 'bg-card' : 'bg-muted/15',
+      !isDayOff && 'hover:bg-accent/40'
     )}>
       <div
         className={cn(

--- a/web/src/components/gantt/GanttTimeHeader.tsx
+++ b/web/src/components/gantt/GanttTimeHeader.tsx
@@ -11,7 +11,7 @@ export function GanttTimeHeader() {
   );
 
   return (
-    <div className="flex border-b bg-gradient-to-b from-muted/80 to-muted/40 sticky top-0 z-10">
+    <div className="flex border-b bg-gradient-to-b from-accent/50 to-accent/20 backdrop-blur-sm sticky top-0 z-10">
       <div
         className="shrink-0 border-r px-2 py-1.5 text-xs font-semibold text-primary"
         style={{ width: HELPER_NAME_WIDTH_PX }}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -34,11 +34,11 @@ export function Header({ onShowWelcome }: HeaderProps = {}) {
   const isLoggedIn = authMode === 'required' && user && !user.isAnonymous;
 
   return (
-    <header className="bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)] px-4 py-3 shadow-md">
+    <header className="bg-gradient-to-r from-[oklch(0.50_0.13_200)] to-[oklch(0.56_0.14_188)] px-4 py-3 shadow-brand">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2.5">
           <Link href="/" className="flex items-center gap-2.5">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/15 backdrop-blur-sm">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/20 backdrop-blur-sm">
               <Heart className="h-4.5 w-4.5 text-white" />
             </div>
             <div>

--- a/web/src/components/onboarding/WelcomeDialog.tsx
+++ b/web/src/components/onboarding/WelcomeDialog.tsx
@@ -48,7 +48,7 @@ export function WelcomeDialog({ open, onClose }: WelcomeDialogProps) {
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md" showCloseButton={false}>
         <DialogHeader>
-          <DialogTitle className="text-center">
+          <DialogTitle className="text-center font-serif">
             VisitCare シフト最適化の使い方
           </DialogTitle>
           <DialogDescription className="text-center">
@@ -91,7 +91,7 @@ export function WelcomeDialog({ open, onClose }: WelcomeDialogProps) {
             onClick={goNext}
             className={
               isLastStep
-                ? 'bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)] text-white hover:opacity-90'
+                ? 'bg-gradient-to-r from-[oklch(0.50_0.13_200)] to-[oklch(0.56_0.14_188)] text-white hover:opacity-90'
                 : ''
             }
           >

--- a/web/src/components/schedule/DayTabs.tsx
+++ b/web/src/components/schedule/DayTabs.tsx
@@ -47,7 +47,7 @@ export function DayTabs({ orderCounts }: DayTabsProps) {
             )}
             {/* アクティブインジケーター */}
             {isSelected && (
-              <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-primary" />
+              <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-gradient-to-r from-primary to-[oklch(0.56_0.14_188)]" />
             )}
           </button>
         );

--- a/web/src/components/schedule/OptimizeButton.tsx
+++ b/web/src/components/schedule/OptimizeButton.tsx
@@ -61,7 +61,7 @@ export function OptimizeButton() {
         <Button
           size="sm"
           disabled={loading}
-          className="bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)] text-white shadow-sm hover:shadow-md hover:brightness-110 transition-all duration-200"
+          className="rounded-full bg-gradient-to-r from-[oklch(0.50_0.13_200)] to-[oklch(0.56_0.14_188)] text-white shadow-brand-sm hover:shadow-brand hover:brightness-110 transition-all duration-200"
         >
           {loading ? (
             <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
@@ -86,7 +86,7 @@ export function OptimizeButton() {
           <Button
             onClick={handleOptimize}
             disabled={loading}
-            className="bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)] text-white"
+            className="bg-gradient-to-r from-[oklch(0.50_0.13_200)] to-[oklch(0.56_0.14_188)] text-white"
           >
             {loading && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
             実行

--- a/web/src/components/schedule/OrderDetailPanel.tsx
+++ b/web/src/components/schedule/OrderDetailPanel.tsx
@@ -34,9 +34,9 @@ const SERVICE_LABELS: Record<string, string> = {
 };
 
 const SERVICE_BADGE_STYLES: Record<string, string> = {
-  physical_care: 'bg-[oklch(0.55_0.15_230)]/10 text-[oklch(0.45_0.15_230)] border-[oklch(0.55_0.15_230)]/30',
-  daily_living: 'bg-[oklch(0.55_0.15_160)]/10 text-[oklch(0.45_0.15_160)] border-[oklch(0.55_0.15_160)]/30',
-  prevention: 'bg-[oklch(0.60_0.12_300)]/10 text-[oklch(0.50_0.12_300)] border-[oklch(0.60_0.12_300)]/30',
+  physical_care: 'bg-[oklch(0.55_0.15_225)]/10 text-[oklch(0.45_0.15_225)] border-[oklch(0.55_0.15_225)]/30',
+  daily_living: 'bg-[oklch(0.55_0.15_162)]/10 text-[oklch(0.45_0.15_162)] border-[oklch(0.55_0.15_162)]/30',
+  prevention: 'bg-[oklch(0.60_0.12_298)]/10 text-[oklch(0.50_0.12_298)] border-[oklch(0.60_0.12_298)]/30',
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -79,7 +79,7 @@ export function OrderDetailPanel({
         </SheetHeader>
         <div className="mt-4 space-y-5">
           {/* 基本情報セクション */}
-          <div className="space-y-3 rounded-lg border bg-muted/30 p-3">
+          <div className="space-y-3 rounded-lg border bg-accent/30 p-3">
             <div className="flex items-center gap-2 text-sm">
               <Clock className="h-4 w-4 text-muted-foreground" />
               <span className="text-muted-foreground">時間</span>
@@ -123,7 +123,7 @@ export function OrderDetailPanel({
                   <li key={h.id} className="flex items-center gap-2 text-sm">
                     <span>{h.name.family} {h.name.given}</span>
                     {h.can_physical_care && (
-                      <Badge variant="secondary" className="text-[10px] bg-[oklch(0.55_0.15_230)]/10 text-[oklch(0.45_0.15_230)]">身体可</Badge>
+                      <Badge variant="secondary" className="text-[10px] bg-[oklch(0.55_0.15_225)]/10 text-[oklch(0.45_0.15_225)]">身体可</Badge>
                     )}
                   </li>
                 ))}

--- a/web/src/components/schedule/StatsBar.tsx
+++ b/web/src/components/schedule/StatsBar.tsx
@@ -28,8 +28,8 @@ export function StatsBar({ schedule, violations }: StatsBarProps) {
   return (
     <div className="grid grid-cols-4 gap-3 px-4 py-3">
       {/* オーダー数 */}
-      <div className="flex items-center gap-3 rounded-lg border bg-card px-3 py-2.5 shadow-sm">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+      <div className="flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 shadow-brand-sm">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-accent">
           <ClipboardList className="h-4.5 w-4.5 text-primary" />
         </div>
         <div>
@@ -39,7 +39,7 @@ export function StatsBar({ schedule, violations }: StatsBarProps) {
       </div>
 
       {/* 割当済 */}
-      <div className="flex items-center gap-3 rounded-lg border bg-card px-3 py-2.5 shadow-sm">
+      <div className="flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 shadow-brand-sm">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
           <CheckCircle2 className="h-4.5 w-4.5 text-emerald-600" />
         </div>
@@ -59,7 +59,7 @@ export function StatsBar({ schedule, violations }: StatsBarProps) {
       </div>
 
       {/* 未割当 */}
-      <div className="flex items-center gap-3 rounded-lg border bg-card px-3 py-2.5 shadow-sm">
+      <div className="flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 shadow-brand-sm">
         <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${schedule.unassignedOrders.length > 0 ? 'bg-amber-500/10' : 'bg-muted'}`}>
           <AlertCircle className={`h-4.5 w-4.5 ${schedule.unassignedOrders.length > 0 ? 'text-amber-600' : 'text-muted-foreground'}`} />
         </div>
@@ -72,8 +72,8 @@ export function StatsBar({ schedule, violations }: StatsBarProps) {
       </div>
 
       {/* ヘルパー */}
-      <div className="flex items-center gap-3 rounded-lg border bg-card px-3 py-2.5 shadow-sm">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+      <div className="flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 shadow-brand-sm">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-accent">
           <Users className="h-4.5 w-4.5 text-primary" />
         </div>
         <div>

--- a/web/src/lib/auth/AuthProvider.tsx
+++ b/web/src/lib/auth/AuthProvider.tsx
@@ -158,7 +158,7 @@ function LoginScreen({ onSignIn }: { onSignIn: () => Promise<void> }) {
     <div className="flex h-screen items-center justify-center bg-gradient-to-br from-[oklch(0.97_0.01_195)] to-[oklch(0.93_0.03_195)]">
       <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-8 shadow-lg">
         <div className="text-center space-y-2">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-r from-primary to-[oklch(0.45_0.10_210)]">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-r from-[oklch(0.50_0.13_200)] to-[oklch(0.56_0.14_188)]">
             <svg className="h-6 w-6 text-white" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
             </svg>


### PR DESCRIPTION
## Summary
- ブランドカラー `#00C4CC` (シアン/ターコイズ) を基調にUI全体のカラーパレット・シャドウ・角丸・フォントを刷新
- 14ファイル修正、新規ファイルなし。既存テスト157件全パス
- ヘッダー/CTA/ガントチャート/StatsBar/ダイアログ等の配色をブランドトンマナに統一

### 主な変更
- **カラーパレット**: `--primary`, `--accent`, `--ring` 等をブランドhue=192に再設計
- **色付きシャドウ**: `.shadow-brand-sm/brand/brand-lg` ユーティリティ追加
- **フォント**: Noto Serif JP 追加（WelcomeDialogタイトル等のアクセント）
- **グラデーション統一**: 6箇所の旧グラデーションを新ブランド値に一括置換
- **ガントバー**: `rounded-lg` + 浮遊ホバーエフェクト (`hover:brightness-105 hover:-translate-y-px`)
- **StatsBar**: `rounded-xl` + `shadow-brand-sm` + `bg-accent` アイコン背景
- **OptimizeButton**: ピル型 (`rounded-full`) CTA
- **サービス種別色**: hue微調整 (230→225, 160→162, 300→298) でブランドシアンとの調和

## Test plan
- [x] `npx tsc --noEmit` — TypeScriptビルド確認（既存テストファイルのエラーのみ、今回の変更と無関係）
- [x] `npm test` — 全12テストファイル / 157テスト全パス
- [ ] ブラウザでヘッダーのグラデーション確認
- [ ] ガントチャート全体の配色確認
- [ ] StatsBarカードの表示確認
- [ ] 最適化ダイアログ（ピル型ボタン）確認
- [ ] D&D操作が正常に動作すること
- [ ] 制約違反リング（赤/黄/青）が視認できること

🤖 Generated with [Claude Code](https://claude.ai/code)