### PR TITLE
feat: デモ環境バナーをヘッダー上部に常時表示

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -42,6 +42,11 @@ export default function RootLayout({
       <body
         className={`${dmSans.variable} ${notoSansJP.variable} ${notoSerifJP.variable} ${geistMono.variable} antialiased`}
       >
+        {process.env.NEXT_PUBLIC_AUTH_MODE !== 'required' && (
+          <div className="bg-amber-500 text-white text-center text-xs py-1 font-medium tracking-wide">
+            デモ環境 — 本番データではありません
+          </div>
+        )}
         <Providers>
           {children}
         </Providers>


### PR DESCRIPTION
## Summary
- デモ環境（`NEXT_PUBLIC_AUTH_MODE !== 'required'`）のとき、ページ最上部にアンバーバナー「デモ環境 — 本番データではありません」を常時表示
- 本番環境（`AUTH_MODE=required`）では非表示
- `layout.tsx`のServer Componentでビルド時に環境変数を参照

## Test plan
- [ ] デモ環境でバナーが表示されること
- [ ] バナーがヘッダーの上に表示されること
- [ ] テキスト「デモ環境 — 本番データではありません」が正しく表示されること
- [ ] 既存テスト全パス

🤖 Generated with [Claude Code](https://claude.ai/code)