### PR TITLE
feat: OrderDetailPanelに手動編集済みバッジを追加

### DIFF
--- a/web/src/components/schedule/OrderDetailPanel.tsx
+++ b/web/src/components/schedule/OrderDetailPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Clock, MapPin, User, AlertTriangle } from 'lucide-react';
+import { Clock, MapPin, User, AlertTriangle, Pencil } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import {
   Sheet,
@@ -99,6 +99,14 @@ export function OrderDetailPanel({
                 {STATUS_LABELS[order.status]}
               </Badge>
             </div>
+            {order.manually_edited && (
+              <div className="flex items-center gap-2 text-sm">
+                <Pencil className="h-4 w-4 text-blue-500" />
+                <Badge variant="outline" className="bg-blue-500/10 text-blue-600 border-blue-500/30">
+                  手動編集済み
+                </Badge>
+              </div>
+            )}
           </div>
 
           {/* 割当スタッフ */}

--- a/web/src/components/schedule/__tests__/OrderDetailPanel.test.tsx
+++ b/web/src/components/schedule/__tests__/OrderDetailPanel.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OrderDetailPanel } from '../OrderDetailPanel';
+import type { Order } from '@/types';
+
+// Radix Sheet uses portal — mock to render inline
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  SheetContent: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    <div {...props}>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 'order-1',
+    customer_id: 'cust-1',
+    week_start_date: new Date('2026-02-09'),
+    date: new Date('2026-02-09'),
+    start_time: '09:00',
+    end_time: '10:00',
+    service_type: 'physical_care',
+    assigned_staff_ids: [],
+    status: 'pending',
+    manually_edited: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  assignedHelpers: [],
+  violations: [],
+  open: true,
+  onClose: vi.fn(),
+};
+
+describe('OrderDetailPanel - 手動編集バッジ', () => {
+  it('manually_edited: true → 「手動編集済み」バッジが表示される', () => {
+    const order = makeOrder({ manually_edited: true });
+    render(<OrderDetailPanel order={order} {...defaultProps} />);
+
+    expect(screen.getByText('手動編集済み')).toBeInTheDocument();
+  });
+
+  it('manually_edited: false → 「手動編集済み」バッジが表示されない', () => {
+    const order = makeOrder({ manually_edited: false });
+    render(<OrderDetailPanel order={order} {...defaultProps} />);
+
+    expect(screen.queryByText('手動編集済み')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- OrderDetailPanel（右サイドシート）の基本情報セクションに「手動編集済み」バッジを追加
- `manually_edited: true` のオーダーでPencilアイコン付き青バッジ（`bg-blue-500/10 text-blue-600`）を表示
- GanttBarの青リング表示（`ring-blue-500`）と視覚的に統一

## Test plan
- [x] `manually_edited: true` → 「手動編集済み」バッジが表示される（ユニットテスト）
- [x] `manually_edited: false` → バッジが表示されない（ユニットテスト）
- [ ] ローカルで手動D&D後にバーをクリック → 「手動編集済み」バッジ表示を確認
- [ ] CI全ジョブグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)