### PR TITLE
feat: travel_times移動時間D&Dバリデーション統合（Issue #113）

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -31,7 +31,7 @@ import type { Order, DayOfWeek } from '@/types';
 function SchedulePage() {
   const { welcomeOpen, closeWelcome, reopenWelcome } = useWelcomeDialog();
   const { weekStart, selectedDay, setSelectedDay, viewMode, setViewMode, ganttAxis } = useScheduleContext();
-  const { customers, helpers, orderCounts, getDaySchedule, unavailability, loading } =
+  const { customers, helpers, orderCounts, getDaySchedule, unavailability, loading, travelTimeLookup } =
     useScheduleData(weekStart);
 
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
@@ -69,8 +69,9 @@ function SchedulePage() {
         unavailability,
         day: selectedDay,
         serviceTypes,
+        travelTimeLookup,
       }),
-    [schedule, helpers, customers, unavailability, selectedDay, serviceTypes]
+    [schedule, helpers, customers, unavailability, selectedDay, serviceTypes, travelTimeLookup]
   );
 
   // DnD — distance: 5px でクリックとドラッグを区別
@@ -100,6 +101,7 @@ function SchedulePage() {
     day: selectedDay,
     slotWidth,
     serviceTypes,
+    travelTimeLookup,
   });
 
   const handleDayNavigation = useCallback(

--- a/web/src/hooks/useDragAndDrop.ts
+++ b/web/src/hooks/useDragAndDrop.ts
@@ -21,10 +21,11 @@ interface UseDragAndDropInput {
   day: DayOfWeek;
   slotWidth: number;
   serviceTypes?: Map<string, ServiceTypeDoc>;
+  travelTimeLookup?: Map<string, number>;
 }
 
 export function useDragAndDrop(input: UseDragAndDropInput) {
-  const { helperRows, unassignedOrders, helpers, customers, unavailability, day, slotWidth, serviceTypes } = input;
+  const { helperRows, unassignedOrders, helpers, customers, unavailability, day, slotWidth, serviceTypes, travelTimeLookup } = input;
   const [dropZoneStatuses, setDropZoneStatuses] = useState<Map<string, DropZoneStatus>>(new Map());
   const [activeOrder, setActiveOrder] = useState<Order | null>(null);
   const [previewTimes, setPreviewTimes] = useState<{ startTime: string; endTime: string } | null>(null);
@@ -116,6 +117,7 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
         newStartTime: shifted?.newStartTime,
         newEndTime: shifted?.newEndTime,
         serviceTypes,
+        travelTimeLookup,
       });
 
       const status: DropZoneStatus = !result.allowed
@@ -211,6 +213,7 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
         newStartTime: shifted?.newStartTime,
         newEndTime: shifted?.newEndTime,
         serviceTypes,
+        travelTimeLookup,
       });
 
       if (!result.allowed) {

--- a/web/src/hooks/useScheduleData.ts
+++ b/web/src/hooks/useScheduleData.ts
@@ -5,6 +5,7 @@ import { useHelpers } from './useHelpers';
 import { useCustomers } from './useCustomers';
 import { useOrders } from './useOrders';
 import { useStaffUnavailability } from './useStaffUnavailability';
+import { useTravelTimes } from './useTravelTimes';
 import type { DayOfWeek, Order, Helper, Customer } from '@/types';
 import { DAY_OF_WEEK_ORDER } from '@/types';
 
@@ -31,6 +32,7 @@ export function useScheduleData(weekStart: Date) {
   const { customers, loading: customersLoading } = useCustomers();
   const { orders, loading: ordersLoading } = useOrders(weekStart);
   const { unavailability, loading: unavailabilityLoading } = useStaffUnavailability(weekStart);
+  const { travelTimeLookup } = useTravelTimes();
 
   const loading = helpersLoading || customersLoading || ordersLoading || unavailabilityLoading;
 
@@ -103,5 +105,6 @@ export function useScheduleData(weekStart: Date) {
     orderCounts,
     getDaySchedule,
     loading,
+    travelTimeLookup,
   };
 }

--- a/web/src/hooks/useTravelTimes.ts
+++ b/web/src/hooks/useTravelTimes.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { getDb } from '@/lib/firebase';
+import { buildTravelTimeLookup } from '@/lib/travelTime';
+
+/**
+ * Firestore travel_times コレクションを一括取得し、
+ * `${fromId}_${toId}` をキーとする移動時間（分）の Map を返す。
+ *
+ * 変更頻度が低いため onSnapshot ではなく getDocs で取得。
+ */
+export function useTravelTimes() {
+  const [travelTimeLookup, setTravelTimeLookup] = useState<Map<string, number>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getDocs(collection(getDb(), 'travel_times'))
+      .then((snapshot) => {
+        if (cancelled) return;
+        const docs = snapshot.docs.map((doc) => ({
+          id: doc.id,
+          travel_time_minutes: (doc.data().travel_time_minutes ?? 0) as number,
+        }));
+        setTravelTimeLookup(buildTravelTimeLookup(docs));
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setError(err);
+        setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, []);
+
+  return { travelTimeLookup, loading, error };
+}

--- a/web/src/lib/__tests__/travelTime.test.ts
+++ b/web/src/lib/__tests__/travelTime.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { parseTravelTimeDocId, buildTravelTimeLookup, getTravelMinutes } from '../travelTime';
+
+// --- parseTravelTimeDocId ---
+
+describe('parseTravelTimeDocId', () => {
+  it('正常系: from_{A}_to_{B} → { fromId, toId }', () => {
+    const result = parseTravelTimeDocId('from_cust001_to_cust002');
+    expect(result).toEqual({ fromId: 'cust001', toId: 'cust002' });
+  });
+
+  it('正常系: IDにハイフンを含む', () => {
+    const result = parseTravelTimeDocId('from_cust-001_to_cust-002');
+    expect(result).toEqual({ fromId: 'cust-001', toId: 'cust-002' });
+  });
+
+  it('異常系: from_ プレフィックスなし → null', () => {
+    const result = parseTravelTimeDocId('cust001_to_cust002');
+    expect(result).toBeNull();
+  });
+
+  it('異常系: _to_ セパレータなし → null', () => {
+    const result = parseTravelTimeDocId('from_cust001_cust002');
+    expect(result).toBeNull();
+  });
+
+  it('異常系: 空文字 → null', () => {
+    const result = parseTravelTimeDocId('');
+    expect(result).toBeNull();
+  });
+
+  it('異常系: from_ のみ → null', () => {
+    const result = parseTravelTimeDocId('from__to_');
+    // from と to が空文字の場合はnull
+    expect(result).toBeNull();
+  });
+
+  it('正常系: IDに数字のみ', () => {
+    const result = parseTravelTimeDocId('from_123_to_456');
+    expect(result).toEqual({ fromId: '123', toId: '456' });
+  });
+});
+
+// --- buildTravelTimeLookup ---
+
+describe('buildTravelTimeLookup', () => {
+  it('複数のドキュメントからlookupを構築', () => {
+    const docs = [
+      { id: 'from_A_to_B', travel_time_minutes: 10 },
+      { id: 'from_B_to_C', travel_time_minutes: 20 },
+    ];
+    const lookup = buildTravelTimeLookup(docs);
+    expect(lookup.get('A_B')).toBe(10);
+    expect(lookup.get('B_C')).toBe(20);
+  });
+
+  it('無効なドキュメントIDはスキップ', () => {
+    const docs = [
+      { id: 'from_A_to_B', travel_time_minutes: 10 },
+      { id: 'invalid-id', travel_time_minutes: 5 },
+    ];
+    const lookup = buildTravelTimeLookup(docs);
+    expect(lookup.size).toBe(1);
+    expect(lookup.get('A_B')).toBe(10);
+  });
+
+  it('空配列 → 空のMap', () => {
+    const lookup = buildTravelTimeLookup([]);
+    expect(lookup.size).toBe(0);
+  });
+});
+
+// --- getTravelMinutes ---
+
+describe('getTravelMinutes', () => {
+  const lookup = new Map([
+    ['A_B', 10],
+    ['C_D', 25],
+  ]);
+
+  it('A→B の移動時間を返す', () => {
+    expect(getTravelMinutes(lookup, 'A', 'B')).toBe(10);
+  });
+
+  it('双方向検索: B→A も10分を返す（A→Bのデータから）', () => {
+    expect(getTravelMinutes(lookup, 'B', 'A')).toBe(10);
+  });
+
+  it('データなし → null を返す', () => {
+    expect(getTravelMinutes(lookup, 'X', 'Y')).toBeNull();
+  });
+
+  it('同一利用者（A→A）→ 0 を返す', () => {
+    expect(getTravelMinutes(lookup, 'A', 'A')).toBe(0);
+  });
+
+  it('C→D の移動時間を返す', () => {
+    expect(getTravelMinutes(lookup, 'C', 'D')).toBe(25);
+  });
+
+  it('D→C の双方向検索', () => {
+    expect(getTravelMinutes(lookup, 'D', 'C')).toBe(25);
+  });
+});

--- a/web/src/lib/travelTime.ts
+++ b/web/src/lib/travelTime.ts
@@ -1,0 +1,60 @@
+/**
+ * travel_times コレクションのユーティリティ。
+ *
+ * FirestoreドキュメントID形式: `from_{fromCustomerId}_to_{toCustomerId}`
+ * Lookupキー形式: `${fromId}_${toId}`
+ */
+
+/** ドキュメントIDをパース */
+export function parseTravelTimeDocId(docId: string): { fromId: string; toId: string } | null {
+  if (!docId.startsWith('from_')) return null;
+
+  // "from_{fromId}_to_{toId}" の形式で "_to_" を区切りに分割
+  const withoutPrefix = docId.slice('from_'.length); // "{fromId}_to_{toId}"
+  const separator = '_to_';
+  const sepIndex = withoutPrefix.indexOf(separator);
+  if (sepIndex === -1) return null;
+
+  const fromId = withoutPrefix.slice(0, sepIndex);
+  const toId = withoutPrefix.slice(sepIndex + separator.length);
+
+  // 空文字は無効
+  if (!fromId || !toId) return null;
+
+  return { fromId, toId };
+}
+
+/** Firestoreドキュメント配列からlookup Mapを構築 */
+export function buildTravelTimeLookup(
+  docs: Array<{ id: string; travel_time_minutes: number }>,
+): Map<string, number> {
+  const lookup = new Map<string, number>();
+  for (const doc of docs) {
+    const parsed = parseTravelTimeDocId(doc.id);
+    if (!parsed) continue;
+    lookup.set(`${parsed.fromId}_${parsed.toId}`, doc.travel_time_minutes);
+  }
+  return lookup;
+}
+
+/**
+ * 2地点間の移動時間（分）を取得。
+ * - 同一地点 → 0
+ * - A→B データがなければ B→A を試みる（双方向検索）
+ * - データなし → null
+ */
+export function getTravelMinutes(
+  lookup: Map<string, number>,
+  fromCustomerId: string,
+  toCustomerId: string,
+): number | null {
+  if (fromCustomerId === toCustomerId) return 0;
+
+  const forward = lookup.get(`${fromCustomerId}_${toCustomerId}`);
+  if (forward != null) return forward;
+
+  const backward = lookup.get(`${toCustomerId}_${fromCustomerId}`);
+  if (backward != null) return backward;
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- `travel_times` Firestoreコレクションをフロントエンドのバリデーションに統合（Issue #113）
- Optimizerに実装済みの移動時間ハード制約をD&DバリデーションとganttConstraints表示に対応

## 変更内容

### 新規ファイル
- `web/src/lib/travelTime.ts` — `parseTravelTimeDocId` / `buildTravelTimeLookup` / `getTravelMinutes` ユーティリティ（双方向検索）
- `web/src/lib/__tests__/travelTime.test.ts` — 16テスト（全件GREEN）
- `web/src/hooks/useTravelTimes.ts` — Firestore `travel_times`一括取得フック（`getDocs`）

### 変更ファイル
- `web/src/hooks/useScheduleData.ts` — `travelTimeLookup` を返却値に追加
- `web/src/lib/dnd/validation.ts` — `validateDrop()` に移動時間不足 **warning** チェックを追加
  - 直前/直後オーダーとのギャップ < travel_time_minutes → 警告（error ではない）
  - 同一利用者間・lookup未提供はスキップ（後方互換）
- `web/src/lib/constraints/checker.ts` — `checkConstraints()` に `travel_time` 違反チェックを追加
  - Violation type に `'travel_time'` (warning) を追加
- `web/src/hooks/useDragAndDrop.ts` — `travelTimeLookup` をvalidateDropに渡す
- `web/src/app/page.tsx` — `checkConstraints` / `useDragAndDrop` に `travelTimeLookup` を配線

### テスト追加
| テストファイル | 追加件数 | 内容 |
|---|---|---|
| `travelTime.test.ts` | 16件 | docIDパース/lookup構築/双方向検索 |
| `validation.test.ts` | +4件 | 移動時間不足/十分/同一利用者/lookup未提供 |
| `checker.test.ts` | +3件 | travel_time違反検出/十分/lookup未提供 |

**合計372テスト全件GREEN（回帰なし）**

## Test plan

- [ ] `cd web && npm test -- --run` で372テスト全件GREEN確認
- [ ] ローカル Emulator 起動 (`./scripts/dev-start.sh`)
- [ ] 移動時間不足のオーダー間D&DでtooltipにWarning表示確認
- [ ] GanttBar の移動時間違反で黄色ring表示確認

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)