### PR TITLE
feat: 休日表示の視認性改善（斜線強調・バッジ強化）

### DIFF
--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -94,7 +94,7 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
     <div className={cn(
       'flex border-b border-border/50 transition-colors duration-100',
       isDayOff
-        ? 'bg-muted/50'
+        ? 'bg-muted/60'
         : isEven ? 'bg-card' : 'bg-muted/15',
       !isDayOff && 'hover:bg-accent/40'
     )}>
@@ -108,7 +108,7 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
       >
         <span className="truncate">{helperName}</span>
         {isDayOff && (
-          <span className="shrink-0 text-[10px] px-1 py-0.5 rounded bg-muted-foreground/15 text-muted-foreground/70 leading-none">
+          <span className="shrink-0 text-[11px] px-1.5 py-0.5 rounded bg-gray-400/20 text-gray-500 font-medium leading-none">
             休
           </span>
         )}

--- a/web/src/components/gantt/UnavailableBlocksOverlay.tsx
+++ b/web/src/components/gantt/UnavailableBlocksOverlay.tsx
@@ -10,18 +10,18 @@ interface UnavailableBlocksOverlayProps {
 const BLOCK_STYLES: Record<UnavailableBlockType, { background: string; backgroundColor: string }> = {
   off_hours: {
     background:
-      'repeating-linear-gradient(135deg, transparent, transparent 3px, rgba(0,0,0,0.08) 3px, rgba(0,0,0,0.08) 4px)',
-    backgroundColor: 'rgba(0,0,0,0.05)',
+      'repeating-linear-gradient(135deg, transparent, transparent 3px, rgba(0,0,0,0.12) 3px, rgba(0,0,0,0.12) 4px)',
+    backgroundColor: 'rgba(0,0,0,0.04)',
   },
   day_off: {
     background:
-      'repeating-linear-gradient(135deg, transparent, transparent 4px, rgba(0,0,0,0.10) 4px, rgba(0,0,0,0.10) 5px)',
-    backgroundColor: 'rgba(0,0,0,0.08)',
+      'repeating-linear-gradient(135deg, transparent, transparent 3px, rgba(0,0,0,0.18) 3px, rgba(0,0,0,0.18) 5px)',
+    backgroundColor: 'rgba(0,0,0,0.12)',
   },
   unavailable: {
     background:
-      'repeating-linear-gradient(135deg, transparent, transparent 4px, rgba(220,80,80,0.15) 4px, rgba(220,80,80,0.15) 5px)',
-    backgroundColor: 'rgba(220,80,80,0.08)',
+      'repeating-linear-gradient(135deg, transparent, transparent 3px, rgba(220,80,80,0.25) 3px, rgba(220,80,80,0.25) 5px)',
+    backgroundColor: 'rgba(220,80,80,0.12)',
   },
 };
 


### PR DESCRIPTION
## Summary
- 非勤務日(`day_off`)・希望休(`unavailable`)の斜線オーバーレイのopacity/線幅を引き上げ、休みエリアを明確に識別可能に
- 勤務時間外(`off_hours`)は微かな表示を維持しつつストライプの視認性を若干向上
- 「休」バッジのフォントサイズ・パディング・コントラストを強化し見逃しを防止
- 非勤務日行の背景色を`bg-muted/50`→`bg-muted/60`に引き上げ

## 変更詳細

### UnavailableBlocksOverlay.tsx — BLOCK_STYLES
| タイプ | 変更前 斜線/背景 | 変更後 斜線/背景 |
|--------|----------------|----------------|
| off_hours | 8% / 5% | 12% / 4% |
| day_off | 10% / 8% | 18% / 12% + 線幅拡大 |
| unavailable | 15% / 8% | 25% / 12% + 線幅拡大 |

### GanttRow.tsx — 「休」バッジ
| 属性 | 変更前 | 変更後 |
|------|--------|--------|
| font-size | text-[10px] | text-[11px] |
| padding | px-1 | px-1.5 |
| bg | bg-muted-foreground/15 | bg-gray-400/20 |
| color | text-muted-foreground/70 | text-gray-500 |
| weight | — | font-medium |

## Test plan
- [x] `npx vitest run` — 全159テストパス
- [x] `npm run build` — ビルド成功
- [ ] ローカル目視: 日曜タブで非勤務日・希望休行の視認性確認
- [ ] CI全ジョブグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)