### PR TITLE
fix: ドラッグ中のゴーストがカーソルに追随しない問題を修正

### DIFF
--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -63,7 +63,8 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
       ref={setNodeRef}
       data-testid={`gantt-bar-${order.id}`}
       className={cn(
-        'absolute top-1 h-8 rounded-lg text-[11px] leading-8 px-2 truncate cursor-grab shadow-brand-sm transition-all duration-150',
+        'absolute top-1 h-8 rounded-lg text-[11px] leading-8 px-2 truncate cursor-grab shadow-brand-sm',
+        isDragging ? 'transition-none' : 'transition-all duration-150',
         colors.bar,
         colors.hover,
         'hover:shadow-brand hover:brightness-105 hover:-translate-y-px',


### PR DESCRIPTION
## Summary
- GanttBarの`transition-all duration-150`がドラッグ中の`transform`更新にも適用されていた
- カーソル移動に対して150msの遅延が発生し、ゴーストが追随できていなかった
- ドラッグ中は`transition-none`に切り替え、即座にカーソルに追随するよう修正

## Test plan
- [ ] ガントバーをドラッグした際、ゴーストがカーソルに即座に追随すること
- [ ] ドラッグしていない時のホバーエフェクト（影、浮遊）がスムーズに動作すること
- [ ] CI全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)