### PR TITLE
feat: staff_count複数割当 D&Dバリデーション対応 (#112)

### DIFF
--- a/docs/schema/firestore-schema.md
+++ b/docs/schema/firestore-schema.md
@@ -121,6 +121,7 @@
 | end_time | string (HH:MM) | Yes | 終了時刻 |
 | service_type | `'physical_care' \| 'daily_living' \| 'mixed' \| 'prevention' \| 'private' \| 'disability' \| 'transport_support' \| 'severe_visiting'` | Yes | サービス種別 |
 | assigned_staff_ids | string[] | Yes | 割当スタッフID |
+| staff_count | number | No | 必要スタッフ数（省略時は1。ServiceSlot.staff_count からも導出可能） |
 | status | `'pending' \| 'assigned' \| 'completed' \| 'cancelled'` | Yes | ステータス |
 | linked_order_id | string | No | 連続訪問リンク先オーダーID |
 | manually_edited | boolean | Yes | 手動編集フラグ |

--- a/shared/types/order.ts
+++ b/shared/types/order.ts
@@ -11,6 +11,7 @@ export interface Order {
   end_time: TimeString;
   service_type: ServiceType;
   assigned_staff_ids: string[];
+  staff_count?: number;
   status: OrderStatus;
   linked_order_id?: string;
   manually_edited: boolean;

--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -19,9 +19,11 @@ interface GanttBarProps {
   onClick?: (order: Order) => void;
   /** ドラッグ元のヘルパーID（null = 未割当） */
   sourceHelperId: string | null;
+  /** 必要スタッフ人数（バッジ表示用） */
+  staffCount?: number;
 }
 
-export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, violationType, violationMessages, onClick, sourceHelperId }: GanttBarProps) {
+export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, violationType, violationMessages, onClick, sourceHelperId, staffCount }: GanttBarProps) {
   const slotWidth = useSlotWidth();
   const startCol = timeToColumn(order.start_time);
   const endCol = timeToColumn(order.end_time);
@@ -81,6 +83,11 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
         {order.status === 'completed' && <Check className="h-3 w-3 shrink-0" />}
         {order.status === 'cancelled' && <X className="h-3 w-3 shrink-0" />}
         {customerName}
+        {staffCount != null && staffCount > 1 && (
+          <span className="shrink-0 ml-0.5 px-1 py-0.5 rounded text-[10px] font-bold leading-none bg-white/30 text-current">
+            {order.assigned_staff_ids.length}/{staffCount}
+          </span>
+        )}
       </span>
     </button>
   );

--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -7,6 +7,7 @@ import { UnavailableBlocksOverlay } from './UnavailableBlocksOverlay';
 import { TOTAL_SLOTS, HELPER_NAME_WIDTH_PX, GANTT_START_HOUR, GANTT_END_HOUR, calculateUnavailableBlocks, timeToColumn } from './constants';
 import { useSlotWidth } from './GanttScaleContext';
 import type { Order, Customer, StaffUnavailability, DayOfWeek } from '@/types';
+import { getStaffCount } from '@/lib/dnd/staffCount';
 import type { HelperScheduleRow } from '@/hooks/useScheduleData';
 import type { ViolationMap } from '@/lib/constraints/checker';
 import type { DropZoneStatus } from '@/lib/dnd/types';
@@ -136,16 +137,19 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
           const orderViolations = violations.get(order.id);
           const hasError = orderViolations?.some((v) => v.severity === 'error');
           const hasWarning = orderViolations?.some((v) => v.severity === 'warning');
+          const customer = customers.get(order.customer_id);
+          const sc = getStaffCount(order, customer, day);
           return (
             <GanttBar
               key={order.id}
               order={order}
-              customer={customers.get(order.customer_id)}
+              customer={customer}
               hasViolation={!!orderViolations?.length}
               violationType={hasError ? 'error' : hasWarning ? 'warning' : undefined}
               violationMessages={orderViolations?.map((v) => v.message)}
               onClick={onOrderClick}
               sourceHelperId={row.helper.id}
+              staffCount={sc}
             />
           );
         })}

--- a/web/src/lib/dnd/__tests__/computeStaffIds.test.ts
+++ b/web/src/lib/dnd/__tests__/computeStaffIds.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { computeNewStaffIds } from '../computeStaffIds';
+
+describe('computeNewStaffIds', () => {
+  describe('同一ヘルパー', () => {
+    it('sourceHelperId == targetId → 既存の割当を維持（時間変更のみ）', () => {
+      const result = computeNewStaffIds(['A', 'B'], 'A', 'A', 2);
+      expect(result).toEqual(['A', 'B']);
+    });
+  });
+
+  describe('staff_count=1（単一スタッフ）', () => {
+    it('置換', () => {
+      const result = computeNewStaffIds(['A'], 'B', 'A', 1);
+      expect(result).toEqual(['B']);
+    });
+
+    it('未割当 → 新規割当', () => {
+      const result = computeNewStaffIds([], 'B', null, 1);
+      expect(result).toEqual(['B']);
+    });
+  });
+
+  describe('staff_count=2（複数スタッフ）', () => {
+    it('空きあり（0人割当）→ 追加', () => {
+      const result = computeNewStaffIds([], 'B', null, 2);
+      expect(result).toEqual(['B']);
+    });
+
+    it('空きあり（1人割当済み）→ 追加', () => {
+      const result = computeNewStaffIds(['A'], 'B', 'A', 2);
+      // sourceHelperId != targetId かつ staff_count > 1 かつ空きあり → 追加
+      // ただしsourceHelperIdがassignedにあるので除去して追加
+      // → A は維持、B を追加
+      expect(result).toEqual(['A', 'B']);
+    });
+
+    it('空きあり（別のヘルパーが1人割当）→ 追加', () => {
+      const result = computeNewStaffIds(['C'], 'B', null, 2);
+      expect(result).toEqual(['C', 'B']);
+    });
+
+    it('満員（2人割当）→ sourceHelperIdをtargetIdに置換', () => {
+      const result = computeNewStaffIds(['A', 'C'], 'B', 'A', 2);
+      expect(result).toEqual(['C', 'B']);
+    });
+
+    it('満員 + sourceHelperId が割当に含まれない → targetIdを末尾に追加', () => {
+      // sourceHelperIdがassignedにないケース（手動でおかしい状態）
+      // → 後方互換でtargetIdを追加
+      const result = computeNewStaffIds(['C', 'D'], 'B', null, 2);
+      // 満員だが sourceHelperId=null → targetIdを末尾追加（最善の選択）
+      expect(result).toEqual(['C', 'D', 'B']);
+    });
+  });
+
+  describe('staff_count=3（3人体制）', () => {
+    it('2人割当済み → 追加', () => {
+      const result = computeNewStaffIds(['A', 'C'], 'B', null, 3);
+      expect(result).toEqual(['A', 'C', 'B']);
+    });
+
+    it('3人割当済み（満員）→ sourceHelperIdをtargetIdに置換', () => {
+      const result = computeNewStaffIds(['A', 'C', 'D'], 'B', 'A', 3);
+      expect(result).toEqual(['C', 'D', 'B']);
+    });
+  });
+
+  describe('重複防止', () => {
+    it('targetId がすでに割当済み → 重複しない', () => {
+      const result = computeNewStaffIds(['A', 'B'], 'B', 'A', 2);
+      // targetIdがすでに割当済みの場合は変更なし
+      expect(result).toEqual(['A', 'B']);
+    });
+  });
+});

--- a/web/src/lib/dnd/__tests__/staffCount.test.ts
+++ b/web/src/lib/dnd/__tests__/staffCount.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { getStaffCount } from '../staffCount';
+import type { Order, Customer, DayOfWeek } from '@/types';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 'order-1',
+    customer_id: 'cust-1',
+    week_start_date: new Date('2026-02-09'),
+    date: new Date('2026-02-09'),
+    start_time: '09:00',
+    end_time: '10:00',
+    service_type: 'physical_care',
+    assigned_staff_ids: [],
+    status: 'pending',
+    manually_edited: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeCustomer(overrides: Partial<Customer> = {}): Customer {
+  return {
+    id: 'cust-1',
+    name: { family: '山田', given: '花子' },
+    address: '東京都',
+    location: { lat: 35.6, lng: 139.7 },
+    ng_staff_ids: [],
+    preferred_staff_ids: [],
+    weekly_services: {},
+    service_manager: 'mgr-1',
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+describe('getStaffCount', () => {
+  describe('フォールバック優先順位', () => {
+    it('order.staff_count がある場合 → そのまま返す', () => {
+      const order = makeOrder({ staff_count: 3 });
+      expect(getStaffCount(order)).toBe(3);
+    });
+
+    it('order.staff_count=1 → 1を返す（0は除外）', () => {
+      const order = makeOrder({ staff_count: 1 });
+      expect(getStaffCount(order)).toBe(1);
+    });
+
+    it('customer の weekly_services からマッチ → staff_count を返す', () => {
+      const order = makeOrder({ start_time: '09:00', end_time: '10:30', service_type: 'physical_care' });
+      const customer = makeCustomer({
+        weekly_services: {
+          monday: [
+            { start_time: '09:00', end_time: '10:30', service_type: 'physical_care', staff_count: 2 },
+          ],
+        },
+      });
+      expect(getStaffCount(order, customer, 'monday')).toBe(2);
+    });
+
+    it('時刻・サービス種別が一致しない → デフォルト 1', () => {
+      const order = makeOrder({ start_time: '09:00', end_time: '10:00', service_type: 'physical_care' });
+      const customer = makeCustomer({
+        weekly_services: {
+          monday: [
+            { start_time: '11:00', end_time: '12:00', service_type: 'physical_care', staff_count: 2 },
+          ],
+        },
+      });
+      expect(getStaffCount(order, customer, 'monday')).toBe(1);
+    });
+
+    it('サービス種別が異なる → デフォルト 1', () => {
+      const order = makeOrder({ start_time: '09:00', end_time: '10:00', service_type: 'physical_care' });
+      const customer = makeCustomer({
+        weekly_services: {
+          monday: [
+            { start_time: '09:00', end_time: '10:00', service_type: 'daily_living', staff_count: 2 },
+          ],
+        },
+      });
+      expect(getStaffCount(order, customer, 'monday')).toBe(1);
+    });
+
+    it('customer 未定義 → デフォルト 1', () => {
+      const order = makeOrder();
+      expect(getStaffCount(order, undefined, 'monday')).toBe(1);
+    });
+
+    it('day 未定義（customer あり） → weekly_services を参照せずデフォルト 1', () => {
+      const order = makeOrder({ start_time: '09:00', end_time: '10:00', service_type: 'physical_care' });
+      const customer = makeCustomer({
+        weekly_services: {
+          monday: [
+            { start_time: '09:00', end_time: '10:00', service_type: 'physical_care', staff_count: 2 },
+          ],
+        },
+      });
+      // dayを渡さない
+      expect(getStaffCount(order, customer)).toBe(1);
+    });
+
+    it('weekly_services が空 → デフォルト 1', () => {
+      const order = makeOrder();
+      const customer = makeCustomer({ weekly_services: {} });
+      expect(getStaffCount(order, customer, 'monday')).toBe(1);
+    });
+
+    it('order.staff_count が優先（customer のマッチより上）', () => {
+      const order = makeOrder({
+        start_time: '09:00', end_time: '10:00', service_type: 'physical_care', staff_count: 3,
+      });
+      const customer = makeCustomer({
+        weekly_services: {
+          monday: [
+            { start_time: '09:00', end_time: '10:00', service_type: 'physical_care', staff_count: 2 },
+          ],
+        },
+      });
+      expect(getStaffCount(order, customer, 'monday')).toBe(3);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('日曜日も正しく参照できる', () => {
+      const order = makeOrder({ start_time: '10:00', end_time: '11:00', service_type: 'daily_living' });
+      const customer = makeCustomer({
+        weekly_services: {
+          sunday: [
+            { start_time: '10:00', end_time: '11:00', service_type: 'daily_living', staff_count: 2 },
+          ],
+        },
+      });
+      expect(getStaffCount(order, customer, 'sunday')).toBe(2);
+    });
+
+    it('複数のサービスから正しいものをマッチ', () => {
+      const order = makeOrder({ start_time: '14:00', end_time: '15:00', service_type: 'mixed' });
+      const customer = makeCustomer({
+        weekly_services: {
+          wednesday: [
+            { start_time: '09:00', end_time: '10:00', service_type: 'physical_care', staff_count: 1 },
+            { start_time: '14:00', end_time: '15:00', service_type: 'mixed', staff_count: 2 },
+          ],
+        },
+      });
+      expect(getStaffCount(order, customer, 'wednesday')).toBe(2);
+    });
+  });
+});

--- a/web/src/lib/dnd/computeStaffIds.ts
+++ b/web/src/lib/dnd/computeStaffIds.ts
@@ -1,0 +1,45 @@
+/**
+ * D&Dドロップ後の新しい割当スタッフIDリストを計算する（純粋関数）。
+ *
+ * ロジック:
+ * - sourceHelperId == targetId → 既存維持（時間変更のみ）
+ * - targetId がすでに割当済み → 変更なし
+ * - staff_count == 1 → [targetId]（置換）
+ * - 空きあり (assigned.length < staffCount) → [...assigned, targetId]（追加）
+ * - 満員 + sourceHelperId が割当に含まれる → sourceHelperIdをtargetIdに置換
+ * - 満員 + sourceHelperId が割当に含まれない → 末尾に追加（フォールバック）
+ */
+export function computeNewStaffIds(
+  currentAssigned: string[],
+  targetId: string,
+  sourceHelperId: string | null,
+  staffCount: number,
+): string[] {
+  // 同一ヘルパー → 変更なし（時間変更のみのケース）
+  if (sourceHelperId === targetId) {
+    return [...currentAssigned];
+  }
+
+  // targetId がすでに割当済み → 変更なし（二重割当防止）
+  if (currentAssigned.includes(targetId)) {
+    return [...currentAssigned];
+  }
+
+  // staff_count=1 → 単純置換
+  if (staffCount === 1) {
+    return [targetId];
+  }
+
+  // 空きがある → 追加
+  if (currentAssigned.length < staffCount) {
+    return [...currentAssigned, targetId];
+  }
+
+  // 満員 + sourceHelperId が割当に含まれる → ソースを置換
+  if (sourceHelperId !== null && currentAssigned.includes(sourceHelperId)) {
+    return [...currentAssigned.filter((id) => id !== sourceHelperId), targetId];
+  }
+
+  // 満員 + sourceHelperId が割当に含まれない → 末尾に追加（フォールバック）
+  return [...currentAssigned, targetId];
+}

--- a/web/src/lib/dnd/staffCount.ts
+++ b/web/src/lib/dnd/staffCount.ts
@@ -1,0 +1,37 @@
+import type { Order, Customer, DayOfWeek } from '@/types';
+
+/**
+ * オーダーに必要なスタッフ数を返す（3段階フォールバック）。
+ * 1. order.staff_count があればそれを使用
+ * 2. customer.weekly_services[day] から時刻・サービス種別マッチで導出
+ * 3. デフォルト 1
+ */
+export function getStaffCount(
+  order: Order,
+  customer?: Customer,
+  day?: DayOfWeek,
+): number {
+  // フォールバック1: order に直接定義されている場合
+  if (order.staff_count != null) {
+    return order.staff_count;
+  }
+
+  // フォールバック2: customer の weekly_services から導出
+  if (customer && day) {
+    const slots = customer.weekly_services[day];
+    if (slots) {
+      const matched = slots.find(
+        (slot) =>
+          slot.start_time === order.start_time &&
+          slot.end_time === order.end_time &&
+          slot.service_type === order.service_type,
+      );
+      if (matched != null) {
+        return matched.staff_count;
+      }
+    }
+  }
+
+  // フォールバック3: デフォルト
+  return 1;
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -125,6 +125,7 @@ export interface Order {
   end_time: TimeString;
   service_type: ServiceType;
   assigned_staff_ids: string[];
+  staff_count?: number;
   status: OrderStatus;
   linked_order_id?: string;
   manually_edited: boolean;


### PR DESCRIPTION
## Summary

- `Order` 型に `staff_count?: number` を追加（shared/types・web/src/types）
- `getStaffCount()` ユーティリティ実装（3段階フォールバック: order.staff_count → customer.weekly_services → デフォルト1）
- `computeNewStaffIds()` 純粋関数実装（空き追加 / 満員置換 / 同一ヘルパー維持）
- `validateDrop()` に同一ヘルパー二重割当防止（error）・満員警告（warning）・`not_visited`複数人体制対応を追加
- `checkConstraints()` に `staff_count_under`（warning）/ `staff_count_over`（error）違反タイプを追加
- `useDragAndDrop`: 複数割当ロジック適用・未割当セクションへのドロップ改善（multi-staff時はsourceHelperのみ除去）
- `GanttBar` に `staffCount > 1` 時の「M/N」バッジを追加
- Firestoreスキーマドキュメントに `staff_count` フィールドを追記

## Test plan

- [x] `staffCount.ts` ユニットテスト: 11件（3段階フォールバック）
- [x] `computeStaffIds.ts` ユニットテスト: 11件（追加・置換・満員・重複防止）
- [x] `validation.test.ts` 追加ケース: 5件（二重割当拒否・満員警告・not_visited警告）
- [x] `checker.test.ts` 追加ケース: 4件（under警告・over error・正常系）
- [x] 全テストスイート 349件 GREEN（回帰なし）

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)