### PR TITLE
fix: E2Eテストから「テスト実行」ボタン参照を削除

### DIFF
--- a/web/e2e/schedule-interactions.spec.ts
+++ b/web/e2e/schedule-interactions.spec.ts
@@ -57,7 +57,7 @@ test.describe('スケジュール画面インタラクション', () => {
     await expect(dialog.getByText('シフト最適化の実行')).toBeVisible();
   });
 
-  test('最適化ダイアログにテスト実行・実行・キャンセルの3ボタンが表示される', async ({ page }) => {
+  test('最適化ダイアログに実行・キャンセルの2ボタンが表示される', async ({ page }) => {
     await goToSchedule(page);
     await waitForGanttBars(page);
 
@@ -67,7 +67,6 @@ test.describe('スケジュール画面インタラクション', () => {
     await expect(dialog).toBeVisible();
 
     await expect(dialog.getByRole('button', { name: 'キャンセル', exact: true })).toBeVisible();
-    await expect(dialog.getByRole('button', { name: 'テスト実行', exact: true })).toBeVisible();
     await expect(dialog.getByRole('button', { name: '実行', exact: true })).toBeVisible();
   });
 
@@ -83,7 +82,7 @@ test.describe('スケジュール画面インタラクション', () => {
     await expect(dialog).toBeHidden();
   });
 
-  test('テスト実行（APIモック）で成功トーストが表示される', async ({ page }) => {
+  test('実行（APIモック）で成功トーストが表示される', async ({ page }) => {
     await mockOptimizerAPI(page, {
       body: {
         status: 'optimal',
@@ -103,9 +102,9 @@ test.describe('スケジュール画面インタラクション', () => {
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
-    await dialog.getByRole('button', { name: 'テスト実行' }).click();
+    await dialog.getByRole('button', { name: '実行', exact: true }).click();
 
-    await waitForToast(page, /最適化（テスト）完了/);
+    await waitForToast(page, /最適化完了/);
   });
 
   test('API失敗時（409）にエラートーストが表示される', async ({ page }) => {
@@ -121,7 +120,7 @@ test.describe('スケジュール画面インタラクション', () => {
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
-    await dialog.getByRole('button', { name: 'テスト実行' }).click();
+    await dialog.getByRole('button', { name: '実行', exact: true }).click();
 
     await waitForToast(page, /最適化不可/);
   });


### PR DESCRIPTION
## Summary
- PR #60で`OptimizeButton`から「テスト実行」ボタンを削除したが、E2Eテストが旧UI（3ボタン構成）を期待しており失敗していた
- E2Eテストを新UI（キャンセル+実行の2ボタン）に合わせて修正
- トースト文言も実際の出力（`最適化完了`）に合わせて更新

## Test plan
- [ ] CI E2Eテスト（schedule-interactions.spec.ts）が全パスすること
- [ ] デプロイがブロックされずに完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)