### PR TITLE
feat: 利用者・ヘルパーマスタに詳細シート（読み取り専用）を追加

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import { Plus, Pencil, Search } from 'lucide-react';
 import { useCustomers } from '@/hooks/useCustomers';
+import { useHelpers } from '@/hooks/useHelpers';
 import { useAuthRole } from '@/lib/auth/AuthProvider';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -16,15 +17,19 @@ import {
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { CustomerEditDialog } from '@/components/masters/CustomerEditDialog';
+import { CustomerDetailSheet } from '@/components/masters/CustomerDetailSheet';
 import { DAY_OF_WEEK_ORDER } from '@/types';
 import type { Customer } from '@/types';
 
 export default function CustomersPage() {
   const { customers, loading } = useCustomers();
+  const { helpers } = useHelpers();
   const { canEditCustomers } = useAuthRole();
   const [search, setSearch] = useState('');
   const [editTarget, setEditTarget] = useState<Customer | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [detailTarget, setDetailTarget] = useState<Customer | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
 
   const filtered = useMemo(() => {
     const list = Array.from(customers.values());
@@ -46,6 +51,16 @@ export default function CustomersPage() {
   const openEdit = (customer: Customer) => {
     setEditTarget(customer);
     setDialogOpen(true);
+  };
+
+  const openDetail = (customer: Customer) => {
+    setDetailTarget(customer);
+    setDetailOpen(true);
+  };
+
+  const handleDetailEdit = () => {
+    setDetailOpen(false);
+    if (detailTarget) openEdit(detailTarget);
   };
 
   const serviceDayCount = (customer: Customer) =>
@@ -107,7 +122,11 @@ export default function CustomersPage() {
               </TableRow>
             ) : (
               filtered.map((customer, index) => (
-                <TableRow key={customer.id} className={index % 2 === 1 ? 'bg-muted/30' : ''}>
+                <TableRow
+                  key={customer.id}
+                  className={`cursor-pointer hover:bg-muted/50 ${index % 2 === 1 ? 'bg-muted/30' : ''}`}
+                  onClick={() => openDetail(customer)}
+                >
                   <TableCell className="font-medium">
                     {customer.name.family} {customer.name.given}
                   </TableCell>
@@ -141,7 +160,10 @@ export default function CustomersPage() {
                         variant="ghost"
                         size="sm"
                         className="h-8 w-8 p-0"
-                        onClick={() => openEdit(customer)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openEdit(customer);
+                        }}
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </Button>
@@ -157,6 +179,14 @@ export default function CustomersPage() {
       <p className="text-xs text-muted-foreground">
         全{customers.size}件{search && `（表示: ${filtered.length}件）`}
       </p>
+
+      <CustomerDetailSheet
+        customer={detailTarget}
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
+        onEdit={handleDetailEdit}
+        helpers={helpers}
+      />
 
       <CustomerEditDialog
         open={dialogOpen}

--- a/web/src/app/masters/helpers/page.tsx
+++ b/web/src/app/masters/helpers/page.tsx
@@ -16,6 +16,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { HelperEditDialog } from '@/components/masters/HelperEditDialog';
+import { HelperDetailSheet } from '@/components/masters/HelperDetailSheet';
 import type { Helper } from '@/types';
 
 const TRANSPORTATION_LABELS: Record<string, string> = {
@@ -36,6 +37,8 @@ export default function HelpersPage() {
   const [search, setSearch] = useState('');
   const [editTarget, setEditTarget] = useState<Helper | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [detailTarget, setDetailTarget] = useState<Helper | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
 
   const filtered = useMemo(() => {
     const list = Array.from(helpers.values());
@@ -57,6 +60,16 @@ export default function HelpersPage() {
   const openEdit = (helper: Helper) => {
     setEditTarget(helper);
     setDialogOpen(true);
+  };
+
+  const openDetail = (helper: Helper) => {
+    setDetailTarget(helper);
+    setDetailOpen(true);
+  };
+
+  const handleDetailEdit = () => {
+    setDetailOpen(false);
+    if (detailTarget) openEdit(detailTarget);
   };
 
   if (loading) {
@@ -115,7 +128,11 @@ export default function HelpersPage() {
               </TableRow>
             ) : (
               filtered.map((helper, index) => (
-                <TableRow key={helper.id} className={index % 2 === 1 ? 'bg-muted/30' : ''}>
+                <TableRow
+                  key={helper.id}
+                  className={`cursor-pointer hover:bg-muted/50 ${index % 2 === 1 ? 'bg-muted/30' : ''}`}
+                  onClick={() => openDetail(helper)}
+                >
                   <TableCell className="font-medium">
                     {helper.name.family} {helper.name.given}
                   </TableCell>
@@ -155,7 +172,10 @@ export default function HelpersPage() {
                         variant="ghost"
                         size="sm"
                         className="h-8 w-8 p-0"
-                        onClick={() => openEdit(helper)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openEdit(helper);
+                        }}
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </Button>
@@ -171,6 +191,14 @@ export default function HelpersPage() {
       <p className="text-xs text-muted-foreground">
         全{helpers.size}件{search && `（表示: ${filtered.length}件）`}
       </p>
+
+      <HelperDetailSheet
+        helper={detailTarget}
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
+        onEdit={handleDetailEdit}
+        customers={customers}
+      />
 
       <HelperEditDialog
         open={dialogOpen}

--- a/web/src/components/masters/CustomerDetailSheet.tsx
+++ b/web/src/components/masters/CustomerDetailSheet.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { Pencil } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { useServiceTypes } from '@/hooks/useServiceTypes';
+import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
+import type { Customer, Helper } from '@/types';
+
+const GENDER_REQUIREMENT_LABELS: Record<string, string> = {
+  any: '指定なし',
+  female: '女性のみ',
+  male: '男性のみ',
+};
+
+const IRREGULAR_PATTERN_LABELS: Record<string, string> = {
+  biweekly: '隔週',
+  monthly: '月次',
+  temporary_stop: '一時停止',
+};
+
+interface CustomerDetailSheetProps {
+  customer: Customer | null;
+  open: boolean;
+  onClose: () => void;
+  onEdit: () => void;
+  helpers: Map<string, Helper>;
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+      {children}
+    </h4>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex gap-2 text-sm">
+      <span className="w-28 shrink-0 text-muted-foreground">{label}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  );
+}
+
+export function CustomerDetailSheet({
+  customer,
+  open,
+  onClose,
+  onEdit,
+  helpers,
+}: CustomerDetailSheetProps) {
+  const { serviceTypes } = useServiceTypes();
+
+  if (!customer) return null;
+
+  const fullName = `${customer.name.family} ${customer.name.given}`;
+  const ngHelpers = customer.ng_staff_ids.map((id) => helpers.get(id)).filter(Boolean) as Helper[];
+  const preferredHelpers = customer.preferred_staff_ids
+    .map((id) => helpers.get(id))
+    .filter(Boolean) as Helper[];
+
+  const hasContact =
+    customer.home_care_office ||
+    customer.care_manager_name ||
+    customer.consultation_support_office ||
+    customer.support_specialist_name;
+
+  const hasExternalIds =
+    customer.aozora_id || customer.kaiso_id || customer.karakara_id || customer.cura_id;
+
+  const hasWeeklyServices = DAY_OF_WEEK_ORDER.some(
+    (d) => customer.weekly_services[d] && customer.weekly_services[d]!.length > 0
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+      <SheetContent className="sm:max-w-lg overflow-y-auto" data-testid="customer-detail-sheet">
+        <SheetHeader>
+          <div className="flex items-start justify-between gap-2">
+            <SheetTitle className="text-lg">{fullName}</SheetTitle>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onEdit}
+              data-testid="customer-detail-edit-button"
+              className="shrink-0"
+            >
+              <Pencil className="mr-1 h-3.5 w-3.5" />
+              編集
+            </Button>
+          </div>
+        </SheetHeader>
+
+        <div className="mt-4 space-y-6">
+          {/* 1. 基本情報 */}
+          <section>
+            <SectionHeader>基本情報</SectionHeader>
+            <div className="space-y-2 rounded-lg border bg-accent/30 p-3">
+              <InfoRow label="住所" value={customer.address} />
+              <InfoRow label="サ責" value={customer.service_manager} />
+              {customer.phone_number && (
+                <InfoRow label="電話番号" value={customer.phone_number} />
+              )}
+              <InfoRow
+                label="性別要件"
+                value={GENDER_REQUIREMENT_LABELS[customer.gender_requirement ?? 'any'] ?? '指定なし'}
+              />
+              {customer.household_id && (
+                <InfoRow label="世帯ID" value={customer.household_id} />
+              )}
+            </div>
+          </section>
+
+          {/* 2. 連絡先・関連機関（値ありのみ） */}
+          {hasContact && (
+            <section>
+              <SectionHeader>連絡先・関連機関</SectionHeader>
+              <div className="space-y-2 rounded-lg border bg-accent/30 p-3">
+                {customer.home_care_office && (
+                  <InfoRow label="担当居宅" value={customer.home_care_office} />
+                )}
+                {customer.care_manager_name && (
+                  <InfoRow label="ケアマネ" value={customer.care_manager_name} />
+                )}
+                {customer.consultation_support_office && (
+                  <InfoRow label="相談支援事業所" value={customer.consultation_support_office} />
+                )}
+                {customer.support_specialist_name && (
+                  <InfoRow label="相談支援専門員" value={customer.support_specialist_name} />
+                )}
+              </div>
+            </section>
+          )}
+
+          {/* 3. NG/推奨スタッフ */}
+          {(ngHelpers.length > 0 || preferredHelpers.length > 0) && (
+            <section>
+              <SectionHeader>NG / 推奨スタッフ</SectionHeader>
+              <div className="space-y-2">
+                {ngHelpers.length > 0 && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">NG</p>
+                    <div className="flex flex-wrap gap-1.5" data-testid="ng-staff-badges">
+                      {ngHelpers.map((h) => (
+                        <Badge key={h.id} variant="destructive">
+                          {h.name.family} {h.name.given}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {preferredHelpers.length > 0 && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">推奨</p>
+                    <div className="flex flex-wrap gap-1.5" data-testid="preferred-staff-badges">
+                      {preferredHelpers.map((h) => (
+                        <Badge key={h.id} variant="secondary">
+                          {h.name.family} {h.name.given}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </section>
+          )}
+
+          {/* 4. 週間サービス */}
+          {hasWeeklyServices && (
+            <section>
+              <SectionHeader>週間サービス</SectionHeader>
+              <div className="overflow-x-auto rounded-lg border">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="p-2 text-left font-medium text-muted-foreground">曜日</th>
+                      <th className="p-2 text-left font-medium text-muted-foreground">時間帯</th>
+                      <th className="p-2 text-left font-medium text-muted-foreground">種別</th>
+                      <th className="p-2 text-right font-medium text-muted-foreground">人数</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {DAY_OF_WEEK_ORDER.flatMap((day) => {
+                      const slots = customer.weekly_services[day];
+                      if (!slots || slots.length === 0) return [];
+                      return slots.map((slot, idx) => (
+                        <tr key={`${day}-${idx}`} className="border-b last:border-0">
+                          {idx === 0 && (
+                            <td
+                              className="p-2 font-medium"
+                              rowSpan={slots.length}
+                            >
+                              {DAY_OF_WEEK_LABELS[day]}
+                            </td>
+                          )}
+                          <td className="p-2">
+                            {slot.start_time} - {slot.end_time}
+                          </td>
+                          <td className="p-2">
+                            {serviceTypes.get(slot.service_type)?.label ?? slot.service_type}
+                          </td>
+                          <td className="p-2 text-right">{slot.staff_count}名</td>
+                        </tr>
+                      ));
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+
+          {/* 5. 不定期パターン（非空時のみ） */}
+          {customer.irregular_patterns && customer.irregular_patterns.length > 0 && (
+            <section>
+              <SectionHeader>不定期パターン</SectionHeader>
+              <div className="space-y-1.5">
+                {customer.irregular_patterns.map((p, i) => (
+                  <div key={i} className="flex items-center gap-2 text-sm">
+                    <Badge variant="outline">
+                      {IRREGULAR_PATTERN_LABELS[p.type] ?? p.type}
+                    </Badge>
+                    <span className="text-muted-foreground">{p.description}</span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* 6. 備考（値ありのみ） */}
+          {customer.notes && (
+            <section>
+              <SectionHeader>備考</SectionHeader>
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap">{customer.notes}</p>
+            </section>
+          )}
+
+          {/* 7. 外部連携ID */}
+          {hasExternalIds && (
+            <section>
+              <SectionHeader>外部連携ID</SectionHeader>
+              <div className="space-y-2 rounded-lg border bg-accent/30 p-3">
+                {customer.aozora_id && <InfoRow label="あおぞらID" value={customer.aozora_id} />}
+                {customer.kaiso_id && <InfoRow label="介ソルID" value={customer.kaiso_id} />}
+                {customer.karakara_id && <InfoRow label="カカラID" value={customer.karakara_id} />}
+                {customer.cura_id && <InfoRow label="CURA ID" value={customer.cura_id} />}
+              </div>
+            </section>
+          )}
+
+          {/* 8. メタ情報 */}
+          <section>
+            <SectionHeader>メタ情報</SectionHeader>
+            <div className="space-y-2 text-xs text-muted-foreground">
+              <div className="flex gap-2">
+                <span className="w-24 shrink-0">作成日時</span>
+                <span>{customer.created_at.toLocaleString('ja-JP')}</span>
+              </div>
+              <div className="flex gap-2">
+                <span className="w-24 shrink-0">更新日時</span>
+                <span>{customer.updated_at.toLocaleString('ja-JP')}</span>
+              </div>
+            </div>
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/components/masters/CustomerEditDialog.tsx
+++ b/web/src/components/masters/CustomerEditDialog.tsx
@@ -8,6 +8,7 @@ import { APIProvider } from '@vis.gl/react-google-maps';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -122,6 +123,7 @@ export function CustomerEditDialog({
       <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isNew ? '利用者を追加' : '利用者を編集'}</DialogTitle>
+          <DialogDescription>利用者の基本情報とサービス設定を管理します</DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/web/src/components/masters/HelperDetailSheet.tsx
+++ b/web/src/components/masters/HelperDetailSheet.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { Pencil } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
+import type { Helper, Customer, TrainingStatus } from '@/types';
+
+const TRANSPORTATION_LABELS: Record<string, string> = {
+  car: '車',
+  bicycle: '自転車',
+  walk: '徒歩',
+};
+
+const EMPLOYMENT_LABELS: Record<string, string> = {
+  full_time: '常勤',
+  part_time: '非常勤',
+};
+
+const GENDER_LABELS: Record<string, string> = {
+  male: '男性',
+  female: '女性',
+};
+
+const TRAINING_STATUS_LABELS: Record<TrainingStatus, string> = {
+  not_visited: '未訪問',
+  training: '同行研修中',
+  independent: '自立',
+};
+
+const TRAINING_STATUS_VARIANTS: Record<TrainingStatus, 'outline' | 'secondary' | 'default'> = {
+  not_visited: 'outline',
+  training: 'secondary',
+  independent: 'default',
+};
+
+interface HelperDetailSheetProps {
+  helper: Helper | null;
+  open: boolean;
+  onClose: () => void;
+  onEdit: () => void;
+  customers: Map<string, Customer>;
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+      {children}
+    </h4>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex gap-2 text-sm">
+      <span className="w-28 shrink-0 text-muted-foreground">{label}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  );
+}
+
+export function HelperDetailSheet({
+  helper,
+  open,
+  onClose,
+  onEdit,
+  customers,
+}: HelperDetailSheetProps) {
+  if (!helper) return null;
+
+  const fullName = `${helper.name.family} ${helper.name.given}`;
+
+  const hasWeeklyAvailability = DAY_OF_WEEK_ORDER.some(
+    (d) => helper.weekly_availability[d] && helper.weekly_availability[d]!.length > 0
+  );
+
+  const trainingEntries = Object.entries(helper.customer_training_status).filter(
+    ([, status]) => status !== 'independent'
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+      <SheetContent className="sm:max-w-lg overflow-y-auto" data-testid="helper-detail-sheet">
+        <SheetHeader>
+          <div className="flex items-start justify-between gap-2">
+            <SheetTitle className="text-lg">{fullName}</SheetTitle>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onEdit}
+              data-testid="helper-detail-edit-button"
+              className="shrink-0"
+            >
+              <Pencil className="mr-1 h-3.5 w-3.5" />
+              編集
+            </Button>
+          </div>
+        </SheetHeader>
+
+        <div className="mt-4 space-y-6">
+          {/* 1. 基本情報 */}
+          <section>
+            <SectionHeader>基本情報</SectionHeader>
+            <div className="space-y-2 rounded-lg border bg-accent/30 p-3">
+              {helper.name.short && <InfoRow label="短縮名" value={helper.name.short} />}
+              <InfoRow label="性別" value={GENDER_LABELS[helper.gender] ?? helper.gender} />
+              {helper.employee_number && (
+                <InfoRow label="社員番号" value={helper.employee_number} />
+              )}
+              {helper.phone_number && (
+                <InfoRow label="電話番号" value={helper.phone_number} />
+              )}
+              {helper.address && <InfoRow label="住所" value={helper.address} />}
+              <InfoRow
+                label="資格"
+                value={
+                  helper.qualifications.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {helper.qualifications.map((q) => (
+                        <Badge key={q} variant="secondary" className="text-xs">
+                          {q}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : (
+                    'なし'
+                  )
+                }
+              />
+              <InfoRow
+                label="身体介護"
+                value={helper.can_physical_care ? '対応可' : '不可'}
+              />
+              <InfoRow
+                label="分断勤務"
+                value={helper.split_shift_allowed ? '可' : '不可'}
+              />
+            </div>
+          </section>
+
+          {/* 2. 雇用条件 */}
+          <section>
+            <SectionHeader>雇用条件</SectionHeader>
+            <div className="space-y-2 rounded-lg border bg-accent/30 p-3">
+              <InfoRow
+                label="雇用形態"
+                value={EMPLOYMENT_LABELS[helper.employment_type] ?? helper.employment_type}
+              />
+              <InfoRow
+                label="移動手段"
+                value={TRANSPORTATION_LABELS[helper.transportation] ?? helper.transportation}
+              />
+              <InfoRow
+                label="希望時間"
+                value={`${helper.preferred_hours.min} 〜 ${helper.preferred_hours.max} 時間/週`}
+              />
+              <InfoRow
+                label="対応可能時間"
+                value={`${helper.available_hours.min} 〜 ${helper.available_hours.max} 時間/週`}
+              />
+            </div>
+          </section>
+
+          {/* 3. 週間勤務可能時間 */}
+          {hasWeeklyAvailability && (
+            <section>
+              <SectionHeader>週間勤務可能時間</SectionHeader>
+              <div className="overflow-x-auto rounded-lg border">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="p-2 text-left font-medium text-muted-foreground">曜日</th>
+                      <th className="p-2 text-left font-medium text-muted-foreground">時間帯</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {DAY_OF_WEEK_ORDER.flatMap((day) => {
+                      const slots = helper.weekly_availability[day];
+                      if (!slots || slots.length === 0) return [];
+                      return slots.map((slot, idx) => (
+                        <tr key={`${day}-${idx}`} className="border-b last:border-0">
+                          {idx === 0 && (
+                            <td className="p-2 font-medium" rowSpan={slots.length}>
+                              {DAY_OF_WEEK_LABELS[day]}
+                            </td>
+                          )}
+                          <td className="p-2">
+                            {slot.start_time} - {slot.end_time}
+                          </td>
+                        </tr>
+                      ));
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+
+          {/* 4. 利用者別研修状態（independentを除く） */}
+          {trainingEntries.length > 0 && (
+            <section>
+              <SectionHeader>利用者別研修状態</SectionHeader>
+              <div className="space-y-1.5" data-testid="training-status-list">
+                {trainingEntries.map(([customerId, status]) => {
+                  const customer = customers.get(customerId);
+                  const displayName = customer
+                    ? `${customer.name.family} ${customer.name.given}`
+                    : customerId;
+                  return (
+                    <div key={customerId} className="flex items-center justify-between text-sm">
+                      <span>{displayName}</span>
+                      <Badge variant={TRAINING_STATUS_VARIANTS[status as TrainingStatus]}>
+                        {TRAINING_STATUS_LABELS[status as TrainingStatus] ?? status}
+                      </Badge>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* 5. メタ情報 */}
+          <section>
+            <SectionHeader>メタ情報</SectionHeader>
+            <div className="space-y-2 text-xs text-muted-foreground">
+              <div className="flex gap-2">
+                <span className="w-24 shrink-0">作成日時</span>
+                <span>{helper.created_at.toLocaleString('ja-JP')}</span>
+              </div>
+              <div className="flex gap-2">
+                <span className="w-24 shrink-0">更新日時</span>
+                <span>{helper.updated_at.toLocaleString('ja-JP')}</span>
+              </div>
+            </div>
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/components/masters/HelperEditDialog.tsx
+++ b/web/src/components/masters/HelperEditDialog.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -133,6 +134,7 @@ export function HelperEditDialog({
       <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isNew ? 'ヘルパーを追加' : 'ヘルパーを編集'}</DialogTitle>
+          <DialogDescription>ヘルパーの基本情報と勤務条件を管理します</DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CustomerDetailSheet } from '../CustomerDetailSheet';
+import type { Customer, Helper } from '@/types';
+
+// Firebase 接続が必要なフックはモック
+vi.mock('@/hooks/useServiceTypes', () => ({
+  useServiceTypes: () => ({
+    serviceTypes: new Map([
+      ['physical_care', { id: 'physical_care', code: 'physical_care', label: '身体介護', short_label: '身体', requires_physical_care_cert: true, sort_order: 1, created_at: new Date(), updated_at: new Date() }],
+      ['daily_living', { id: 'daily_living', code: 'daily_living', label: '生活援助', short_label: '生活', requires_physical_care_cert: false, sort_order: 2, created_at: new Date(), updated_at: new Date() }],
+    ]),
+    sortedList: [],
+    loading: false,
+    error: null,
+  }),
+}));
+
+// Radix Sheet はポータルを使うためインラインでモック
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  SheetContent: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    <div {...props}>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+function makeCustomer(overrides: Partial<Customer> = {}): Customer {
+  return {
+    id: 'cust-1',
+    name: { family: '田中', given: '花子' },
+    address: '東京都新宿区1-1-1',
+    location: { lat: 35.6895, lng: 139.6917 },
+    ng_staff_ids: [],
+    preferred_staff_ids: [],
+    weekly_services: {},
+    service_manager: '山田太郎',
+    gender_requirement: 'any',
+    created_at: new Date('2025-01-01T00:00:00'),
+    updated_at: new Date('2025-06-01T00:00:00'),
+    ...overrides,
+  };
+}
+
+function makeHelper(id: string, family: string, given: string): Helper {
+  return {
+    id,
+    name: { family, given },
+    qualifications: [],
+    can_physical_care: false,
+    transportation: 'bicycle',
+    weekly_availability: {},
+    preferred_hours: { min: 20, max: 40 },
+    available_hours: { min: 20, max: 40 },
+    customer_training_status: {},
+    employment_type: 'part_time',
+    gender: 'female',
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onEdit: vi.fn(),
+  helpers: new Map<string, Helper>(),
+};
+
+describe('CustomerDetailSheet', () => {
+  it('open=false のとき何も表示しない', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} open={false} />);
+    expect(screen.queryByTestId('customer-detail-sheet')).not.toBeInTheDocument();
+  });
+
+  it('customer=null のとき何も表示しない', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={null} />);
+    expect(screen.queryByTestId('customer-detail-sheet')).not.toBeInTheDocument();
+  });
+
+  it('利用者名が表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    expect(screen.getByText('田中 花子')).toBeInTheDocument();
+  });
+
+  it('住所・サ責・性別要件が表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    expect(screen.getByText('東京都新宿区1-1-1')).toBeInTheDocument();
+    expect(screen.getByText('山田太郎')).toBeInTheDocument();
+    expect(screen.getByText('指定なし')).toBeInTheDocument();
+  });
+
+  it('電話番号は値があるときのみ表示される', () => {
+    const customer = makeCustomer({ phone_number: '03-1234-5678' });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    expect(screen.getByText('03-1234-5678')).toBeInTheDocument();
+  });
+
+  it('連絡先セクションは全て空のとき表示されない', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    expect(screen.queryByText('連絡先・関連機関')).not.toBeInTheDocument();
+  });
+
+  it('担当居宅が設定されている場合に連絡先セクションが表示される', () => {
+    const customer = makeCustomer({
+      home_care_office: 'ケアセンター新宿',
+      care_manager_name: '佐藤ケアマネ',
+    });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    expect(screen.getByText('ケアセンター新宿')).toBeInTheDocument();
+    expect(screen.getByText('佐藤ケアマネ')).toBeInTheDocument();
+  });
+
+  it('NGスタッフのバッジが表示される', () => {
+    const helper = makeHelper('h-1', '鈴木', '一郎');
+    const helpers = new Map([['h-1', helper]]);
+    const customer = makeCustomer({ ng_staff_ids: ['h-1'] });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} helpers={helpers} />);
+    expect(screen.getByTestId('ng-staff-badges')).toBeInTheDocument();
+    expect(screen.getByText('鈴木 一郎')).toBeInTheDocument();
+  });
+
+  it('推奨スタッフのバッジが表示される', () => {
+    const helper = makeHelper('h-2', '高橋', '二郎');
+    const helpers = new Map([['h-2', helper]]);
+    const customer = makeCustomer({ preferred_staff_ids: ['h-2'] });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} helpers={helpers} />);
+    expect(screen.getByTestId('preferred-staff-badges')).toBeInTheDocument();
+    expect(screen.getByText('高橋 二郎')).toBeInTheDocument();
+  });
+
+  it('週間サービスが設定されている場合にテーブルが表示される', () => {
+    const customer = makeCustomer({
+      weekly_services: {
+        monday: [
+          { start_time: '09:00', end_time: '10:00', service_type: 'physical_care', staff_count: 1 },
+        ],
+      },
+    });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    expect(screen.getByText('月')).toBeInTheDocument();
+    expect(screen.getByText('09:00 - 10:00')).toBeInTheDocument();
+    expect(screen.getByText('身体介護')).toBeInTheDocument();
+    expect(screen.getByText('1名')).toBeInTheDocument();
+  });
+
+  it('週間サービスが空のとき週間サービスセクションが表示されない', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    expect(screen.queryByText('週間サービス')).not.toBeInTheDocument();
+  });
+
+  it('備考が設定されている場合に表示される', () => {
+    const customer = makeCustomer({ notes: '特記事項あり' });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    expect(screen.getByText('特記事項あり')).toBeInTheDocument();
+  });
+
+  it('備考が未設定のとき備考セクションが表示されない', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    expect(screen.queryByText('備考')).not.toBeInTheDocument();
+  });
+
+  it('外部IDが1つでもある場合に外部連携IDセクションが表示される', () => {
+    const customer = makeCustomer({ kaiso_id: 'KAISO-001' });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    expect(screen.getByText('KAISO-001')).toBeInTheDocument();
+  });
+
+  it('外部IDが全て空のとき外部連携IDセクションが表示されない', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    expect(screen.queryByText('外部連携ID')).not.toBeInTheDocument();
+  });
+
+  it('編集ボタンクリックで onEdit が呼ばれる', () => {
+    const onEdit = vi.fn();
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} onEdit={onEdit} />);
+    fireEvent.click(screen.getByTestId('customer-detail-edit-button'));
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it('不定期パターンが設定されている場合に表示される', () => {
+    const customer = makeCustomer({
+      irregular_patterns: [{ type: 'biweekly', description: '第1・3週のみ' }],
+    });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    expect(screen.getByText('隔週')).toBeInTheDocument();
+    expect(screen.getByText('第1・3週のみ')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/masters/__tests__/HelperDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/HelperDetailSheet.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HelperDetailSheet } from '../HelperDetailSheet';
+import type { Helper, Customer } from '@/types';
+
+// Radix Sheet はポータルを使うためインラインでモック
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  SheetContent: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    <div {...props}>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+function makeHelper(overrides: Partial<Helper> = {}): Helper {
+  return {
+    id: 'helper-1',
+    name: { family: '佐藤', given: '次郎' },
+    qualifications: [],
+    can_physical_care: false,
+    transportation: 'bicycle',
+    weekly_availability: {},
+    preferred_hours: { min: 20, max: 40 },
+    available_hours: { min: 20, max: 40 },
+    customer_training_status: {},
+    employment_type: 'part_time',
+    gender: 'male',
+    split_shift_allowed: false,
+    created_at: new Date('2025-01-01T00:00:00'),
+    updated_at: new Date('2025-06-01T00:00:00'),
+    ...overrides,
+  };
+}
+
+function makeCustomer(id: string, family: string, given: string): Customer {
+  return {
+    id,
+    name: { family, given },
+    address: '東京都渋谷区1-1',
+    location: { lat: 35.0, lng: 139.0 },
+    ng_staff_ids: [],
+    preferred_staff_ids: [],
+    weekly_services: {},
+    service_manager: '担当者',
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onEdit: vi.fn(),
+  customers: new Map<string, Customer>(),
+};
+
+describe('HelperDetailSheet', () => {
+  it('open=false のとき何も表示しない', () => {
+    render(<HelperDetailSheet {...defaultProps} helper={makeHelper()} open={false} />);
+    expect(screen.queryByTestId('helper-detail-sheet')).not.toBeInTheDocument();
+  });
+
+  it('helper=null のとき何も表示しない', () => {
+    render(<HelperDetailSheet {...defaultProps} helper={null} />);
+    expect(screen.queryByTestId('helper-detail-sheet')).not.toBeInTheDocument();
+  });
+
+  it('ヘルパー名が表示される', () => {
+    render(<HelperDetailSheet {...defaultProps} helper={makeHelper()} />);
+    expect(screen.getByText('佐藤 次郎')).toBeInTheDocument();
+  });
+
+  it('性別・雇用形態・移動手段が表示される', () => {
+    render(<HelperDetailSheet {...defaultProps} helper={makeHelper()} />);
+    expect(screen.getByText('男性')).toBeInTheDocument();
+    expect(screen.getByText('非常勤')).toBeInTheDocument();
+    expect(screen.getByText('自転車')).toBeInTheDocument();
+  });
+
+  it('希望時間と対応可能時間が表示される', () => {
+    const helper = makeHelper({ preferred_hours: { min: 20, max: 40 }, available_hours: { min: 30, max: 48 } });
+    render(<HelperDetailSheet {...defaultProps} helper={helper} />);
+    expect(screen.getByText('20 〜 40 時間/週')).toBeInTheDocument();
+    expect(screen.getByText('30 〜 48 時間/週')).toBeInTheDocument();
+  });
+
+  it('資格がある場合に表示される', () => {
+    const helper = makeHelper({ qualifications: ['介護福祉士', '実務者研修'] });
+    render(<HelperDetailSheet {...defaultProps} helper={helper} />);
+    expect(screen.getByText('介護福祉士')).toBeInTheDocument();
+    expect(screen.getByText('実務者研修')).toBeInTheDocument();
+  });
+
+  it('身体介護可の場合に「対応可」が表示される', () => {
+    const helper = makeHelper({ can_physical_care: true });
+    render(<HelperDetailSheet {...defaultProps} helper={helper} />);
+    expect(screen.getByText('対応可')).toBeInTheDocument();
+  });
+
+  it('電話番号は値があるときのみ表示される', () => {
+    const helper = makeHelper({ phone_number: '090-1234-5678' });
+    render(<HelperDetailSheet {...defaultProps} helper={helper} />);
+    expect(screen.getByText('090-1234-5678')).toBeInTheDocument();
+  });
+
+  it('週間勤務可能時間が設定されている場合にテーブルが表示される', () => {
+    const helper = makeHelper({
+      weekly_availability: {
+        tuesday: [{ start_time: '10:00', end_time: '15:00' }],
+      },
+    });
+    render(<HelperDetailSheet {...defaultProps} helper={helper} />);
+    expect(screen.getByText('火')).toBeInTheDocument();
+    expect(screen.getByText('10:00 - 15:00')).toBeInTheDocument();
+  });
+
+  it('週間勤務可能時間が空のとき週間テーブルが表示されない', () => {
+    render(<HelperDetailSheet {...defaultProps} helper={makeHelper()} />);
+    expect(screen.queryByText('週間勤務可能時間')).not.toBeInTheDocument();
+  });
+
+  it('研修中の利用者が研修状態リストに表示される', () => {
+    const customer = makeCustomer('cust-1', '田中', '花子');
+    const customers = new Map([['cust-1', customer]]);
+    const helper = makeHelper({
+      customer_training_status: { 'cust-1': 'training' },
+    });
+    render(<HelperDetailSheet {...defaultProps} helper={helper} customers={customers} />);
+    expect(screen.getByTestId('training-status-list')).toBeInTheDocument();
+    expect(screen.getByText('田中 花子')).toBeInTheDocument();
+    expect(screen.getByText('同行研修中')).toBeInTheDocument();
+  });
+
+  it('independent な利用者は研修状態リストに表示されない', () => {
+    const customer = makeCustomer('cust-2', '高橋', '三郎');
+    const customers = new Map([['cust-2', customer]]);
+    const helper = makeHelper({
+      customer_training_status: { 'cust-2': 'independent' },
+    });
+    render(<HelperDetailSheet {...defaultProps} helper={helper} customers={customers} />);
+    expect(screen.queryByTestId('training-status-list')).not.toBeInTheDocument();
+  });
+
+  it('編集ボタンクリックで onEdit が呼ばれる', () => {
+    const onEdit = vi.fn();
+    render(<HelperDetailSheet {...defaultProps} helper={makeHelper()} onEdit={onEdit} />);
+    fireEvent.click(screen.getByTestId('helper-detail-edit-button'));
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it('短縮名がある場合に表示される', () => {
+    const helper = makeHelper({ name: { family: '佐藤', given: '次郎', short: '佐次' } });
+    render(<HelperDetailSheet {...defaultProps} helper={helper} />);
+    expect(screen.getByText('佐次')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- 利用者マスタ・ヘルパーマスタの一覧で**行クリック → 詳細シート表示**（読み取り専用）を実装
- `CustomerDetailSheet` / `HelperDetailSheet` を新規作成（Radix UI Sheet、右サイドパネル）
- 詳細シート内の「編集」ボタンで既存の EditDialog へシームレスに遷移
- `CustomerEditDialog` / `HelperEditDialog` に `DialogDescription` 追加（aria-describedby 警告を解消）
- ユニットテスト 31 件追加（CustomerDetailSheet: 17件、HelperDetailSheet: 14件）

## 表示内容

| コンポーネント | 表示セクション |
|---|---|
| CustomerDetailSheet | 基本情報・連絡先関連機関・NG/推奨スタッフ（名前解決）・週間サービステーブル・不定期パターン・備考・外部連携ID・メタ情報 |
| HelperDetailSheet | 基本情報（資格バッジ）・雇用条件・週間勤務可能時間テーブル・利用者別研修状態（independent除外）・メタ情報 |

## UIパターン

読み取り専用 = Sheet（右パネル）/ 編集 = Dialog — `OrderDetailPanel.tsx` のパターンを踏襲

## Test plan

- [x] `CustomerDetailSheet` ユニットテスト 17件 通過
- [x] `HelperDetailSheet` ユニットテスト 14件 通過
- [x] 全テストスイート（403件）回帰確認済み
- [ ] 手動: `/masters/customers` → 行クリック → シート表示 → 編集ボタン → EditDialog
- [ ] 手動: `/masters/helpers` → 同様の動作確認
- [ ] aria-describedby warning が出ないこと（DevTools Console）

🤖 Generated with [Claude Code](https://claude.com/claude-code)