### PR TITLE
feat: スケジュール UI 改善（利用者軸ビュー・基本予定一覧・差分カード）

### DIFF
--- a/web/src/app/masters/weekly-schedule/page.tsx
+++ b/web/src/app/masters/weekly-schedule/page.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Search } from 'lucide-react';
+import { useCustomers } from '@/hooks/useCustomers';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
+import type { Customer, ServiceSlot } from '@/types';
+
+const SERVICE_LABELS: Record<string, string> = {
+  physical_care: '身体',
+  daily_living: '生活',
+  mixed: '混合',
+  prevention: '予防',
+  private: '自費',
+  disability: '障がい',
+  transport_support: '移送',
+  severe_visiting: '重訪',
+};
+
+const SERVICE_BADGE_STYLES: Record<string, string> = {
+  physical_care: 'bg-blue-50 text-blue-700 border-blue-200',
+  daily_living: 'bg-green-50 text-green-700 border-green-200',
+  mixed: 'bg-amber-50 text-amber-700 border-amber-200',
+  prevention: 'bg-purple-50 text-purple-700 border-purple-200',
+  private: 'bg-rose-50 text-rose-700 border-rose-200',
+  disability: 'bg-lime-50 text-lime-700 border-lime-200',
+  transport_support: 'bg-cyan-50 text-cyan-700 border-cyan-200',
+  severe_visiting: 'bg-orange-50 text-orange-700 border-orange-200',
+};
+
+function ServiceSlotChip({ slot }: { slot: ServiceSlot }) {
+  const label = SERVICE_LABELS[slot.service_type] ?? slot.service_type;
+  const style = SERVICE_BADGE_STYLES[slot.service_type] ?? '';
+  return (
+    <div className="flex flex-col gap-0.5 text-[10px] leading-tight">
+      <Badge variant="outline" className={`h-4 px-1 text-[9px] ${style}`}>
+        {label}
+        {slot.staff_count > 1 && <span className="ml-0.5 opacity-70">×{slot.staff_count}</span>}
+      </Badge>
+      <span className="text-muted-foreground font-mono">
+        {slot.start_time}–{slot.end_time}
+      </span>
+    </div>
+  );
+}
+
+function totalWeeklySlots(customer: Customer): number {
+  return DAY_OF_WEEK_ORDER.reduce(
+    (sum, day) => sum + (customer.weekly_services[day]?.length ?? 0),
+    0,
+  );
+}
+
+export default function WeeklySchedulePage() {
+  const { customers, loading } = useCustomers();
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    const list = Array.from(customers.values()).sort((a, b) => {
+      const na = a.name.short ?? `${a.name.family}${a.name.given}`;
+      const nb = b.name.short ?? `${b.name.family}${b.name.given}`;
+      return na.localeCompare(nb, 'ja');
+    });
+    if (!search.trim()) return list;
+    const q = search.trim().toLowerCase();
+    return list.filter(
+      (c) =>
+        c.name.family.toLowerCase().includes(q) ||
+        c.name.given.toLowerCase().includes(q) ||
+        (c.name.short ?? '').toLowerCase().includes(q),
+    );
+  }, [customers, search]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <div className="flex flex-col items-center gap-3">
+          <div className="h-8 w-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
+          <p className="text-sm text-muted-foreground">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">基本予定一覧</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            利用者ごとの週間サービス予定を表示します
+          </p>
+        </div>
+        <div className="relative w-64">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="利用者名で検索..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-8"
+          />
+        </div>
+      </div>
+
+      <div className="rounded-md border overflow-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-32 sticky left-0 bg-background z-10">利用者</TableHead>
+              {DAY_OF_WEEK_ORDER.map((day) => (
+                <TableHead key={day} className="text-center min-w-[90px]">
+                  {DAY_OF_WEEK_LABELS[day]}
+                </TableHead>
+              ))}
+              <TableHead className="text-center w-16">合計</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={9} className="h-24 text-center text-muted-foreground">
+                  該当する利用者がいません
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((customer) => {
+                const total = totalWeeklySlots(customer);
+                const name =
+                  customer.name.short ??
+                  `${customer.name.family} ${customer.name.given}`;
+                return (
+                  <TableRow key={customer.id}>
+                    <TableCell
+                      className="font-medium sticky left-0 bg-background z-10 border-r"
+                      title={`${customer.name.family} ${customer.name.given}`}
+                    >
+                      <span className="truncate block max-w-[120px]">{name}</span>
+                    </TableCell>
+                    {DAY_OF_WEEK_ORDER.map((day) => {
+                      const slots = customer.weekly_services[day] ?? [];
+                      return (
+                        <TableCell key={day} className="align-top py-2 text-center">
+                          {slots.length === 0 ? (
+                            <span className="text-muted-foreground/40 text-xs">—</span>
+                          ) : (
+                            <div className="flex flex-col gap-1.5 items-center">
+                              {slots.map((slot, i) => (
+                                <ServiceSlotChip key={i} slot={slot} />
+                              ))}
+                            </div>
+                          )}
+                        </TableCell>
+                      );
+                    })}
+                    <TableCell className="text-center">
+                      {total > 0 ? (
+                        <span className="font-semibold">{total}</span>
+                      ) : (
+                        <span className="text-muted-foreground/40 text-xs">0</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -16,6 +16,7 @@ import { ResetButton } from '@/components/schedule/ResetButton';
 import { BulkCompleteButton } from '@/components/schedule/BulkCompleteButton';
 import { GanttChart } from '@/components/gantt/GanttChart';
 import { WeeklyGanttChart } from '@/components/gantt/WeeklyGanttChart';
+import { CustomerGanttChart } from '@/components/gantt/CustomerGanttChart';
 import { OrderDetailPanel } from '@/components/schedule/OrderDetailPanel';
 import { useScheduleData } from '@/hooks/useScheduleData';
 import { useDragAndDrop } from '@/hooks/useDragAndDrop';
@@ -29,7 +30,7 @@ import type { Order, DayOfWeek } from '@/types';
 
 function SchedulePage() {
   const { welcomeOpen, closeWelcome, reopenWelcome } = useWelcomeDialog();
-  const { weekStart, selectedDay, setSelectedDay, viewMode, setViewMode } = useScheduleContext();
+  const { weekStart, selectedDay, setSelectedDay, viewMode, setViewMode, ganttAxis } = useScheduleContext();
   const { customers, helpers, orderCounts, getDaySchedule, unavailability, loading } =
     useScheduleData(weekStart);
 
@@ -182,30 +183,40 @@ function SchedulePage() {
       <StatsBar
         schedule={viewMode === 'week' ? weeklySchedule : schedule}
         violations={viewMode === 'week' ? (new Map() as typeof violations) : violations}
+        diffMap={diffMap}
       />
       <main className="flex-1 overflow-auto p-4">
         {viewMode === 'day' ? (
-          <DndContext
-            sensors={sensors}
-            onDragStart={handleDragStart}
-            onDragOver={handleDragOver}
-            onDragMove={handleDragMove}
-            onDragEnd={handleDragEnd}
-            onDragCancel={handleDragCancel}
-          >
-            <GanttChart
+          ganttAxis === 'customer' ? (
+            <CustomerGanttChart
               schedule={schedule}
               customers={customers}
-              violations={violations}
+              helpers={helpers}
               onOrderClick={handleOrderClick}
-              dropZoneStatuses={dropZoneStatuses}
-              unavailability={unavailability}
-              activeOrder={activeOrder}
-              onSlotWidthChange={handleSlotWidthChange}
-              previewTimes={previewTimes}
-              dropMessage={dropMessage}
             />
-          </DndContext>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragMove={handleDragMove}
+              onDragEnd={handleDragEnd}
+              onDragCancel={handleDragCancel}
+            >
+              <GanttChart
+                schedule={schedule}
+                customers={customers}
+                violations={violations}
+                onOrderClick={handleOrderClick}
+                dropZoneStatuses={dropZoneStatuses}
+                unavailability={unavailability}
+                activeOrder={activeOrder}
+                onSlotWidthChange={handleSlotWidthChange}
+                previewTimes={previewTimes}
+                dropMessage={dropMessage}
+              />
+            </DndContext>
+          )
         ) : (
           <WeeklyGanttChart
             weekStart={weekStart}

--- a/web/src/components/gantt/CustomerGanttChart.tsx
+++ b/web/src/components/gantt/CustomerGanttChart.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useRef, useState, useEffect, useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  GANTT_START_HOUR,
+  GANTT_END_HOUR,
+  HELPER_NAME_WIDTH_PX,
+  ROW_HEIGHT_PX,
+  timeToMinutes,
+  SERVICE_COLORS,
+} from './constants';
+import type { DaySchedule } from '@/hooks/useScheduleData';
+import type { Customer, Helper, Order } from '@/types';
+
+const GANTT_START_MIN = GANTT_START_HOUR * 60;
+const GANTT_END_MIN = GANTT_END_HOUR * 60;
+const GANTT_DURATION_MIN = GANTT_END_MIN - GANTT_START_MIN;
+const HOURS = Array.from(
+  { length: GANTT_END_HOUR - GANTT_START_HOUR },
+  (_, i) => GANTT_START_HOUR + i,
+);
+
+export interface CustomerGanttChartProps {
+  schedule: DaySchedule;
+  customers: Map<string, Customer>;
+  helpers: Map<string, Helper>;
+  onOrderClick?: (order: Order) => void;
+}
+
+interface CustomerOrderBarProps {
+  order: Order;
+  chartWidth: number;
+  helpers: Map<string, Helper>;
+  onOrderClick?: (order: Order) => void;
+}
+
+function CustomerOrderBar({ order, chartWidth, helpers, onOrderClick }: CustomerOrderBarProps) {
+  const startMin = timeToMinutes(order.start_time);
+  const endMin = timeToMinutes(order.end_time);
+  const left = Math.max(0, ((startMin - GANTT_START_MIN) / GANTT_DURATION_MIN) * chartWidth);
+  const width = Math.max(8, ((endMin - startMin) / GANTT_DURATION_MIN) * chartWidth);
+  const colors = SERVICE_COLORS[order.service_type] ?? SERVICE_COLORS.physical_care;
+  const helperLabel =
+    order.assigned_staff_ids
+      .map((id) => {
+        const h = helpers.get(id);
+        return h ? (h.name.short ?? `${h.name.family}${h.name.given}`) : id;
+      })
+      .join(' ') || '未割当';
+
+  return (
+    <button
+      className={cn(
+        'absolute top-1 rounded overflow-hidden text-left px-1 text-[10px] leading-tight',
+        colors.bar,
+        'transition-opacity hover:opacity-80',
+      )}
+      style={{ left, width, height: ROW_HEIGHT_PX - 8 }}
+      title={`${order.start_time}-${order.end_time} ${helperLabel}`}
+      onClick={() => onOrderClick?.(order)}
+    >
+      <span className="truncate block">{helperLabel}</span>
+    </button>
+  );
+}
+
+interface UnassignedOrderBarProps {
+  order: Order;
+  chartWidth: number;
+  customerName: string;
+  onOrderClick?: (order: Order) => void;
+}
+
+function UnassignedOrderBar({ order, chartWidth, customerName, onOrderClick }: UnassignedOrderBarProps) {
+  const startMin = timeToMinutes(order.start_time);
+  const endMin = timeToMinutes(order.end_time);
+  const left = Math.max(0, ((startMin - GANTT_START_MIN) / GANTT_DURATION_MIN) * chartWidth);
+  const width = Math.max(8, ((endMin - startMin) / GANTT_DURATION_MIN) * chartWidth);
+
+  return (
+    <button
+      className="absolute top-1 rounded overflow-hidden text-left px-1 text-[10px] leading-tight bg-amber-200 text-amber-900 transition-opacity hover:opacity-80"
+      style={{ left, width, height: ROW_HEIGHT_PX - 8 }}
+      title={`${customerName} ${order.start_time}-${order.end_time}`}
+      onClick={() => onOrderClick?.(order)}
+    >
+      <span className="truncate block">{customerName}</span>
+    </button>
+  );
+}
+
+export function CustomerGanttChart({
+  schedule,
+  customers,
+  helpers,
+  onOrderClick,
+}: CustomerGanttChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [chartWidth, setChartWidth] = useState(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      setChartWidth(Math.max(0, width - HELPER_NAME_WIDTH_PX));
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const customerRows = useMemo(() => {
+    const allOrders = schedule.helperRows.flatMap((r) => r.orders);
+    const ordersByCustomer = new Map<string, Order[]>();
+    for (const order of allOrders) {
+      const existing = ordersByCustomer.get(order.customer_id) ?? [];
+      existing.push(order);
+      ordersByCustomer.set(order.customer_id, existing);
+    }
+    return Array.from(ordersByCustomer.entries())
+      .map(([customerId, orders]) => ({
+        customer: customers.get(customerId),
+        customerId,
+        orders,
+      }))
+      .sort((a, b) => {
+        const nameA = a.customer
+          ? (a.customer.name.short ?? `${a.customer.name.family}${a.customer.name.given}`)
+          : a.customerId;
+        const nameB = b.customer
+          ? (b.customer.name.short ?? `${b.customer.name.family}${b.customer.name.given}`)
+          : b.customerId;
+        return nameA.localeCompare(nameB, 'ja');
+      });
+  }, [schedule, customers]);
+
+  if (schedule.totalOrders === 0) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground">
+        この日のオーダーはありません
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="overflow-auto border rounded-lg shadow-brand-sm">
+      {/* 時刻ヘッダー */}
+      <div className="flex border-b bg-accent/30 sticky top-0 z-10" style={{ height: 28 }}>
+        <div
+          className="shrink-0 border-r px-2 py-1.5 text-xs font-semibold text-primary"
+          style={{ width: HELPER_NAME_WIDTH_PX }}
+        >
+          利用者
+        </div>
+        <div className="relative flex-1">
+          {HOURS.map((hour) => {
+            const left = ((hour * 60 - GANTT_START_MIN) / GANTT_DURATION_MIN) * chartWidth;
+            return (
+              <div
+                key={hour}
+                className="absolute top-0 h-full border-l border-border/40"
+                style={{ left }}
+              >
+                <span className="px-1 text-[10px] font-medium text-muted-foreground">
+                  {hour}:00
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* 利用者行 */}
+      {customerRows.map(({ customer, customerId, orders }) => {
+        const customerName = customer
+          ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+          : customerId;
+        return (
+          <div key={customerId} className="flex border-b" style={{ height: ROW_HEIGHT_PX }}>
+            <div
+              className="sticky left-0 z-10 flex items-center bg-background border-r px-2 shrink-0 text-xs font-medium truncate"
+              style={{ width: HELPER_NAME_WIDTH_PX, height: ROW_HEIGHT_PX }}
+              title={customerName}
+            >
+              {customerName}
+            </div>
+            <div className="relative flex-1" style={{ height: ROW_HEIGHT_PX }}>
+              {orders.map((order) => (
+                <CustomerOrderBar
+                  key={order.id}
+                  order={order}
+                  chartWidth={chartWidth}
+                  helpers={helpers}
+                  onOrderClick={onOrderClick}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+
+      {/* 未割当行 */}
+      {schedule.unassignedOrders.length > 0 && (
+        <div className="flex border-b bg-amber-50/30" style={{ height: ROW_HEIGHT_PX }}>
+          <div
+            className="sticky left-0 z-10 flex items-center bg-amber-50/30 border-r px-2 shrink-0 text-xs font-medium text-amber-700"
+            style={{ width: HELPER_NAME_WIDTH_PX, height: ROW_HEIGHT_PX }}
+          >
+            未割当
+          </div>
+          <div className="relative flex-1" style={{ height: ROW_HEIGHT_PX }}>
+            {schedule.unassignedOrders.map((order) => {
+              const customer = customers.get(order.customer_id);
+              const customerName = customer
+                ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+                : order.customer_id;
+              return (
+                <UnassignedOrderBar
+                  key={order.id}
+                  order={order}
+                  chartWidth={chartWidth}
+                  customerName={customerName}
+                  onOrderClick={onOrderClick}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Heart, Settings, Users, UserCog, CalendarOff, History, LogOut, HelpCircle, BarChart2, Tag } from 'lucide-react';
+import { Heart, Settings, Users, UserCog, CalendarOff, History, LogOut, HelpCircle, BarChart2, Tag, CalendarCheck } from 'lucide-react';
 import { WeekSelector } from '@/components/schedule/WeekSelector';
 import { useAuth } from '@/lib/auth/AuthProvider';
 import {
@@ -96,6 +96,12 @@ export function Header({ onShowWelcome }: HeaderProps = {}) {
                 <Link href="/masters/service-types">
                   <Tag className="mr-2 h-4 w-4" />
                   サービス種別マスタ
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/masters/weekly-schedule">
+                  <CalendarCheck className="mr-2 h-4 w-4" />
+                  基本予定一覧
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuSeparator />

--- a/web/src/components/schedule/StatsBar.tsx
+++ b/web/src/components/schedule/StatsBar.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { ClipboardList, CheckCircle2, AlertCircle, Users, CircleCheck } from 'lucide-react';
+import { ClipboardList, CheckCircle2, AlertCircle, Users, CircleCheck, GitCompare } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import type { DaySchedule } from '@/hooks/useScheduleData';
 import type { ViolationMap } from '@/lib/constraints/checker';
+import type { AssignmentDiff } from '@/hooks/useAssignmentDiff';
 
 interface StatsBarProps {
   schedule: DaySchedule;
   violations: ViolationMap;
+  diffMap?: Map<string, AssignmentDiff>;
 }
 
-export function StatsBar({ schedule, violations }: StatsBarProps) {
+export function StatsBar({ schedule, violations, diffMap }: StatsBarProps) {
   const allOrders = schedule.helperRows.flatMap((r) => r.orders).concat(schedule.unassignedOrders);
   const assignedCount = schedule.helperRows.reduce(
     (sum, row) => sum + row.orders.length, 0
@@ -32,8 +34,10 @@ export function StatsBar({ schedule, violations }: StatsBarProps) {
     ? Math.round((completedCount / completionDenominator) * 100)
     : 0;
 
+  const diffCount = diffMap?.size ?? 0;
+
   return (
-    <div className="grid grid-cols-5 gap-3 px-4 py-3">
+    <div className="grid grid-cols-6 gap-3 px-4 py-3">
       {/* オーダー数 */}
       <div className="flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 shadow-brand-sm">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-accent">
@@ -123,6 +127,23 @@ export function StatsBar({ schedule, violations }: StatsBarProps) {
               </Badge>
             )}
           </div>
+        </div>
+      </div>
+
+      {/* 最適化差分 */}
+      <div className="flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 shadow-brand-sm">
+        <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${diffCount > 0 ? 'bg-violet-500/10' : 'bg-muted'}`}>
+          <GitCompare className={`h-4.5 w-4.5 ${diffCount > 0 ? 'text-violet-600' : 'text-muted-foreground'}`} />
+        </div>
+        <div>
+          <p className="text-[11px] text-muted-foreground leading-none">最適化差分</p>
+          <p className={`text-lg font-bold leading-tight ${diffCount > 0 ? 'text-violet-600' : 'text-muted-foreground'}`}>
+            {diffCount === 0 ? (
+              <span className="text-sm font-normal">変更なし</span>
+            ) : (
+              <>{diffCount}<span className="text-xs font-normal text-muted-foreground ml-0.5">件変更</span></>
+            )}
+          </p>
         </div>
       </div>
     </div>

--- a/web/src/components/schedule/ViewModeToggle.tsx
+++ b/web/src/components/schedule/ViewModeToggle.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { CalendarDays, CalendarRange } from 'lucide-react';
+import { CalendarDays, CalendarRange, Users, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useScheduleContext } from '@/contexts/ScheduleContext';
 
 export function ViewModeToggle() {
-  const { viewMode, setViewMode } = useScheduleContext();
+  const { viewMode, setViewMode, ganttAxis, setGanttAxis } = useScheduleContext();
 
   return (
-    <div data-testid="view-mode-toggle" className="flex items-center border-r px-2">
+    <div data-testid="view-mode-toggle" className="flex items-center border-r px-2 gap-2">
       <div className="flex rounded-md shadow-xs">
         <Button
           data-testid="view-mode-day"
@@ -33,6 +33,32 @@ export function ViewModeToggle() {
           週
         </Button>
       </div>
+      {viewMode === 'day' && (
+        <div className="flex rounded-md shadow-xs">
+          <Button
+            data-testid="gantt-axis-staff"
+            variant={ganttAxis === 'staff' ? 'default' : 'outline'}
+            size="sm"
+            className="rounded-r-none border-r-0"
+            onClick={() => setGanttAxis('staff')}
+            aria-pressed={ganttAxis === 'staff'}
+          >
+            <Users className="size-4" />
+            スタッフ軸
+          </Button>
+          <Button
+            data-testid="gantt-axis-customer"
+            variant={ganttAxis === 'customer' ? 'default' : 'outline'}
+            size="sm"
+            className="rounded-l-none"
+            onClick={() => setGanttAxis('customer')}
+            aria-pressed={ganttAxis === 'customer'}
+          >
+            <User className="size-4" />
+            利用者軸
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/schedule/__tests__/NotifyChangesButton.test.tsx
+++ b/web/src/components/schedule/__tests__/NotifyChangesButton.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { NotifyChangesButton } from '../NotifyChangesButton';
+import type { AssignmentDiff } from '@/hooks/useAssignmentDiff';
+import type { Order } from '@/types';
+
+const mockNotifyShiftChanged = vi.fn();
+
+vi.mock('@/lib/api/optimizer', () => ({
+  notifyShiftChanged: (...args: unknown[]) => mockNotifyShiftChanged(...args),
+  OptimizeApiError: class extends Error {
+    statusCode: number;
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.name = 'OptimizeApiError';
+    }
+  },
+}));
+
+vi.mock('@/contexts/ScheduleContext', () => ({
+  useScheduleContext: () => ({
+    weekStart: new Date('2026-02-09'),
+  }),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const makeOrder = (id: string, assignedStaffIds: string[]): Order => ({
+  id,
+  customer_id: 'c-1',
+  week_start_date: new Date('2026-02-09'),
+  date: new Date('2026-02-09'),
+  start_time: '09:00',
+  end_time: '10:00',
+  service_type: 'physical_care',
+  assigned_staff_ids: assignedStaffIds,
+  status: 'assigned',
+  manually_edited: false,
+  created_at: new Date(),
+  updated_at: new Date(),
+});
+
+const helpers = new Map([
+  ['h-1', { id: 'h-1', name: { family: '田中', given: '太郎' } }],
+  ['h-2', { id: 'h-2', name: { family: '鈴木', given: '次郎' } }],
+]);
+
+const customers = new Map([
+  ['c-1', { id: 'c-1', name: { family: '山田', given: '花子' } }],
+]);
+
+describe('NotifyChangesButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('diffMap が空のとき変更通知ボタンが disabled になる', () => {
+    render(
+      <NotifyChangesButton
+        diffMap={new Map()}
+        helpers={helpers}
+        customers={customers}
+        orders={[]}
+      />
+    );
+    expect(screen.getByRole('button', { name: /変更通知/ })).toBeDisabled();
+  });
+
+  it('変更ありのとき変更通知ボタンが有効になり件数バッジを表示する', () => {
+    const diffMap = new Map<string, AssignmentDiff>([
+      ['o-1', { added: ['h-2'], removed: ['h-1'], isChanged: true }],
+    ]);
+    render(
+      <NotifyChangesButton
+        diffMap={diffMap}
+        helpers={helpers}
+        customers={customers}
+        orders={[makeOrder('o-1', ['h-2'])]}
+      />
+    );
+    expect(screen.getByRole('button', { name: /変更通知/ })).not.toBeDisabled();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('ボタンクリックでダイアログが開き変更内容を表示する', () => {
+    const diffMap = new Map<string, AssignmentDiff>([
+      ['o-1', { added: ['h-2'], removed: ['h-1'], isChanged: true }],
+    ]);
+    render(
+      <NotifyChangesButton
+        diffMap={diffMap}
+        helpers={helpers}
+        customers={customers}
+        orders={[makeOrder('o-1', ['h-2'])]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /変更通知/ }));
+    expect(screen.getByText('シフト変更通知')).toBeInTheDocument();
+    expect(screen.getByText('山田 花子')).toBeInTheDocument();
+    expect(screen.getByText('田中 太郎')).toBeInTheDocument();
+    expect(screen.getByText('鈴木 次郎')).toBeInTheDocument();
+  });
+
+  it('送信クリックで API を呼び成功トーストを表示する', async () => {
+    mockNotifyShiftChanged.mockResolvedValue({ emails_sent: 1, recipients: [] });
+    const diffMap = new Map<string, AssignmentDiff>([
+      ['o-1', { added: ['h-2'], removed: ['h-1'], isChanged: true }],
+    ]);
+    render(
+      <NotifyChangesButton
+        diffMap={diffMap}
+        helpers={helpers}
+        customers={customers}
+        orders={[makeOrder('o-1', ['h-2'])]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /変更通知/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^送信$/ }));
+    await waitFor(() => {
+      expect(mockNotifyShiftChanged).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith('変更通知送信完了: 1名に送信しました');
+    });
+  });
+
+  it('API エラーでエラートーストを表示する', async () => {
+    const { OptimizeApiError } = await import('@/lib/api/optimizer');
+    mockNotifyShiftChanged.mockRejectedValue(new OptimizeApiError(500, 'サーバーエラー'));
+    const diffMap = new Map<string, AssignmentDiff>([
+      ['o-1', { added: ['h-2'], removed: ['h-1'], isChanged: true }],
+    ]);
+    render(
+      <NotifyChangesButton
+        diffMap={diffMap}
+        helpers={helpers}
+        customers={customers}
+        orders={[makeOrder('o-1', ['h-2'])]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /変更通知/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^送信$/ }));
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('通知エラー: サーバーエラー');
+    });
+  });
+});

--- a/web/src/components/schedule/__tests__/NotifyConfirmDialog.test.tsx
+++ b/web/src/components/schedule/__tests__/NotifyConfirmDialog.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { NotifyConfirmDialog } from '../NotifyConfirmDialog';
+
+const mockNotifyShiftConfirmed = vi.fn();
+
+vi.mock('@/lib/api/optimizer', () => ({
+  notifyShiftConfirmed: (...args: unknown[]) => mockNotifyShiftConfirmed(...args),
+  OptimizeApiError: class extends Error {
+    statusCode: number;
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.name = 'OptimizeApiError';
+    }
+  },
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+describe('NotifyConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    weekStartDate: '2026-02-09',
+    assignedCount: 20,
+    totalOrders: 25,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('open=true でダイアログを表示する', () => {
+    render(<NotifyConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('シフト確定通知')).toBeInTheDocument();
+    expect(screen.getByText(/2026-02-09/)).toBeInTheDocument();
+    expect(screen.getByText(/20 \/ 25 件割当/)).toBeInTheDocument();
+  });
+
+  it('open=false でダイアログを非表示にする', () => {
+    render(<NotifyConfirmDialog {...defaultProps} open={false} />);
+    expect(screen.queryByText('シフト確定通知')).not.toBeInTheDocument();
+  });
+
+  it('スキップクリックで onClose を呼ぶ', () => {
+    const onClose = vi.fn();
+    render(<NotifyConfirmDialog {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'スキップ' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('送信クリックで API を呼び成功トーストを表示する', async () => {
+    mockNotifyShiftConfirmed.mockResolvedValue({ emails_sent: 2, recipients: [] });
+    const onClose = vi.fn();
+    render(<NotifyConfirmDialog {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /送信/ }));
+    await waitFor(() => {
+      expect(mockNotifyShiftConfirmed).toHaveBeenCalledWith({
+        week_start_date: '2026-02-09',
+        assigned_count: 20,
+        total_orders: 25,
+      });
+    });
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith('通知送信完了: 2名に送信しました');
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('API エラーでエラートーストを表示する', async () => {
+    const { OptimizeApiError } = await import('@/lib/api/optimizer');
+    mockNotifyShiftConfirmed.mockRejectedValue(new OptimizeApiError(500, 'サーバーエラー'));
+    render(<NotifyConfirmDialog {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /送信/ }));
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('通知エラー: サーバーエラー');
+    });
+  });
+});

--- a/web/src/components/schedule/__tests__/ViewModeToggle.test.tsx
+++ b/web/src/components/schedule/__tests__/ViewModeToggle.test.tsx
@@ -1,17 +1,24 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ViewModeToggle } from '../ViewModeToggle';
 
 const mockSetViewMode = vi.fn();
+const mockSetGanttAxis = vi.fn();
 
 vi.mock('@/contexts/ScheduleContext', () => ({
   useScheduleContext: () => ({
     viewMode: 'day',
     setViewMode: mockSetViewMode,
+    ganttAxis: 'staff',
+    setGanttAxis: mockSetGanttAxis,
   }),
 }));
 
 describe('ViewModeToggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('日と週のボタンが表示される', () => {
     render(<ViewModeToggle />);
     expect(screen.getByTestId('view-mode-day')).toBeInTheDocument();
@@ -39,5 +46,23 @@ describe('ViewModeToggle', () => {
   it('data-testid="view-mode-toggle"が存在する', () => {
     render(<ViewModeToggle />);
     expect(screen.getByTestId('view-mode-toggle')).toBeInTheDocument();
+  });
+
+  it('viewMode=dayのとき軸切替ボタンが表示される', () => {
+    render(<ViewModeToggle />);
+    expect(screen.getByTestId('gantt-axis-staff')).toBeInTheDocument();
+    expect(screen.getByTestId('gantt-axis-customer')).toBeInTheDocument();
+  });
+
+  it('ganttAxis=staffのときスタッフ軸ボタンがアクティブ', () => {
+    render(<ViewModeToggle />);
+    expect(screen.getByTestId('gantt-axis-staff')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('gantt-axis-customer')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('利用者軸ボタンクリックでsetGanttAxis("customer")が呼ばれる', () => {
+    render(<ViewModeToggle />);
+    fireEvent.click(screen.getByTestId('gantt-axis-customer'));
+    expect(mockSetGanttAxis).toHaveBeenCalledWith('customer');
   });
 });

--- a/web/src/contexts/ScheduleContext.tsx
+++ b/web/src/contexts/ScheduleContext.tsx
@@ -14,6 +14,8 @@ interface ScheduleContextValue {
   goToWeek: (date: Date) => void;
   viewMode: 'day' | 'week';
   setViewMode: (mode: 'day' | 'week') => void;
+  ganttAxis: 'staff' | 'customer';
+  setGanttAxis: (axis: 'staff' | 'customer') => void;
 }
 
 const ScheduleContext = createContext<ScheduleContextValue | null>(null);
@@ -28,6 +30,7 @@ export function ScheduleProvider({ children }: { children: ReactNode }) {
     DAY_OF_WEEK_ORDER[new Date().getDay() === 0 ? 6 : new Date().getDay() - 1]
   );
   const [viewMode, setViewMode] = useState<'day' | 'week'>('day');
+  const [ganttAxis, setGanttAxis] = useState<'staff' | 'customer'>('staff');
 
   const goToNextWeek = useCallback(() => setWeekStart((w) => addWeeks(w, 1)), []);
   const goToPrevWeek = useCallback(() => setWeekStart((w) => subWeeks(w, 1)), []);
@@ -35,7 +38,7 @@ export function ScheduleProvider({ children }: { children: ReactNode }) {
 
   return (
     <ScheduleContext.Provider
-      value={{ weekStart, selectedDay, setSelectedDay, goToNextWeek, goToPrevWeek, goToWeek, viewMode, setViewMode }}
+      value={{ weekStart, selectedDay, setSelectedDay, goToNextWeek, goToPrevWeek, goToWeek, viewMode, setViewMode, ganttAxis, setGanttAxis }}
     >
       {children}
     </ScheduleContext.Provider>


### PR DESCRIPTION
## Summary

- **StatsBar 差分カード**: `diffMap` を受け取り、最適化後の変更件数を violet で表示（A+B）
- **利用者軸ビュー**: 日表示で「スタッフ軸 / 利用者軸」切替ボタンを追加。利用者軸選択時は `CustomerGanttChart` を表示（利用者行 × 時刻軸）（C）
- **基本予定一覧**: `/masters/weekly-schedule` ページ新規作成。利用者の `weekly_services` を曜日別テーブルで一覧表示（D）
- **Header ナビ**: 設定ドロップダウンに「基本予定一覧」リンク追加
- **コンポーネントテスト**: `NotifyConfirmDialog` / `NotifyChangesButton` のテスト追加（各5件）、`ViewModeToggle` テストを軸ボタン対応に更新

## Test plan

- [x] `npm test -- --run` — 318件グリーン確認
- [x] `npx tsc --noEmit` — 新規コード由来のエラーなし確認
- [ ] 基本予定一覧ページ: 利用者の weekly_services が曜日別に表示されること
- [ ] 利用者軸ビュー: 「利用者軸」ボタン押下で CustomerGanttChart に切替わること
- [ ] StatsBar: 最適化後に「最適化差分 N件変更」が violet で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)