### PR TITLE
feat: ガントバーのテキスト視認性を大幅改善

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -138,6 +138,7 @@
   .shadow-brand-sm { box-shadow: 0 1px 3px -1px oklch(0.40 0.08 192 / 0.12), 0 1px 2px -1px oklch(0.40 0.08 192 / 0.06); }
   .shadow-brand    { box-shadow: 0 2px 8px -2px oklch(0.40 0.08 192 / 0.15), 0 1px 3px -1px oklch(0.40 0.08 192 / 0.08); }
   .shadow-brand-lg { box-shadow: 0 4px 16px -4px oklch(0.40 0.08 192 / 0.18), 0 2px 6px -2px oklch(0.40 0.08 192 / 0.10); }
+  .text-shadow-bar { text-shadow: 0 0 4px rgba(0,0,0,0.55), 0 1px 2px rgba(0,0,0,0.35), 0 0 1px rgba(0,0,0,0.3); }
 }
 
 @layer base {

--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -63,11 +63,12 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
       ref={setNodeRef}
       data-testid={`gantt-bar-${order.id}`}
       className={cn(
-        'absolute top-1 h-8 rounded-lg text-[11px] leading-8 px-2 truncate cursor-grab shadow-brand-sm',
+        'absolute top-1 h-8 rounded-lg text-xs font-medium leading-8 px-2 cursor-grab shadow-brand-sm',
+        'overflow-visible whitespace-nowrap text-shadow-bar',
         isDragging ? 'transition-none' : 'transition-all duration-150',
         colors.bar,
         colors.hover,
-        'hover:shadow-brand hover:brightness-105 hover:-translate-y-px',
+        'hover:shadow-brand hover:brightness-105 hover:-translate-y-px hover:z-20',
         hasViolation && violationType === 'error' && 'ring-2 ring-red-500 ring-offset-1',
         hasViolation && violationType === 'warning' && 'ring-2 ring-yellow-500 ring-offset-1',
         !hasViolation && order.manually_edited && 'ring-2 ring-blue-500 ring-offset-1',
@@ -79,7 +80,7 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
       {...attributes}
       {...listeners}
     >
-      {width > 20 ? customerName : ''}
+      {customerName}
     </button>
   );
 });


### PR DESCRIPTION
## Summary
- ガントバーのテキストが`truncate`で「伊藤...」「前田...」と省略されていた問題を修正
- `overflow-visible`でテキストをブロック外にはみ出し表示に変更
- 3層text-shadowによる暗いハロー効果でフォント周りに黒枠線相当の視認性を確保
- フォントサイズ12px化 + font-medium でテキストを際立たせる
- hover時にz-20で前面表示、重なった文字の確認が可能

## 変更ファイル
- `globals.css`: `.text-shadow-bar` ユーティリティ追加
- `GanttBar.tsx`: テキスト overflow + shadow + hover z-index

## Test plan
- [ ] 短い時間のオーダー（30分未満）で顧客名が完全に表示されること
- [ ] テキストがバーの右端を超えて表示されること
- [ ] テキストシャドウにより白文字が背景色に関わらず読めること
- [ ] hover時にバーが前面に表示され、重なった文字が確認できること
- [ ] ドラッグ＆ドロップが正常に動作すること
- [ ] 制約違反リング（赤/黄/青）が正常に表示されること
- [ ] 既存テスト全パス

🤖 Generated with [Claude Code](https://claude.ai/code)