### PR TITLE
feat: ドラッグ中にドロップ拒否/警告の理由をリアルタイム表示

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -77,6 +77,7 @@ function SchedulePage() {
     dropZoneStatuses,
     activeOrder,
     previewTimes,
+    dropMessage,
     handleDragStart,
     handleDragOver,
     handleDragEnd,
@@ -152,6 +153,7 @@ function SchedulePage() {
             activeOrder={activeOrder}
             onSlotWidthChange={handleSlotWidthChange}
             previewTimes={previewTimes}
+            dropMessage={dropMessage}
           />
         </DndContext>
       </main>

--- a/web/src/components/gantt/GanttChart.tsx
+++ b/web/src/components/gantt/GanttChart.tsx
@@ -25,9 +25,11 @@ interface GanttChartProps {
   onSlotWidthChange?: (slotWidth: number) => void;
   /** ドラッグ中の時刻プレビュー（時間軸移動用） */
   previewTimes?: { startTime: string; endTime: string } | null;
+  /** ドロップ拒否/警告の理由テキスト */
+  dropMessage?: string | null;
 }
 
-export function GanttChart({ schedule, customers, violations, onOrderClick, dropZoneStatuses, unavailability, activeOrder, onSlotWidthChange, previewTimes }: GanttChartProps) {
+export function GanttChart({ schedule, customers, violations, onOrderClick, dropZoneStatuses, unavailability, activeOrder, onSlotWidthChange, previewTimes, dropMessage }: GanttChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [slotWidth, setSlotWidth] = useState(SLOT_WIDTH_PX);
 
@@ -80,6 +82,7 @@ export function GanttChart({ schedule, customers, violations, onOrderClick, drop
                 dayDate={schedule.date}
                 activeOrder={activeOrder}
                 previewTimes={previewTimes}
+                dropMessage={dropMessage}
               />
             ))}
             {/* ドラッグ中の時間帯ハイライト（全行横断） */}

--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -25,6 +25,8 @@ interface GanttRowProps {
   activeOrder?: Order | null;
   /** ドラッグ中の時刻プレビュー（時間軸移動用） */
   previewTimes?: { startTime: string; endTime: string } | null;
+  /** ドロップ拒否/警告の理由テキスト */
+  dropMessage?: string | null;
 }
 
 /** ゴーストバー用の薄い背景色（サービスタイプ別） */
@@ -45,7 +47,7 @@ const DROP_ZONE_STYLES: Record<DropZoneStatus, string> = {
 const SLOTS_PER_10MIN = 2;
 const TOTAL_10MIN_INTERVALS = (GANTT_END_HOUR - GANTT_START_HOUR) * 6; // 14h × 6 = 84
 
-export const GanttRow = memo(function GanttRow({ row, customers, violations, onOrderClick, dropZoneStatus = 'idle', index, unavailability, day, dayDate, activeOrder, previewTimes }: GanttRowProps) {
+export const GanttRow = memo(function GanttRow({ row, customers, violations, onOrderClick, dropZoneStatus = 'idle', index, unavailability, day, dayDate, activeOrder, previewTimes, dropMessage }: GanttRowProps) {
   const slotWidth = useSlotWidth();
   const pxPer10Min = SLOTS_PER_10MIN * slotWidth;
   const helperName = row.helper.name.short ?? `${row.helper.name.family}${row.helper.name.given}`;
@@ -183,6 +185,19 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
             );
           });
         })()}
+        {/* ドロップ拒否/警告の理由オーバーレイ */}
+        {isOver && dropMessage && (dropZoneStatus === 'invalid' || dropZoneStatus === 'warning') && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-20">
+            <span className={cn(
+              'px-2.5 py-1 rounded-md text-xs font-medium shadow-sm backdrop-blur-sm',
+              dropZoneStatus === 'invalid'
+                ? 'bg-red-50/90 text-red-700 border border-red-300'
+                : 'bg-yellow-50/90 text-yellow-700 border border-yellow-300'
+            )}>
+              {dropMessage}
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/hooks/useDragAndDrop.ts
+++ b/web/src/hooks/useDragAndDrop.ts
@@ -25,6 +25,7 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
   const [dropZoneStatuses, setDropZoneStatuses] = useState<Map<string, DropZoneStatus>>(new Map());
   const [activeOrder, setActiveOrder] = useState<Order | null>(null);
   const [previewTimes, setPreviewTimes] = useState<{ startTime: string; endTime: string } | null>(null);
+  const [dropMessage, setDropMessage] = useState<string | null>(null);
 
   const findOrder = useCallback(
     (orderId: string): Order | undefined => {
@@ -51,6 +52,7 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
       if (!dragData || !event.over) {
         setDropZoneStatuses(new Map());
         setPreviewTimes(null);
+        setDropMessage(null);
         return;
       }
 
@@ -72,12 +74,14 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
       // 未割当セクションへのドロップは常に許可（時間変更なし）
       if (targetHelperId === 'unassigned-section') {
         setDropZoneStatuses(new Map([['unassigned-section', 'valid']]));
+        setDropMessage(null);
         return;
       }
 
       // 同じヘルパー + 時間変更なし → idle
       if (dragData.sourceHelperId === targetHelperId && !hasTimeShift) {
         setDropZoneStatuses(new Map([[targetHelperId, 'idle']]));
+        setDropMessage(null);
         return;
       }
 
@@ -100,6 +104,13 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
           ? 'warning'
           : 'valid';
       setDropZoneStatuses(new Map([[targetHelperId, status]]));
+
+      const message = !result.allowed
+        ? result.reason
+        : result.warnings.length > 0
+          ? result.warnings[0]
+          : null;
+      setDropMessage(message);
     },
     [findOrder, helperRows, helpers, customers, unavailability, day, slotWidth]
   );
@@ -109,6 +120,7 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
       setDropZoneStatuses(new Map());
       setActiveOrder(null);
       setPreviewTimes(null);
+      setDropMessage(null);
 
       const dragData = event.active.data.current as DragData | undefined;
       if (!dragData || !event.over) return;
@@ -203,12 +215,14 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
     setDropZoneStatuses(new Map());
     setActiveOrder(null);
     setPreviewTimes(null);
+    setDropMessage(null);
   }, []);
 
   return {
     dropZoneStatuses,
     activeOrder,
     previewTimes,
+    dropMessage,
     handleDragStart,
     handleDragOver,
     handleDragEnd,


### PR DESCRIPTION
## Summary
- グレーアウト領域（希望休・勤務時間外等）にドラッグした際、行上に理由テキストをリアルタイム表示
- 拒否（赤ラベル）: 「○○は希望休（終日）です」「NGスタッフです」「時間が重複」等
- 警告（黄ラベル）: 「○○の勤務時間外です」
- 既存のリング色 + ドロップ後toastは維持

## Test plan
- [ ] 希望休ヘルパーの行にドラッグ → 赤ラベルで「希望休（終日）です」表示
- [ ] 勤務時間外の行にドラッグ → 黄ラベルで「勤務時間外です」表示
- [ ] NGスタッフの行にドラッグ → 赤ラベルで「NGスタッフです」表示
- [ ] 有効なドロップ先 → ラベル非表示（従来通りの緑リング）
- [ ] CI全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)