### PR TITLE
feat: ガントチャートに変更確認チェックボタンを追加

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -23,6 +23,7 @@ import { useDragAndDrop } from '@/hooks/useDragAndDrop';
 import { useOrderEdit } from '@/hooks/useOrderEdit';
 import { useAssignmentDiff } from '@/hooks/useAssignmentDiff';
 import { checkConstraints } from '@/lib/constraints/checker';
+import { confirmManualEdit } from '@/lib/firestore/updateOrder';
 import { useServiceTypes } from '@/hooks/useServiceTypes';
 import { SLOT_WIDTH_PX } from '@/components/gantt/constants';
 import { DAY_OF_WEEK_ORDER } from '@/types';
@@ -135,6 +136,10 @@ function SchedulePage() {
     setDetailOpen(true);
   };
 
+  const handleConfirmManualEdit = useCallback(async (orderId: string) => {
+    await confirmManualEdit(orderId);
+  }, []);
+
   const assignedHelpers = useMemo(() => {
     if (!selectedOrder) return [];
     return selectedOrder.assigned_staff_ids
@@ -216,6 +221,7 @@ function SchedulePage() {
                 onSlotWidthChange={handleSlotWidthChange}
                 previewTimes={previewTimes}
                 dropMessage={dropMessage}
+                onConfirmManualEdit={handleConfirmManualEdit}
               />
             </DndContext>
           )

--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -3,7 +3,7 @@
 import { memo } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { Check, X } from 'lucide-react';
+import { Check, CheckCircle2, X } from 'lucide-react';
 import { timeToColumn, getServiceColor } from './constants';
 import { useSlotWidth } from './GanttScaleContext';
 import type { Order, Customer } from '@/types';
@@ -21,9 +21,11 @@ interface GanttBarProps {
   sourceHelperId: string | null;
   /** 必要スタッフ人数（バッジ表示用） */
   staffCount?: number;
+  /** 変更確認済みにするコールバック */
+  onConfirmManualEdit?: (orderId: string) => void;
 }
 
-export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, violationType, violationMessages, onClick, sourceHelperId, staffCount }: GanttBarProps) {
+export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, violationType, violationMessages, onClick, sourceHelperId, staffCount, onConfirmManualEdit }: GanttBarProps) {
   const slotWidth = useSlotWidth();
   const startCol = timeToColumn(order.start_time);
   const endCol = timeToColumn(order.end_time);
@@ -87,6 +89,17 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
           <span className="shrink-0 ml-0.5 px-1 py-0.5 rounded text-[10px] font-bold leading-none bg-white/30 text-current">
             {order.assigned_staff_ids.length}/{staffCount}
           </span>
+        )}
+        {!isFinalized && order.manually_edited && onConfirmManualEdit && (
+          <button
+            data-testid={`confirm-edit-${order.id}`}
+            className="shrink-0 ml-auto -mr-1 p-0.5 rounded-full hover:bg-white/40 transition-colors"
+            onClick={(e) => { e.stopPropagation(); onConfirmManualEdit(order.id); }}
+            onPointerDown={(e) => e.stopPropagation()}
+            title="変更を確認済みにする"
+          >
+            <CheckCircle2 className="h-3.5 w-3.5" />
+          </button>
         )}
       </span>
     </button>

--- a/web/src/components/gantt/GanttChart.tsx
+++ b/web/src/components/gantt/GanttChart.tsx
@@ -27,9 +27,11 @@ interface GanttChartProps {
   previewTimes?: { startTime: string; endTime: string } | null;
   /** ドロップ拒否/警告の理由テキスト */
   dropMessage?: string | null;
+  /** 変更確認済みにするコールバック */
+  onConfirmManualEdit?: (orderId: string) => void;
 }
 
-export function GanttChart({ schedule, customers, violations, onOrderClick, dropZoneStatuses, unavailability, activeOrder, onSlotWidthChange, previewTimes, dropMessage }: GanttChartProps) {
+export function GanttChart({ schedule, customers, violations, onOrderClick, dropZoneStatuses, unavailability, activeOrder, onSlotWidthChange, previewTimes, dropMessage, onConfirmManualEdit }: GanttChartProps) {
   // コールバックref: totalOrders が 0→>0 になりDOMが現れたタイミングで再測定できるよう
   // useRef + useLayoutEffect([]) の代わりに useState を使用する
   const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
@@ -84,6 +86,7 @@ export function GanttChart({ schedule, customers, violations, onOrderClick, drop
                 activeOrder={activeOrder}
                 previewTimes={previewTimes}
                 dropMessage={dropMessage}
+                onConfirmManualEdit={onConfirmManualEdit}
               />
             ))}
             {/* ドラッグ中の時間帯ハイライト（全行横断） */}

--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -28,6 +28,8 @@ interface GanttRowProps {
   previewTimes?: { startTime: string; endTime: string } | null;
   /** ドロップ拒否/警告の理由テキスト */
   dropMessage?: string | null;
+  /** 変更確認済みにするコールバック */
+  onConfirmManualEdit?: (orderId: string) => void;
 }
 
 /** ゴーストバー用の薄い背景色（サービスタイプ別） */
@@ -53,7 +55,7 @@ const DROP_ZONE_STYLES: Record<DropZoneStatus, string> = {
 const SLOTS_PER_10MIN = 2;
 const TOTAL_10MIN_INTERVALS = (GANTT_END_HOUR - GANTT_START_HOUR) * 6; // 14h × 6 = 84
 
-export const GanttRow = memo(function GanttRow({ row, customers, violations, onOrderClick, dropZoneStatus = 'idle', index, unavailability, day, dayDate, activeOrder, previewTimes, dropMessage }: GanttRowProps) {
+export const GanttRow = memo(function GanttRow({ row, customers, violations, onOrderClick, dropZoneStatus = 'idle', index, unavailability, day, dayDate, activeOrder, previewTimes, dropMessage, onConfirmManualEdit }: GanttRowProps) {
   const slotWidth = useSlotWidth();
   const pxPer10Min = SLOTS_PER_10MIN * slotWidth;
   const helperName = row.helper.name.short ?? `${row.helper.name.family}${row.helper.name.given}`;
@@ -150,6 +152,7 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
               onClick={onOrderClick}
               sourceHelperId={row.helper.id}
               staffCount={sc}
+              onConfirmManualEdit={onConfirmManualEdit}
             />
           );
         })}

--- a/web/src/components/gantt/__tests__/GanttBar.test.tsx
+++ b/web/src/components/gantt/__tests__/GanttBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { GanttBar } from '../GanttBar';
 import type { Order } from '@/types';
 
@@ -124,5 +124,42 @@ describe('GanttBar - 手動編集リング表示', () => {
     const bar = screen.getByTestId('gantt-bar-order-1');
     expect(bar.className).toContain('ring-yellow-500');
     expect(bar.className).not.toContain('ring-blue-500');
+  });
+});
+
+describe('GanttBar - 変更確認チェックボタン', () => {
+  it('manually_edited: true + onConfirmManualEdit → チェックボタンが表示される', () => {
+    const order = makeOrder({ manually_edited: true });
+    const onConfirm = vi.fn();
+    render(<GanttBar order={order} sourceHelperId="h1" onConfirmManualEdit={onConfirm} />);
+
+    expect(screen.getByTestId('confirm-edit-order-1')).toBeTruthy();
+  });
+
+  it('manually_edited: false → チェックボタンが表示されない', () => {
+    const order = makeOrder({ manually_edited: false });
+    const onConfirm = vi.fn();
+    render(<GanttBar order={order} sourceHelperId="h1" onConfirmManualEdit={onConfirm} />);
+
+    expect(screen.queryByTestId('confirm-edit-order-1')).toBeNull();
+  });
+
+  it('チェックボタンクリック → onConfirmManualEdit が orderId で呼ばれる', () => {
+    const order = makeOrder({ manually_edited: true });
+    const onConfirm = vi.fn();
+    render(<GanttBar order={order} sourceHelperId="h1" onConfirmManualEdit={onConfirm} />);
+
+    fireEvent.click(screen.getByTestId('confirm-edit-order-1'));
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledWith('order-1');
+  });
+
+  it('status: completed → manually_edited: true でもチェックボタンが表示されない', () => {
+    const order = makeOrder({ status: 'completed', manually_edited: true });
+    const onConfirm = vi.fn();
+    render(<GanttBar order={order} sourceHelperId="h1" onConfirmManualEdit={onConfirm} />);
+
+    expect(screen.queryByTestId('confirm-edit-order-1')).toBeNull();
   });
 });

--- a/web/src/lib/firestore/updateOrder.ts
+++ b/web/src/lib/firestore/updateOrder.ts
@@ -87,6 +87,18 @@ export async function bulkUpdateOrderStatus(
 }
 
 /**
+ * 手動編集フラグをリセットして変更確認済みにする。
+ * 青リング（manually_edited: true）を消す際に使用。
+ */
+export async function confirmManualEdit(orderId: string): Promise<void> {
+  const orderRef = doc(getDb(), 'orders', orderId);
+  await updateDoc(orderRef, {
+    manually_edited: false,
+    updated_at: serverTimestamp(),
+  });
+}
+
+/**
  * オーダーの割当スタッフと時刻を同時に更新する。
  * D&D 時間軸移動時に使用。
  */


### PR DESCRIPTION
## Summary
- D&Dでオーダーを移動した際の青リング（`manually_edited: true`）をリセットするチェックボタンをガントバー上に追加
- `CheckCircle2` アイコンをバー右端に表示し、クリックで Firestore の `manually_edited` を `false` に更新
- `completed` / `cancelled` ステータスのバーにはボタン非表示

## 変更ファイル（6ファイル）
| ファイル | 内容 |
|---------|------|
| `web/src/lib/firestore/updateOrder.ts` | `confirmManualEdit()` 関数追加 |
| `web/src/components/gantt/GanttBar.tsx` | チェックボタンUI追加 |
| `web/src/components/gantt/GanttRow.tsx` | `onConfirmManualEdit` props伝播 |
| `web/src/components/gantt/GanttChart.tsx` | `onConfirmManualEdit` props伝播 |
| `web/src/app/page.tsx` | ハンドラ作成・GanttChartに渡す |
| `web/src/components/gantt/__tests__/GanttBar.test.tsx` | テスト4件追加 |

## Test plan
- [x] 全406テストがパス（`npm test`）
- [ ] D&Dでオーダー移動 → 青リング表示確認
- [ ] 青リング付きバーの右端にチェックアイコン表示確認
- [ ] チェックアイコンクリック → 青リング消失・チェックアイコン消失
- [ ] バー本体クリック → 詳細パネルが開く（チェックボタンの影響なし）
- [ ] completed/cancelledのバー → チェックボタン非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)