### PR TITLE
fix: iPad横向き（1024px）レスポンシブ対応

### DIFF
--- a/web/src/components/schedule/BulkCompleteButton.tsx
+++ b/web/src/components/schedule/BulkCompleteButton.tsx
@@ -55,9 +55,10 @@ export function BulkCompleteButton({ schedule }: BulkCompleteButtonProps) {
           size="sm"
           disabled={assignedOrders.length === 0}
           data-testid="bulk-complete-button"
+          title="一括確認"
         >
-          <CheckCheck className="mr-1.5 h-4 w-4" />
-          一括確認
+          <CheckCheck className="h-4 w-4 xl:mr-1.5" />
+          <span className="hidden xl:inline">一括確認</span>
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/web/src/components/schedule/DayTabs.tsx
+++ b/web/src/components/schedule/DayTabs.tsx
@@ -13,7 +13,7 @@ export function DayTabs({ orderCounts }: DayTabsProps) {
   const { selectedDay, setSelectedDay } = useScheduleContext();
 
   return (
-    <div className="flex gap-0.5 px-4 py-2" role="tablist">
+    <div className="flex gap-0 2xl:gap-0.5 px-2 2xl:px-4 py-2" role="tablist">
       {DAY_OF_WEEK_ORDER.map((day) => {
         const count = orderCounts?.[day] ?? 0;
         const isSelected = selectedDay === day;
@@ -26,7 +26,7 @@ export function DayTabs({ orderCounts }: DayTabsProps) {
             aria-selected={isSelected}
             onClick={() => setSelectedDay(day)}
             className={cn(
-              'relative flex items-center gap-1.5 rounded-t-md px-3 py-2 text-sm font-medium transition-all duration-200',
+              'relative flex items-center gap-1 2xl:gap-1.5 rounded-t-md px-2 2xl:px-3 py-1.5 2xl:py-2 text-xs 2xl:text-sm font-medium transition-all duration-200',
               isSelected
                 ? 'text-primary'
                 : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',

--- a/web/src/components/schedule/NotifyChangesButton.tsx
+++ b/web/src/components/schedule/NotifyChangesButton.tsx
@@ -108,8 +108,8 @@ export function NotifyChangesButton({ diffMap, helpers, customers, orders }: Pro
         onClick={() => setOpen(true)}
         title={changes.length > 0 ? `${changes.length}件の変更を通知` : '変更なし'}
       >
-        <Bell className="mr-1.5 h-4 w-4" />
-        変更通知
+        <Bell className="h-4 w-4 xl:mr-1.5" />
+        <span className="hidden xl:inline">変更通知</span>
         {changes.length > 0 && (
           <span className="ml-1 rounded-full bg-destructive px-1.5 py-0.5 text-xs text-destructive-foreground">
             {changes.length}

--- a/web/src/components/schedule/ResetButton.tsx
+++ b/web/src/components/schedule/ResetButton.tsx
@@ -51,13 +51,14 @@ export function ResetButton({ onHistoryClear }: ResetButtonProps = {}) {
           variant="outline"
           size="sm"
           disabled={loading}
+          title="リセット"
         >
           {loading ? (
-            <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin xl:mr-1.5" />
           ) : (
-            <RotateCcw className="mr-1.5 h-4 w-4" />
+            <RotateCcw className="h-4 w-4 xl:mr-1.5" />
           )}
-          リセット
+          <span className="hidden xl:inline">リセット</span>
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/web/src/components/schedule/StatsBar.tsx
+++ b/web/src/components/schedule/StatsBar.tsx
@@ -37,7 +37,7 @@ export function StatsBar({ schedule, violations, diffMap }: StatsBarProps) {
   const diffCount = diffMap?.size ?? 0;
 
   return (
-    <div className="grid grid-cols-6 gap-3 px-4 py-3">
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 px-4 py-3">
       {/* オーダー数 */}
       <div className="flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 shadow-brand-sm">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-accent">

--- a/web/src/components/schedule/ViewModeToggle.tsx
+++ b/web/src/components/schedule/ViewModeToggle.tsx
@@ -42,9 +42,10 @@ export function ViewModeToggle() {
             className="rounded-r-none border-r-0"
             onClick={() => setGanttAxis('staff')}
             aria-pressed={ganttAxis === 'staff'}
+            title="スタッフ軸"
           >
             <Users className="size-4" />
-            スタッフ軸
+            <span className="hidden xl:inline">スタッフ軸</span>
           </Button>
           <Button
             data-testid="gantt-axis-customer"
@@ -53,9 +54,10 @@ export function ViewModeToggle() {
             className="rounded-l-none"
             onClick={() => setGanttAxis('customer')}
             aria-pressed={ganttAxis === 'customer'}
+            title="利用者軸"
           >
             <User className="size-4" />
-            利用者軸
+            <span className="hidden xl:inline">利用者軸</span>
           </Button>
         </div>
       )}


### PR DESCRIPTION
## 問題

iPad横向き（1024px幅）でツールバーの総コンテンツ幅が約1361pxになり、横スクロールが発生。ViewModeToggle・StatsBar先頭2カードが画面左に見切れていた。

## 原因分析

ツールバー構成の幅見積もり（修正前）:
- ViewModeToggle（4ボタン全テキスト）: ~297px
- DayTabs（7タブ × ~70px）: ~534px
- 右側ボタン群（全テキスト）: ~530px
- **合計: ~1361px > 1024px** → 横スクロール発生

## 修正内容（6ファイル）

### ブレークポイント戦略
| 幅 | モード |
|---|---|
| <1024px | アイコンのみ、コンパクトタブ |
| 1024-1279px (iPad) | アイコンのみ、コンパクトタブ |
| 1280px+ (xl) | テキストラベル表示 |
| 1536px+ (2xl) | DayTabsをフルサイズで表示 |

### 変更ファイル
- **ViewModeToggle**: 「スタッフ軸」「利用者軸」テキストを `hidden xl:inline` で非表示（+title属性）
- **DayTabs**: `px-2 2xl:px-3`, `text-xs 2xl:text-sm` でコンパクト化
- **ResetButton**: `hidden xl:inline` でアイコンのみ表示（+title属性）
- **NotifyChangesButton**: `hidden xl:inline` でアイコンのみ表示
- **BulkCompleteButton**: `hidden xl:inline` でアイコンのみ表示（+title属性）
- **StatsBar**: `grid-cols-6` → `grid-cols-2 sm:grid-cols-3 lg:grid-cols-6`

## 修正後の幅見積もり
| 環境 | 幅 | 結果 |
|---|---|---|
| iPad 1024px | ~961px | ✅ 63px余裕 |
| Desktop 1280px | ~1235px | ✅ 45px余裕 |
| Wide 1536px+ | ~1361px | ✅ フルUI |

## テスト
- Vitest: 442 tests passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)