### PR TITLE
feat: 外部連携ID入力UI + 分断勤務フラグを実装

### DIFF
--- a/docs/schema/firestore-schema.md
+++ b/docs/schema/firestore-schema.md
@@ -56,6 +56,7 @@
 | available_hours | `{ min, max }` | Yes | 対応可能時間（時/週） |
 | customer_training_status | `Record<string, TrainingStatus>` | Yes | 利用者別研修状態 |
 | employment_type | `'full_time' \| 'part_time'` | Yes | 雇用形態 |
+| split_shift_allowed | boolean | No | 分断勤務可（午前・午後の非連続勤務） |
 | created_at | Timestamp | Yes | 作成日時 |
 | updated_at | Timestamp | Yes | 更新日時 |
 

--- a/optimizer/src/optimizer/data/firestore_loader.py
+++ b/optimizer/src/optimizer/data/firestore_loader.py
@@ -146,6 +146,7 @@ def load_helpers(db: firestore.Client) -> list[Helper]:
                 ),
                 customer_training_status=d.get("customer_training_status", {}),
                 employment_type=d.get("employment_type", "full_time"),
+                split_shift_allowed=d.get("split_shift_allowed", False),
             )
         )
     return helpers

--- a/optimizer/src/optimizer/models/helper.py
+++ b/optimizer/src/optimizer/models/helper.py
@@ -23,3 +23,4 @@ class Helper(BaseModel):
     available_hours: HoursRange
     customer_training_status: dict[str, TrainingStatus] = {}
     employment_type: EmploymentType
+    split_shift_allowed: bool = False

--- a/optimizer/tests/test_firestore_loader.py
+++ b/optimizer/tests/test_firestore_loader.py
@@ -263,6 +263,32 @@ class TestLoadHelpers:
         h = load_helpers(db)[0]
         assert h.customer_training_status.get("C010") == "training"
 
+    def test_split_shift_allowed_default(self) -> None:
+        """split_shift_allowedが未設定の場合はFalse"""
+        db = _mock_db_with_collections({"helpers": [self._sample_helper_doc()]})
+        h = load_helpers(db)[0]
+        assert h.split_shift_allowed is False
+
+    def test_split_shift_allowed_true(self) -> None:
+        """split_shift_allowed=Trueが正しく読み込まれる"""
+        doc = _mock_doc(
+            "H002",
+            {
+                "name": {"family": "田中", "given": "太郎"},
+                "qualifications": [],
+                "can_physical_care": False,
+                "transportation": "bicycle",
+                "weekly_availability": {},
+                "preferred_hours": {"min": 10.0, "max": 20.0},
+                "available_hours": {"min": 8.0, "max": 24.0},
+                "employment_type": "part_time",
+                "split_shift_allowed": True,
+            },
+        )
+        db = _mock_db_with_collections({"helpers": [doc]})
+        h = load_helpers(db)[0]
+        assert h.split_shift_allowed is True
+
 
 # --- Orderローダーテスト ---
 

--- a/shared/types/helper.ts
+++ b/shared/types/helper.ts
@@ -20,6 +20,7 @@ export interface Helper {
   available_hours: { min: number; max: number };
   customer_training_status: Record<string, TrainingStatus>;
   employment_type: EmploymentType;
+  split_shift_allowed?: boolean;
   created_at: Timestamp;
   updated_at: Timestamp;
 }

--- a/web/src/components/masters/CustomerEditDialog.tsx
+++ b/web/src/components/masters/CustomerEditDialog.tsx
@@ -252,6 +252,40 @@ export function CustomerEditDialog({
             <Input id="notes" {...register('notes')} placeholder="特記事項" />
           </div>
 
+          {/* 外部連携ID */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">外部連携ID（任意）</Label>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="kaiso_id" className="text-xs text-muted-foreground">介ソルID</Label>
+                <Input
+                  id="kaiso_id"
+                  {...register('kaiso_id')}
+                  placeholder="KS-001"
+                  className="h-8 text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="karakara_id" className="text-xs text-muted-foreground">カカラID</Label>
+                <Input
+                  id="karakara_id"
+                  {...register('karakara_id')}
+                  placeholder="KK-001"
+                  className="h-8 text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="cura_id" className="text-xs text-muted-foreground">CURA ID</Label>
+                <Input
+                  id="cura_id"
+                  {...register('cura_id')}
+                  placeholder="CR-001"
+                  className="h-8 text-sm"
+                />
+              </div>
+            </div>
+          </div>
+
           {/* NGスタッフ */}
           <Controller
             name="ng_staff_ids"
@@ -338,6 +372,9 @@ function getDefaults(customer?: Customer): CustomerFormValues {
       household_id: '',
       notes: '',
       irregular_patterns: [],
+      kaiso_id: '',
+      karakara_id: '',
+      cura_id: '',
     };
   }
   return {
@@ -351,5 +388,8 @@ function getDefaults(customer?: Customer): CustomerFormValues {
     household_id: customer.household_id ?? '',
     notes: customer.notes ?? '',
     irregular_patterns: customer.irregular_patterns ?? [],
+    kaiso_id: customer.kaiso_id ?? '',
+    karakara_id: customer.karakara_id ?? '',
+    cura_id: customer.cura_id ?? '',
   };
 }

--- a/web/src/components/masters/HelperEditDialog.tsx
+++ b/web/src/components/masters/HelperEditDialog.tsx
@@ -83,6 +83,7 @@ export function HelperEditDialog({
     const saveData = {
       ...data,
       customer_training_status: data.customer_training_status ?? {},
+      split_shift_allowed: data.split_shift_allowed ?? false,
     };
     try {
       if (isNew) {
@@ -177,6 +178,20 @@ export function HelperEditDialog({
                     onCheckedChange={field.onChange}
                   />
                   身体介護対応可
+                </label>
+              )}
+            />
+
+            <Controller
+              name="split_shift_allowed"
+              control={control}
+              render={({ field }) => (
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={field.value ?? false}
+                    onCheckedChange={field.onChange}
+                  />
+                  分断勤務可（午前・午後の非連続勤務）
                 </label>
               )}
             />
@@ -369,6 +384,7 @@ function getDefaults(helper?: Helper): HelperFormValues {
       available_hours: { min: 0, max: 40 },
       employment_type: 'part_time',
       customer_training_status: {},
+      split_shift_allowed: false,
     };
   }
   return {
@@ -381,5 +397,6 @@ function getDefaults(helper?: Helper): HelperFormValues {
     available_hours: helper.available_hours,
     employment_type: helper.employment_type,
     customer_training_status: helper.customer_training_status ?? {},
+    split_shift_allowed: helper.split_shift_allowed ?? false,
   };
 }

--- a/web/src/lib/validation/__tests__/schemas.test.ts
+++ b/web/src/lib/validation/__tests__/schemas.test.ts
@@ -338,6 +338,37 @@ describe('customerSchema', () => {
     };
     expect(customerSchema.safeParse(data).success).toBe(false);
   });
+
+  // ---- 外部連携ID ----
+
+  it('外部連携IDなしでパースできる', () => {
+    expect(customerSchema.safeParse(validCustomer()).success).toBe(true);
+  });
+
+  it('kaiso_idを設定できる', () => {
+    const data = { ...validCustomer(), kaiso_id: 'KS-001' };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('karakara_idを設定できる', () => {
+    const data = { ...validCustomer(), karakara_id: 'KK-001' };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('cura_idを設定できる', () => {
+    const data = { ...validCustomer(), cura_id: 'CR-001' };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('全外部連携IDを同時に設定できる', () => {
+    const data = {
+      ...validCustomer(),
+      kaiso_id: 'KS-001',
+      karakara_id: 'KK-001',
+      cura_id: 'CR-001',
+    };
+    expect(customerSchema.safeParse(data).success).toBe(true);
+  });
 });
 
 // ================================================================
@@ -438,6 +469,22 @@ describe('helperSchema', () => {
       },
     };
     expect(helperSchema.safeParse(data).success).toBe(false);
+  });
+
+  // ---- split_shift_allowed ----
+
+  it('split_shift_allowedなしでパースできる', () => {
+    expect(helperSchema.safeParse(validHelper()).success).toBe(true);
+  });
+
+  it('split_shift_allowed=trueでパースできる', () => {
+    const data = { ...validHelper(), split_shift_allowed: true };
+    expect(helperSchema.safeParse(data).success).toBe(true);
+  });
+
+  it('split_shift_allowed=falseでパースできる', () => {
+    const data = { ...validHelper(), split_shift_allowed: false };
+    expect(helperSchema.safeParse(data).success).toBe(true);
   });
 });
 

--- a/web/src/lib/validation/schemas.ts
+++ b/web/src/lib/validation/schemas.ts
@@ -66,6 +66,9 @@ export const customerSchema = z.object({
   service_manager: z.string().min(1, 'サービス提供責任者は必須です'),
   notes: z.string().optional(),
   irregular_patterns: z.array(irregularPatternSchema).optional(),
+  kaiso_id: z.string().optional(),
+  karakara_id: z.string().optional(),
+  cura_id: z.string().optional(),
 });
 
 export type CustomerFormValues = z.infer<typeof customerSchema>;
@@ -92,6 +95,7 @@ export const helperSchema = z.object({
   }),
   employment_type: z.enum(['full_time', 'part_time']),
   customer_training_status: trainingStatusSchema.optional(),
+  split_shift_allowed: z.boolean().optional(),
 });
 
 export type HelperFormValues = z.infer<typeof helperSchema>;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -70,6 +70,9 @@ export interface Customer {
   irregular_patterns?: IrregularPattern[];
   household_id?: string;
   service_manager: string;
+  kaiso_id?: string;
+  karakara_id?: string;
+  cura_id?: string;
   notes?: string;
   created_at: Date;
   updated_at: Date;
@@ -86,6 +89,7 @@ export interface Helper {
   available_hours: { min: number; max: number };
   customer_training_status: Record<string, TrainingStatus>;
   employment_type: EmploymentType;
+  split_shift_allowed?: boolean;
   created_at: Date;
   updated_at: Date;
 }


### PR DESCRIPTION
## Summary
Closes #83, Closes #81

- **#83**: 利用者編集ダイアログに外部連携ID（介ソルID、カカラID、CURA ID）の入力フィールドを追加
- **#81**: ヘルパーに分断勤務可フラグ（split_shift_allowed）を追加し、編集UIとバックエンドモデルを対応

## Changes
| カテゴリ | ファイル | 内容 |
|---------|---------|------|
| 型定義 | `web/src/types/index.ts` | Customer に kaiso_id等、Helper に split_shift_allowed 追加 |
| 型定義 | `shared/types/helper.ts` | split_shift_allowed フィールド追加 |
| バリデーション | `web/src/lib/validation/schemas.ts` | 両スキーマにフィールド追加 |
| テスト | `web/src/lib/validation/__tests__/schemas.test.ts` | 8件の新規テスト |
| UI | `web/src/components/masters/CustomerEditDialog.tsx` | 外部連携IDセクション追加 |
| UI | `web/src/components/masters/HelperEditDialog.tsx` | 分断勤務チェックボックス追加 |
| Python | `optimizer/src/optimizer/models/helper.py` | split_shift_allowed フィールド追加 |
| Python | `optimizer/src/optimizer/data/firestore_loader.py` | split_shift_allowed 読み込み追加 |
| テスト | `optimizer/tests/test_firestore_loader.py` | 2件の新規テスト |
| ドキュメント | `docs/schema/firestore-schema.md` | split_shift_allowed 追加 |

## Test plan
- [x] Zodスキーマテスト 57件パス（+8件）
- [x] Web全テスト 247件パス
- [x] TypeScript型チェック通過
- [ ] Python ローダーテスト（CI環境で実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)