### PR TITLE
feat: スケジュール週全体ビュー（ピボット表示）を追加

### DIFF
--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -4,7 +4,7 @@ import { memo } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import { Check, X } from 'lucide-react';
-import { timeToColumn } from './constants';
+import { timeToColumn, SERVICE_COLORS } from './constants';
 import { useSlotWidth } from './GanttScaleContext';
 import type { Order, Customer } from '@/types';
 import type { DragData } from '@/lib/dnd/types';
@@ -19,41 +19,6 @@ interface GanttBarProps {
   /** ドラッグ元のヘルパーID（null = 未割当） */
   sourceHelperId: string | null;
 }
-
-const SERVICE_COLORS: Record<string, { bar: string; hover: string }> = {
-  physical_care: {
-    bar: 'bg-gradient-to-r from-[oklch(0.55_0.15_225)] to-[oklch(0.60_0.12_205)] text-white',
-    hover: 'hover:from-[oklch(0.50_0.16_225)] hover:to-[oklch(0.55_0.13_205)]',
-  },
-  daily_living: {
-    bar: 'bg-gradient-to-r from-[oklch(0.55_0.15_162)] to-[oklch(0.60_0.12_147)] text-white',
-    hover: 'hover:from-[oklch(0.50_0.16_162)] hover:to-[oklch(0.55_0.13_147)]',
-  },
-  mixed: {
-    bar: 'bg-gradient-to-r from-[oklch(0.58_0.14_50)] to-[oklch(0.63_0.11_35)] text-white',
-    hover: 'hover:from-[oklch(0.53_0.15_50)] hover:to-[oklch(0.58_0.12_35)]',
-  },
-  prevention: {
-    bar: 'bg-gradient-to-r from-[oklch(0.60_0.12_298)] to-[oklch(0.65_0.10_278)] text-white',
-    hover: 'hover:from-[oklch(0.55_0.13_298)] hover:to-[oklch(0.60_0.11_278)]',
-  },
-  private: {
-    bar: 'bg-gradient-to-r from-[oklch(0.60_0.12_350)] to-[oklch(0.65_0.10_330)] text-white',
-    hover: 'hover:from-[oklch(0.55_0.13_350)] hover:to-[oklch(0.60_0.11_330)]',
-  },
-  disability: {
-    bar: 'bg-gradient-to-r from-[oklch(0.58_0.14_120)] to-[oklch(0.63_0.11_105)] text-white',
-    hover: 'hover:from-[oklch(0.53_0.15_120)] hover:to-[oklch(0.58_0.12_105)]',
-  },
-  transport_support: {
-    bar: 'bg-gradient-to-r from-[oklch(0.60_0.12_200)] to-[oklch(0.65_0.10_185)] text-white',
-    hover: 'hover:from-[oklch(0.55_0.13_200)] hover:to-[oklch(0.60_0.11_185)]',
-  },
-  severe_visiting: {
-    bar: 'bg-gradient-to-r from-[oklch(0.53_0.18_25)] to-[oklch(0.58_0.15_10)] text-white',
-    hover: 'hover:from-[oklch(0.48_0.19_25)] hover:to-[oklch(0.53_0.16_10)]',
-  },
-};
 
 export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, violationType, onClick, sourceHelperId }: GanttBarProps) {
   const slotWidth = useSlotWidth();

--- a/web/src/components/gantt/WeeklyGanttChart.tsx
+++ b/web/src/components/gantt/WeeklyGanttChart.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import { useMemo, useRef, useState, useEffect } from 'react';
+import { addDays, format } from 'date-fns';
+import { cn } from '@/lib/utils';
+import { SERVICE_COLORS, GANTT_START_HOUR, GANTT_END_HOUR, timeToMinutes } from './constants';
+import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
+import type { DayOfWeek, Helper, Customer, Order, StaffUnavailability } from '@/types';
+import type { DaySchedule } from '@/hooks/useScheduleData';
+
+const HELPER_COL_WIDTH = 100;
+const ROW_HEIGHT = 28;
+const GANTT_START_MIN = GANTT_START_HOUR * 60;
+const GANTT_END_MIN = GANTT_END_HOUR * 60;
+const GANTT_DURATION_MIN = GANTT_END_MIN - GANTT_START_MIN;
+
+export interface WeeklyGanttChartProps {
+  weekStart: Date;
+  getDaySchedule: (day: DayOfWeek, date: Date) => DaySchedule;
+  helpers: Map<string, Helper>;
+  customers: Map<string, Customer>;
+  unavailability: StaffUnavailability[];
+  onDayClick: (day: DayOfWeek) => void;
+  onOrderClick?: (order: Order) => void;
+}
+
+function getDayDate(weekStart: Date, day: DayOfWeek): Date {
+  const idx = DAY_OF_WEEK_ORDER.indexOf(day);
+  return addDays(weekStart, idx);
+}
+
+function isWorkingDay(helper: Helper, day: DayOfWeek): boolean {
+  const slots = helper.weekly_availability[day];
+  return !!(slots && slots.length > 0);
+}
+
+function isUnavailableAllDay(
+  helper: Helper,
+  day: DayOfWeek,
+  dayDate: Date,
+  unavailability: StaffUnavailability[],
+): boolean {
+  const helperUnavail = unavailability.find((u) => u.staff_id === helper.id);
+  if (!helperUnavail) return false;
+  for (const slot of helperUnavail.unavailable_slots) {
+    if (!slot.all_day) continue;
+    const d = slot.date;
+    if (
+      d.getFullYear() === dayDate.getFullYear() &&
+      d.getMonth() === dayDate.getMonth() &&
+      d.getDate() === dayDate.getDate()
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+interface WeeklyMiniBarProps {
+  order: Order;
+  customer?: Customer;
+  dayColWidth: number;
+  onDayClick: () => void;
+}
+
+function WeeklyMiniBar({ order, customer, dayColWidth, onDayClick }: WeeklyMiniBarProps) {
+  const startMin = timeToMinutes(order.start_time);
+  const endMin = timeToMinutes(order.end_time);
+  const left = Math.max(0, ((startMin - GANTT_START_MIN) / GANTT_DURATION_MIN) * dayColWidth);
+  const width = Math.max(3, ((endMin - startMin) / GANTT_DURATION_MIN) * dayColWidth);
+
+  const colors = SERVICE_COLORS[order.service_type] ?? SERVICE_COLORS.physical_care;
+  const customerName = customer
+    ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+    : order.customer_id;
+
+  return (
+    <button
+      className={cn(
+        'absolute top-0.5 rounded-sm overflow-hidden',
+        'cursor-pointer',
+        colors.bar,
+      )}
+      style={{
+        left,
+        width,
+        height: ROW_HEIGHT - 6,
+      }}
+      title={`${customerName} ${order.start_time}-${order.end_time}`}
+      onClick={onDayClick}
+    />
+  );
+}
+
+interface WeeklyDayCellProps {
+  orders: Order[];
+  customers: Map<string, Customer>;
+  dayColWidth: number;
+  isNonWorking: boolean;
+  onDayClick: () => void;
+}
+
+function WeeklyDayCell({ orders, customers, dayColWidth, isNonWorking, onDayClick }: WeeklyDayCellProps) {
+  return (
+    <div
+      className={cn(
+        'relative border-r flex-shrink-0',
+        isNonWorking && 'bg-muted/40',
+      )}
+      style={{ width: dayColWidth, height: ROW_HEIGHT }}
+    >
+      {orders.map((order) => (
+        <WeeklyMiniBar
+          key={order.id}
+          order={order}
+          customer={customers.get(order.customer_id)}
+          dayColWidth={dayColWidth}
+          onDayClick={onDayClick}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface WeeklyHelperRowProps {
+  helper: Helper;
+  schedules: Map<DayOfWeek, DaySchedule>;
+  customers: Map<string, Customer>;
+  dayColWidth: number;
+  unavailability: StaffUnavailability[];
+  weekStart: Date;
+  onDayClick: (day: DayOfWeek) => void;
+}
+
+function WeeklyHelperRow({
+  helper,
+  schedules,
+  customers,
+  dayColWidth,
+  unavailability,
+  weekStart,
+  onDayClick,
+}: WeeklyHelperRowProps) {
+  const helperName = helper.name.short ?? `${helper.name.family}${helper.name.given}`;
+
+  return (
+    <div className="flex border-b" style={{ height: ROW_HEIGHT }}>
+      <div
+        className="sticky left-0 z-10 flex items-center bg-background border-r px-2 shrink-0 text-xs font-medium truncate"
+        style={{ width: HELPER_COL_WIDTH, height: ROW_HEIGHT }}
+        title={helperName}
+      >
+        {helperName}
+      </div>
+      {DAY_OF_WEEK_ORDER.map((day) => {
+        const schedule = schedules.get(day);
+        const helperRow = schedule?.helperRows.find((r) => r.helper.id === helper.id);
+        const orders = helperRow?.orders ?? [];
+        const dayDate = getDayDate(weekStart, day);
+        const nonWorking =
+          !isWorkingDay(helper, day) || isUnavailableAllDay(helper, day, dayDate, unavailability);
+
+        return (
+          <WeeklyDayCell
+            key={day}
+            orders={orders}
+            customers={customers}
+            dayColWidth={dayColWidth}
+            isNonWorking={nonWorking}
+            onDayClick={() => onDayClick(day)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+interface WeeklyUnassignedRowProps {
+  schedules: Map<DayOfWeek, DaySchedule>;
+  dayColWidth: number;
+  onDayClick: (day: DayOfWeek) => void;
+}
+
+function WeeklyUnassignedRow({ schedules, dayColWidth, onDayClick }: WeeklyUnassignedRowProps) {
+  const hasCounts = DAY_OF_WEEK_ORDER.some(
+    (day) => (schedules.get(day)?.unassignedOrders.length ?? 0) > 0,
+  );
+  if (!hasCounts) return null;
+
+  return (
+    <div className="flex border-b bg-red-50/30" data-testid="weekly-unassigned-row">
+      <div
+        className="sticky left-0 z-10 flex items-center bg-red-50/30 border-r px-2 shrink-0 text-xs font-medium text-muted-foreground"
+        style={{ width: HELPER_COL_WIDTH, height: ROW_HEIGHT }}
+      >
+        未割当
+      </div>
+      {DAY_OF_WEEK_ORDER.map((day) => {
+        const count = schedules.get(day)?.unassignedOrders.length ?? 0;
+        return (
+          <button
+            key={day}
+            data-testid={`weekly-unassigned-${day}`}
+            className={cn(
+              'border-r flex items-center justify-center text-xs flex-shrink-0',
+              count > 0
+                ? 'text-red-600 font-medium cursor-pointer hover:bg-red-50'
+                : 'text-muted-foreground cursor-default',
+            )}
+            style={{ width: dayColWidth, height: ROW_HEIGHT }}
+            onClick={() => count > 0 && onDayClick(day)}
+            title={count > 0 ? `${count}件の未割当` : undefined}
+          >
+            {count > 0 && (
+              <span
+                data-testid={`weekly-unassigned-badge-${day}`}
+                className="rounded-full bg-red-100 text-red-600 px-1.5 py-0.5 text-[10px] font-medium"
+              >
+                {count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function WeeklyGanttChart({
+  weekStart,
+  getDaySchedule,
+  helpers,
+  customers,
+  unavailability,
+  onDayClick,
+}: WeeklyGanttChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      setContainerWidth(width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const dayColWidth = Math.max(60, (containerWidth - HELPER_COL_WIDTH) / 7);
+
+  const schedules = useMemo(() => {
+    const map = new Map<DayOfWeek, DaySchedule>();
+    for (const day of DAY_OF_WEEK_ORDER) {
+      const dayDate = getDayDate(weekStart, day);
+      map.set(day, getDaySchedule(day, dayDate));
+    }
+    return map;
+  }, [weekStart, getDaySchedule]);
+
+  const helperList = useMemo(() => Array.from(helpers.values()), [helpers]);
+
+  return (
+    <div ref={containerRef} className="w-full overflow-auto">
+      <div>
+        {/* ヘッダー行 */}
+        <div className="flex border-b sticky top-0 z-20 bg-background" data-testid="weekly-header">
+          <div
+            className="sticky left-0 z-30 bg-background border-r shrink-0"
+            style={{ width: HELPER_COL_WIDTH }}
+          />
+          {DAY_OF_WEEK_ORDER.map((day, idx) => {
+            const date = addDays(weekStart, idx);
+            return (
+              <button
+                key={day}
+                data-testid={`weekly-day-header-${day}`}
+                className="border-r flex-shrink-0 flex flex-col items-center justify-center py-1 hover:bg-accent text-xs font-medium"
+                style={{ width: dayColWidth }}
+                onClick={() => onDayClick(day)}
+              >
+                <span>{DAY_OF_WEEK_LABELS[day]}</span>
+                <span className="text-muted-foreground text-[10px]">{format(date, 'M/d')}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* ヘルパー行 */}
+        {helperList.map((helper) => (
+          <WeeklyHelperRow
+            key={helper.id}
+            helper={helper}
+            schedules={schedules}
+            customers={customers}
+            dayColWidth={dayColWidth}
+            unavailability={unavailability}
+            weekStart={weekStart}
+            onDayClick={onDayClick}
+          />
+        ))}
+
+        {/* 未割当行 */}
+        <WeeklyUnassignedRow
+          schedules={schedules}
+          dayColWidth={dayColWidth}
+          onDayClick={onDayClick}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/gantt/__tests__/WeeklyGanttChart.test.tsx
+++ b/web/src/components/gantt/__tests__/WeeklyGanttChart.test.tsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WeeklyGanttChart } from '../WeeklyGanttChart';
+import type { Helper, Customer, Order, StaffUnavailability, DayOfWeek } from '@/types';
+import type { DaySchedule, HelperScheduleRow } from '@/hooks/useScheduleData';
+
+// ResizeObserver のモック
+// vi.fn().mockImplementation はアロー関数を返すため new で呼び出せない。
+// クラス構文を使うことで new ResizeObserver(...) が正しく動作する。
+class ResizeObserverMock {
+  private cb: (entries: { contentRect: { width: number } }[]) => void;
+  observe = vi.fn((el: Element) => {
+    this.cb([{ contentRect: { width: 700 } }]);
+  });
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  constructor(cb: (entries: { contentRect: { width: number } }[]) => void) {
+    this.cb = cb;
+  }
+}
+global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+// --- フィクスチャ ---
+function makeHelper(overrides: Partial<Helper> = {}): Helper {
+  return {
+    id: 'helper-1',
+    name: { family: '田中', given: '花子', short: '田中' },
+    qualifications: [],
+    can_physical_care: true,
+    transportation: 'bicycle',
+    weekly_availability: {
+      monday: [{ start_time: '09:00', end_time: '18:00' }],
+      tuesday: [{ start_time: '09:00', end_time: '18:00' }],
+      wednesday: [{ start_time: '09:00', end_time: '18:00' }],
+      thursday: [{ start_time: '09:00', end_time: '18:00' }],
+      friday: [{ start_time: '09:00', end_time: '18:00' }],
+    },
+    preferred_hours: { min: 20, max: 40 },
+    available_hours: { min: 0, max: 40 },
+    customer_training_status: {},
+    employment_type: 'part_time',
+    gender: 'female',
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeCustomer(overrides: Partial<Customer> = {}): Customer {
+  return {
+    id: 'cust-1',
+    name: { family: '佐藤', given: '一郎', short: '佐藤' },
+    address: '東京都渋谷区',
+    location: { lat: 35.6, lng: 139.7 },
+    ng_staff_ids: [],
+    preferred_staff_ids: [],
+    weekly_services: {},
+    service_manager: 'sm-1',
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 'order-1',
+    customer_id: 'cust-1',
+    week_start_date: new Date('2026-02-16'),
+    date: new Date('2026-02-16'),
+    start_time: '09:00',
+    end_time: '10:00',
+    service_type: 'physical_care',
+    assigned_staff_ids: ['helper-1'],
+    status: 'assigned',
+    manually_edited: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeDaySchedule(
+  day: DayOfWeek,
+  date: Date,
+  helperRows: HelperScheduleRow[] = [],
+  unassignedOrders: Order[] = [],
+): DaySchedule {
+  return {
+    day,
+    date,
+    helperRows,
+    unassignedOrders,
+    totalOrders: helperRows.flatMap((r) => r.orders).length + unassignedOrders.length,
+  };
+}
+
+describe('WeeklyGanttChart', () => {
+  const weekStart = new Date('2026-02-16'); // 月曜日
+  const helper = makeHelper();
+  const customer = makeCustomer();
+  const helpers = new Map([['helper-1', helper]]);
+  const customers = new Map([['cust-1', customer]]);
+  const unavailability: StaffUnavailability[] = [];
+  const onDayClick = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeGetDaySchedule(
+    scheduleMap: Partial<Record<DayOfWeek, DaySchedule>> = {},
+  ) {
+    return (day: DayOfWeek, date: Date): DaySchedule =>
+      scheduleMap[day] ?? makeDaySchedule(day, date);
+  }
+
+  it('7曜日のヘッダーが表示される（月〜日）', () => {
+    render(
+      <WeeklyGanttChart
+        weekStart={weekStart}
+        getDaySchedule={makeGetDaySchedule()}
+        helpers={helpers}
+        customers={customers}
+        unavailability={unavailability}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    expect(screen.getByTestId('weekly-day-header-monday')).toBeInTheDocument();
+    expect(screen.getByTestId('weekly-day-header-tuesday')).toBeInTheDocument();
+    expect(screen.getByTestId('weekly-day-header-wednesday')).toBeInTheDocument();
+    expect(screen.getByTestId('weekly-day-header-thursday')).toBeInTheDocument();
+    expect(screen.getByTestId('weekly-day-header-friday')).toBeInTheDocument();
+    expect(screen.getByTestId('weekly-day-header-saturday')).toBeInTheDocument();
+    expect(screen.getByTestId('weekly-day-header-sunday')).toBeInTheDocument();
+  });
+
+  it('ヘルパー名が行として表示される', () => {
+    render(
+      <WeeklyGanttChart
+        weekStart={weekStart}
+        getDaySchedule={makeGetDaySchedule()}
+        helpers={helpers}
+        customers={customers}
+        unavailability={unavailability}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    expect(screen.getByText('田中')).toBeInTheDocument();
+  });
+
+  it('日ヘッダークリックでonDayClickが発火する', () => {
+    render(
+      <WeeklyGanttChart
+        weekStart={weekStart}
+        getDaySchedule={makeGetDaySchedule()}
+        helpers={helpers}
+        customers={customers}
+        unavailability={unavailability}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('weekly-day-header-monday'));
+    expect(onDayClick).toHaveBeenCalledWith('monday');
+  });
+
+  it('オーダーのバーがレンダリングされる（titleで確認）', () => {
+    const order = makeOrder({ id: 'order-x', start_time: '09:00', end_time: '10:00' });
+    const getDaySchedule = makeGetDaySchedule({
+      monday: makeDaySchedule('monday', new Date('2026-02-16'), [
+        { helper, orders: [order] },
+      ]),
+    });
+
+    render(
+      <WeeklyGanttChart
+        weekStart={weekStart}
+        getDaySchedule={getDaySchedule}
+        helpers={helpers}
+        customers={customers}
+        unavailability={unavailability}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    // title 属性で顧客名と時間が確認できる
+    expect(screen.getByTitle('佐藤 09:00-10:00')).toBeInTheDocument();
+  });
+
+  it('バークリックでonDayClickが呼ばれる', () => {
+    const order = makeOrder({ id: 'order-y' });
+    const getDaySchedule = makeGetDaySchedule({
+      tuesday: makeDaySchedule('tuesday', new Date('2026-02-17'), [
+        { helper, orders: [order] },
+      ]),
+    });
+
+    render(
+      <WeeklyGanttChart
+        weekStart={weekStart}
+        getDaySchedule={getDaySchedule}
+        helpers={helpers}
+        customers={customers}
+        unavailability={unavailability}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle('佐藤 09:00-10:00'));
+    expect(onDayClick).toHaveBeenCalledWith('tuesday');
+  });
+
+  it('未割当オーダーがある場合に件数バッジが表示される', () => {
+    const unassigned = makeOrder({ id: 'u-1', assigned_staff_ids: [] });
+    const getDaySchedule = makeGetDaySchedule({
+      wednesday: makeDaySchedule('wednesday', new Date('2026-02-18'), [], [unassigned]),
+    });
+
+    render(
+      <WeeklyGanttChart
+        weekStart={weekStart}
+        getDaySchedule={getDaySchedule}
+        helpers={helpers}
+        customers={customers}
+        unavailability={unavailability}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    expect(screen.getByTestId('weekly-unassigned-badge-wednesday')).toHaveTextContent('1');
+  });
+
+  it('全曜日0件の場合は未割当行が表示されない', () => {
+    render(
+      <WeeklyGanttChart
+        weekStart={weekStart}
+        getDaySchedule={makeGetDaySchedule()}
+        helpers={helpers}
+        customers={customers}
+        unavailability={unavailability}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    expect(screen.queryByTestId('weekly-unassigned-row')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/gantt/constants.ts
+++ b/web/src/components/gantt/constants.ts
@@ -189,3 +189,39 @@ export function isOverlapping(
   const e2 = timeToMinutes(end2);
   return s1 < e2 && s2 < e1;
 }
+
+/** サービス種別の色マッピング */
+export const SERVICE_COLORS: Record<string, { bar: string; hover: string }> = {
+  physical_care: {
+    bar: 'bg-gradient-to-r from-[oklch(0.55_0.15_225)] to-[oklch(0.60_0.12_205)] text-white',
+    hover: 'hover:from-[oklch(0.50_0.16_225)] hover:to-[oklch(0.55_0.13_205)]',
+  },
+  daily_living: {
+    bar: 'bg-gradient-to-r from-[oklch(0.55_0.15_162)] to-[oklch(0.60_0.12_147)] text-white',
+    hover: 'hover:from-[oklch(0.50_0.16_162)] hover:to-[oklch(0.55_0.13_147)]',
+  },
+  mixed: {
+    bar: 'bg-gradient-to-r from-[oklch(0.58_0.14_50)] to-[oklch(0.63_0.11_35)] text-white',
+    hover: 'hover:from-[oklch(0.53_0.15_50)] hover:to-[oklch(0.58_0.12_35)]',
+  },
+  prevention: {
+    bar: 'bg-gradient-to-r from-[oklch(0.60_0.12_298)] to-[oklch(0.65_0.10_278)] text-white',
+    hover: 'hover:from-[oklch(0.55_0.13_298)] hover:to-[oklch(0.60_0.11_278)]',
+  },
+  private: {
+    bar: 'bg-gradient-to-r from-[oklch(0.60_0.12_350)] to-[oklch(0.65_0.10_330)] text-white',
+    hover: 'hover:from-[oklch(0.55_0.13_350)] hover:to-[oklch(0.60_0.11_330)]',
+  },
+  disability: {
+    bar: 'bg-gradient-to-r from-[oklch(0.58_0.14_120)] to-[oklch(0.63_0.11_105)] text-white',
+    hover: 'hover:from-[oklch(0.53_0.15_120)] hover:to-[oklch(0.58_0.12_105)]',
+  },
+  transport_support: {
+    bar: 'bg-gradient-to-r from-[oklch(0.60_0.12_200)] to-[oklch(0.65_0.10_185)] text-white',
+    hover: 'hover:from-[oklch(0.55_0.13_200)] hover:to-[oklch(0.60_0.11_185)]',
+  },
+  severe_visiting: {
+    bar: 'bg-gradient-to-r from-[oklch(0.53_0.18_25)] to-[oklch(0.58_0.15_10)] text-white',
+    hover: 'hover:from-[oklch(0.48_0.19_25)] hover:to-[oklch(0.53_0.16_10)]',
+  },
+};

--- a/web/src/components/schedule/ViewModeToggle.tsx
+++ b/web/src/components/schedule/ViewModeToggle.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { CalendarDays, CalendarRange } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useScheduleContext } from '@/contexts/ScheduleContext';
+
+export function ViewModeToggle() {
+  const { viewMode, setViewMode } = useScheduleContext();
+
+  return (
+    <div data-testid="view-mode-toggle" className="flex items-center border-r px-2">
+      <div className="flex rounded-md shadow-xs">
+        <Button
+          data-testid="view-mode-day"
+          variant={viewMode === 'day' ? 'default' : 'outline'}
+          size="sm"
+          className="rounded-r-none border-r-0"
+          onClick={() => setViewMode('day')}
+          aria-pressed={viewMode === 'day'}
+        >
+          <CalendarDays className="size-4" />
+          日
+        </Button>
+        <Button
+          data-testid="view-mode-week"
+          variant={viewMode === 'week' ? 'default' : 'outline'}
+          size="sm"
+          className="rounded-l-none"
+          onClick={() => setViewMode('week')}
+          aria-pressed={viewMode === 'week'}
+        >
+          <CalendarRange className="size-4" />
+          週
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/schedule/__tests__/ViewModeToggle.test.tsx
+++ b/web/src/components/schedule/__tests__/ViewModeToggle.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ViewModeToggle } from '../ViewModeToggle';
+
+const mockSetViewMode = vi.fn();
+
+vi.mock('@/contexts/ScheduleContext', () => ({
+  useScheduleContext: () => ({
+    viewMode: 'day',
+    setViewMode: mockSetViewMode,
+  }),
+}));
+
+describe('ViewModeToggle', () => {
+  it('日と週のボタンが表示される', () => {
+    render(<ViewModeToggle />);
+    expect(screen.getByTestId('view-mode-day')).toBeInTheDocument();
+    expect(screen.getByTestId('view-mode-week')).toBeInTheDocument();
+  });
+
+  it('viewMode=dayのとき日ボタンがアクティブ（aria-pressed=true）', () => {
+    render(<ViewModeToggle />);
+    expect(screen.getByTestId('view-mode-day')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('view-mode-week')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('週ボタンクリックでsetViewMode("week")が呼ばれる', () => {
+    render(<ViewModeToggle />);
+    fireEvent.click(screen.getByTestId('view-mode-week'));
+    expect(mockSetViewMode).toHaveBeenCalledWith('week');
+  });
+
+  it('日ボタンクリックでsetViewMode("day")が呼ばれる', () => {
+    render(<ViewModeToggle />);
+    fireEvent.click(screen.getByTestId('view-mode-day'));
+    expect(mockSetViewMode).toHaveBeenCalledWith('day');
+  });
+
+  it('data-testid="view-mode-toggle"が存在する', () => {
+    render(<ViewModeToggle />);
+    expect(screen.getByTestId('view-mode-toggle')).toBeInTheDocument();
+  });
+});

--- a/web/src/contexts/ScheduleContext.tsx
+++ b/web/src/contexts/ScheduleContext.tsx
@@ -12,6 +12,8 @@ interface ScheduleContextValue {
   goToNextWeek: () => void;
   goToPrevWeek: () => void;
   goToWeek: (date: Date) => void;
+  viewMode: 'day' | 'week';
+  setViewMode: (mode: 'day' | 'week') => void;
 }
 
 const ScheduleContext = createContext<ScheduleContextValue | null>(null);
@@ -25,6 +27,7 @@ export function ScheduleProvider({ children }: { children: ReactNode }) {
   const [selectedDay, setSelectedDay] = useState<DayOfWeek>(
     DAY_OF_WEEK_ORDER[new Date().getDay() === 0 ? 6 : new Date().getDay() - 1]
   );
+  const [viewMode, setViewMode] = useState<'day' | 'week'>('day');
 
   const goToNextWeek = useCallback(() => setWeekStart((w) => addWeeks(w, 1)), []);
   const goToPrevWeek = useCallback(() => setWeekStart((w) => subWeeks(w, 1)), []);
@@ -32,7 +35,7 @@ export function ScheduleProvider({ children }: { children: ReactNode }) {
 
   return (
     <ScheduleContext.Provider
-      value={{ weekStart, selectedDay, setSelectedDay, goToNextWeek, goToPrevWeek, goToWeek }}
+      value={{ weekStart, selectedDay, setSelectedDay, goToNextWeek, goToPrevWeek, goToWeek, viewMode, setViewMode }}
     >
       {children}
     </ScheduleContext.Provider>


### PR DESCRIPTION
## Summary

- `ScheduleContext` に `viewMode`（`'day' | 'week'`）を追加し、デフォルトは `'day'`（既存 E2E テストへの影響なし）
- `ViewModeToggle` コンポーネントで日/週ボタン切り替えを実装
- `WeeklyGanttChart` でヘルパー×曜日のピボット表示を実装
  - `ResizeObserver` でコンテナ幅に追従するレスポンシブ列幅
  - 日ヘッダー・バークリックで日ビューへ遷移
  - 非勤務日セルをグレー表示、未割当件数をバッジ表示
- `SERVICE_COLORS` を `constants.ts` に移動し週ビューでも再利用
- `page.tsx` で `viewMode` による日/週ビューの出し分けを統合

## Test plan

- [x] `ViewModeToggle.test.tsx` — 5件 PASS（ボタン表示、aria-pressed、クリック）
- [x] `WeeklyGanttChart.test.tsx` — 7件 PASS（ヘッダー表示、ヘルパー行、バー、クリック遷移、未割当バッジ）
- [x] 既存テスト 262件すべて PASS（回帰なし）
- [ ] 手動確認: 日ビューがデフォルト表示
- [ ] 手動確認: 「週」ボタンクリックでピボット表示に切替
- [ ] 手動確認: 曜日ヘッダークリックでその日の日ビューに遷移
- [ ] 手動確認: バーの色が日ビューと一致
- [ ] 手動確認: ウィンドウ幅変更で列幅が追従

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)