### PR TITLE
feat: 性別・研修状態・推奨スタッフ制約チェックをD&Dバリデーションとガントバーに追加

### DIFF
--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -15,12 +15,13 @@ interface GanttBarProps {
   customer?: Customer;
   hasViolation?: boolean;
   violationType?: 'error' | 'warning';
+  violationMessages?: string[];
   onClick?: (order: Order) => void;
   /** ドラッグ元のヘルパーID（null = 未割当） */
   sourceHelperId: string | null;
 }
 
-export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, violationType, onClick, sourceHelperId }: GanttBarProps) {
+export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, violationType, violationMessages, onClick, sourceHelperId }: GanttBarProps) {
   const slotWidth = useSlotWidth();
   const startCol = timeToColumn(order.start_time);
   const endCol = timeToColumn(order.end_time);
@@ -68,7 +69,11 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
       )}
       style={style}
       onClick={() => !isDragging && onClick?.(order)}
-      title={`${customerName} ${order.start_time}-${order.end_time}`}
+      title={
+        violationMessages && violationMessages.length > 0
+          ? `${customerName} ${order.start_time}-${order.end_time}\n---\n${violationMessages.join('\n')}`
+          : `${customerName} ${order.start_time}-${order.end_time}`
+      }
       {...attributes}
       {...listeners}
     >

--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -143,6 +143,7 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
               customer={customers.get(order.customer_id)}
               hasViolation={!!orderViolations?.length}
               violationType={hasError ? 'error' : hasWarning ? 'warning' : undefined}
+              violationMessages={orderViolations?.map((v) => v.message)}
               onClick={onOrderClick}
               sourceHelperId={row.helper.id}
             />


### PR DESCRIPTION
## Summary

- **性別要件** (`gender_requirement=female/male`): 性別不一致のヘルパーへのD&Dをエラーで拒否、既存割当に赤枠を表示
- **研修状態** (`customer_training_status`): `not_visited` → エラー拒否、`training` → 黄色警告+同行必要メッセージ
- **推奨スタッフ外** (`preferred_staff_ids`): リスト外ヘルパーへのD&Dに黄色警告を表示
- **ツールチップ改善**: GanttBar の title 属性に違反メッセージ一覧を付加（ホバーで確認可能）

PRD 2.3「リアルタイムバリデーション」の完全実装（移動時間系は Phase 2 で対応）。

## Python ソルバーとの対応

| Python 制約 | FE 実装 | severity |
|---|---|---|
| `_add_gender_constraint` (ハード) | 性別不一致 → 拒否 | error |
| `_add_training_constraint` (ハード) | not_visited → 拒否 | error |
| 同上 | training → 警告 | warning |
| ソフト: preferred_staff | preferred 外 → 警告 | warning |

## Test plan

- [x] `checker.test.ts` 9件追加（性別3, 研修3, 推奨スタッフ3）
- [x] `validation.test.ts` 9件追加（性別3, 研修3, 推奨スタッフ3）
- [x] 全305テストパス（回帰なし）
- [ ] ローカルで性別違反の赤枠、研修中の黄枠、ツールチップ表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)