### PR TITLE
fix: Helper.genderをrequiredに統一・walk記述を実態（30分上限）に修正

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -75,8 +75,8 @@ cd optimizer && .venv/bin/pytest tests/ -v  # pytest
   - 利用者編集ダイアログに外部連携ID（介ソルID / カカラID / CURA ID）入力フィールド追加
   - ヘルパーに `split_shift_allowed` フラグ追加（UI + バックエンドモデル）
 
-- **PR #88** ✅: 徒歩移動スタッフへの訪問距離上限制約を追加（Closes #84）
-  - Optimizer: `walking_distance_km` パラメータ追加（デフォルト2.0km）
+- **PR #88** ✅: 徒歩移動スタッフへの訪問移動時間上限制約を追加（Closes #84）
+  - Optimizer: `MAX_WALK_TRAVEL_MINUTES = 30`（30分）を超えるペアへの割り当てを禁止
   - API/Schema: `WalkingDistanceConstraint` モデル、routes.py に制約適用
   - Firestore loader: ヘルパーの `transport_mode` 読み込み対応
 

--- a/shared/types/helper.ts
+++ b/shared/types/helper.ts
@@ -21,7 +21,7 @@ export interface Helper {
   available_hours: { min: number; max: number };
   customer_training_status: Record<string, TrainingStatus>;
   employment_type: EmploymentType;
-  gender?: Gender;
+  gender: Gender;
   split_shift_allowed?: boolean;
   created_at: Timestamp;
   updated_at: Timestamp;

--- a/web/src/lib/constraints/__tests__/checker.test.ts
+++ b/web/src/lib/constraints/__tests__/checker.test.ts
@@ -34,6 +34,7 @@ function makeHelper(overrides: Partial<Helper> = {}): Helper {
     available_hours: { min: 4, max: 8 },
     customer_training_status: {},
     employment_type: 'full_time',
+    gender: 'female',
     created_at: new Date(),
     updated_at: new Date(),
     ...overrides,

--- a/web/src/lib/dnd/__tests__/validation.test.ts
+++ b/web/src/lib/dnd/__tests__/validation.test.ts
@@ -36,6 +36,7 @@ function makeHelper(overrides: Partial<Helper> = {}): Helper {
     available_hours: { min: 0, max: 40 },
     customer_training_status: {},
     employment_type: 'full_time',
+    gender: 'female',
     created_at: new Date(),
     updated_at: new Date(),
     ...overrides,

--- a/web/src/lib/report/__tests__/aggregation.test.ts
+++ b/web/src/lib/report/__tests__/aggregation.test.ts
@@ -41,6 +41,7 @@ function makeHelper(id: string, family: string, given: string): Helper {
     available_hours: { min: 20, max: 40 },
     customer_training_status: {},
     employment_type: 'full_time',
+    gender: 'female',
     created_at: new Date(),
     updated_at: new Date(),
   };

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -100,7 +100,7 @@ export interface Helper {
   available_hours: { min: number; max: number };
   customer_training_status: Record<string, TrainingStatus>;
   employment_type: EmploymentType;
-  gender?: Gender;
+  gender: Gender;
   split_shift_allowed?: boolean;
   created_at: Date;
   updated_at: Date;


### PR DESCRIPTION
## Summary
- `Helper.gender` を `optional` → `required` に統一（Zodスキーマ・Python・Seedは既にrequired済み）
- テストの `makeHelper()` に `gender: 'female'` デフォルト値を追加（checker / dnd / aggregation）
- `docs/handoff/LATEST.md` のPR#88記述を「距離2.0km」→「時間30分（`MAX_WALK_TRAVEL_MINUTES = 30`）」に修正（実態と一致）

## Test plan
- [x] TypeScript型チェック: 既存エラーなし（firestore/__tests__のTS2556は既存・無関係）
- [x] Web 247件 全パス
- [ ] PR をレビューしてマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)