### PR TITLE
fix: デモバナー文字サイズ拡大 + ゴースト同一行内ドラッグ追随修正

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
         className={`${dmSans.variable} ${notoSansJP.variable} ${notoSerifJP.variable} ${geistMono.variable} antialiased`}
       >
         {process.env.NEXT_PUBLIC_AUTH_MODE !== 'required' && (
-          <div className="bg-amber-500 text-white text-center text-xs py-1 font-medium tracking-wide">
+          <div className="bg-amber-500 text-white text-center text-sm py-1 font-medium tracking-wide">
             デモ環境 — 本番データではありません
           </div>
         )}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -80,6 +80,7 @@ function SchedulePage() {
     dropMessage,
     handleDragStart,
     handleDragOver,
+    handleDragMove,
     handleDragEnd,
     handleDragCancel,
   } = useDragAndDrop({
@@ -140,6 +141,7 @@ function SchedulePage() {
           sensors={sensors}
           onDragStart={handleDragStart}
           onDragOver={handleDragOver}
+          onDragMove={handleDragMove}
           onDragEnd={handleDragEnd}
           onDragCancel={handleDragCancel}
         >


### PR DESCRIPTION
## Summary
- デモバナーの文字サイズを `text-xs` → `text-sm` に変更（視認性向上）
- `onDragMove` ハンドラを追加し、同一行内の水平ドラッグでもゴーストプレビューが10分単位で追随するように修正
- `processPreview` 共通関数に抽出し、`lastPreviewRef` による重複計算スキップでパフォーマンス最適化

## 修正内容

### デモバナー
`text-xs`（12px）→ `text-sm`（14px）に変更。小さすぎて読めないとの指摘対応。

### ゴースト追随
**根本原因**: `@dnd-kit/core` の `onDragOver` は droppable ターゲットが変わったときのみ発火。同一行内の水平ドラッグでは発火しないため、`previewTimes` と `dropZoneStatus` が更新されなかった。

**修正**: `onDragMove`（毎ピクセル発火）を追加し、共通の `processPreview` 関数で処理。`useRef` で前回のスナップ値（ターゲットID + シフト分数）を保持し、同一値なら再計算をスキップすることで高頻度発火のパフォーマンス問題を回避。

## Test plan
- [ ] デモバナーの文字が読みやすいサイズで表示される
- [ ] ガントバーを同一行内で水平にドラッグ → ゴーストが10分単位で追随
- [ ] 行をまたぐドラッグでもゴースト表示が正常
- [ ] 既存の全テスト157件パス ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)