### PR TITLE
feat: 利用者編集UIに同一世帯・同一施設メンバー選択UIを追加（Phase C）

### DIFF
--- a/web/src/components/masters/CustomerEditDialog.tsx
+++ b/web/src/components/masters/CustomerEditDialog.tsx
@@ -20,6 +20,7 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { WeeklyServicesEditor } from './WeeklyServicesEditor';
 import { StaffMultiSelect } from './StaffMultiSelect';
+import { CustomerMultiSelect } from './CustomerMultiSelect';
 import { IrregularPatternEditor } from './IrregularPatternEditor';
 import { CustomerLocationPicker } from './CustomerLocationPicker';
 import {
@@ -33,6 +34,7 @@ import { customerSchema, type CustomerFormValues } from '@/lib/validation/schema
 import { createCustomer, updateCustomer } from '@/lib/firestore/customers';
 import { geocodeAddress } from '@/lib/geocoding';
 import { useHelpers } from '@/hooks/useHelpers';
+import { useCustomers } from '@/hooks/useCustomers';
 import type { Customer } from '@/types';
 
 const GOOGLE_MAPS_API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? '';
@@ -50,6 +52,7 @@ export function CustomerEditDialog({
 }: CustomerEditDialogProps) {
   const isNew = !customer;
   const { helpers } = useHelpers();
+  const { customers } = useCustomers();
   const [isGeocoding, setIsGeocoding] = useState(false);
 
   const {
@@ -280,7 +283,35 @@ export function CustomerEditDialog({
             )}
           </div>
 
-          {/* 同一世帯・同一施設は Phase C で選択UIを実装予定 */}
+          {/* 同一世帯 */}
+          <Controller
+            name="same_household_customer_ids"
+            control={control}
+            render={({ field }) => (
+              <CustomerMultiSelect
+                label="同一世帯"
+                selected={field.value ?? []}
+                onChange={field.onChange}
+                customers={customers}
+                excludeIds={customer ? [customer.id] : []}
+              />
+            )}
+          />
+
+          {/* 同一施設 */}
+          <Controller
+            name="same_facility_customer_ids"
+            control={control}
+            render={({ field }) => (
+              <CustomerMultiSelect
+                label="同一施設"
+                selected={field.value ?? []}
+                onChange={field.onChange}
+                customers={customers}
+                excludeIds={customer ? [customer.id] : []}
+              />
+            )}
+          />
 
           {/* 備考 */}
           <div className="space-y-1">

--- a/web/src/components/masters/CustomerMultiSelect.tsx
+++ b/web/src/components/masters/CustomerMultiSelect.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { X, Search, UserPlus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Checkbox } from '@/components/ui/checkbox';
+import type { Customer } from '@/types';
+
+interface CustomerMultiSelectProps {
+  label: string;
+  selected: string[];
+  onChange: (ids: string[]) => void;
+  customers: Map<string, Customer>;
+  excludeIds?: string[];
+}
+
+export function CustomerMultiSelect({
+  label,
+  selected,
+  onChange,
+  customers,
+  excludeIds = [],
+}: CustomerMultiSelectProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [draft, setDraft] = useState<string[]>([]);
+
+  const openDialog = () => {
+    setDraft([...selected]);
+    setSearch('');
+    setDialogOpen(true);
+  };
+
+  const toggleCustomer = (id: string) => {
+    setDraft((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const confirm = () => {
+    onChange(draft);
+    setDialogOpen(false);
+  };
+
+  const removeCustomer = (id: string) => {
+    onChange(selected.filter((x) => x !== id));
+  };
+
+  const filteredCustomers = useMemo(() => {
+    const list = Array.from(customers.values()).filter(
+      (c) => !excludeIds.includes(c.id)
+    );
+    if (!search.trim()) return list;
+    const q = search.trim().toLowerCase();
+    return list.filter(
+      (c) =>
+        c.name.family.toLowerCase().includes(q) ||
+        c.name.given.toLowerCase().includes(q) ||
+        (c.name.family_kana?.toLowerCase().includes(q)) ||
+        (c.name.given_kana?.toLowerCase().includes(q)) ||
+        c.address.toLowerCase().includes(q)
+    );
+  }, [customers, excludeIds, search]);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <Label className="text-sm font-medium">{label}</Label>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={openDialog}
+        >
+          <UserPlus className="mr-1 h-3 w-3" />
+          選択
+        </Button>
+      </div>
+
+      {selected.length > 0 ? (
+        <div className="flex flex-wrap gap-1">
+          {selected.map((id) => {
+            const c = customers.get(id);
+            return (
+              <Badge key={id} variant="secondary" className="gap-1 pr-1">
+                {c ? `${c.name.family} ${c.name.given}` : id}
+                <button
+                  type="button"
+                  onClick={() => removeCustomer(id)}
+                  className="ml-0.5 rounded-full hover:bg-muted-foreground/20 p-0.5"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">未設定</p>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={(v) => !v && setDialogOpen(false)}>
+        <DialogContent className="max-h-[70vh] max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{label}を選択</DialogTitle>
+          </DialogHeader>
+
+          <div className="relative">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="名前・住所で検索..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+
+          <div className="max-h-60 overflow-y-auto space-y-1">
+            {filteredCustomers.map((c) => (
+              <label
+                key={c.id}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted cursor-pointer"
+              >
+                <Checkbox
+                  checked={draft.includes(c.id)}
+                  onCheckedChange={() => toggleCustomer(c.id)}
+                />
+                <span className="text-sm">
+                  {c.name.family} {c.name.given}
+                </span>
+                <span className="text-xs text-muted-foreground ml-auto truncate max-w-[150px]">
+                  {c.address}
+                </span>
+              </label>
+            ))}
+            {filteredCustomers.length === 0 && (
+              <p className="text-center text-sm text-muted-foreground py-4">
+                該当なし
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+            >
+              キャンセル
+            </Button>
+            <Button type="button" onClick={confirm}>
+              確定（{draft.length}名）
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/web/src/components/masters/__tests__/CustomerMultiSelect.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerMultiSelect.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CustomerMultiSelect } from '../CustomerMultiSelect';
+import type { Customer } from '@/types';
+
+// Radix Dialog はポータルを使うためインラインでモック
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+function makeCustomer(id: string, family: string, given: string, address = '東京都'): Customer {
+  return {
+    id,
+    name: { family, given },
+    address,
+    location: { lat: 35.68, lng: 139.69 },
+    ng_staff_ids: [],
+    allowed_staff_ids: [],
+    preferred_staff_ids: [],
+    same_household_customer_ids: [],
+    same_facility_customer_ids: [],
+    weekly_services: {},
+    service_manager: 'テスト',
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+function makeCustomerMap(...entries: Customer[]): Map<string, Customer> {
+  return new Map(entries.map((c) => [c.id, c]));
+}
+
+describe('CustomerMultiSelect', () => {
+  it('should show "未設定" when no customers are selected', () => {
+    render(
+      <CustomerMultiSelect
+        label="同一世帯"
+        selected={[]}
+        onChange={() => {}}
+        customers={new Map()}
+      />
+    );
+    expect(screen.getByText('未設定')).toBeInTheDocument();
+  });
+
+  it('should display selected customer names as badges', () => {
+    const customers = makeCustomerMap(
+      makeCustomer('c1', '田中', '太郎'),
+      makeCustomer('c2', '佐藤', '花子'),
+    );
+    render(
+      <CustomerMultiSelect
+        label="同一世帯"
+        selected={['c1', 'c2']}
+        onChange={() => {}}
+        customers={customers}
+      />
+    );
+    expect(screen.getByText('田中 太郎')).toBeInTheDocument();
+    expect(screen.getByText('佐藤 花子')).toBeInTheDocument();
+  });
+
+  it('should remove a customer when badge X is clicked', () => {
+    const onChange = vi.fn();
+    const customers = makeCustomerMap(
+      makeCustomer('c1', '田中', '太郎'),
+      makeCustomer('c2', '佐藤', '花子'),
+    );
+    render(
+      <CustomerMultiSelect
+        label="同一世帯"
+        selected={['c1', 'c2']}
+        onChange={onChange}
+        customers={customers}
+      />
+    );
+    // Badge内のXボタン（aria-labelなし）をクエリ
+    const badges = screen.getAllByText(/田中|佐藤/).map((el) => el.closest('[data-slot="badge"]')!);
+    const removeButton = badges[0].querySelector('button')!;
+    fireEvent.click(removeButton);
+    expect(onChange).toHaveBeenCalledWith(['c2']);
+  });
+
+  it('should exclude customers specified in excludeIds', () => {
+    const customers = makeCustomerMap(
+      makeCustomer('c1', '田中', '太郎'),
+      makeCustomer('c2', '佐藤', '花子'),
+      makeCustomer('c3', '鈴木', '一郎'),
+    );
+    render(
+      <CustomerMultiSelect
+        label="同一世帯"
+        selected={[]}
+        onChange={() => {}}
+        customers={customers}
+        excludeIds={['c1']}
+      />
+    );
+    // ダイアログを開く
+    fireEvent.click(screen.getByText('選択'));
+    // c1は除外される
+    expect(screen.queryByText('田中 太郎')).not.toBeInTheDocument();
+    expect(screen.getByText('佐藤 花子')).toBeInTheDocument();
+    expect(screen.getByText('鈴木 一郎')).toBeInTheDocument();
+  });
+
+  it('should filter customers by search query (name)', () => {
+    const customers = makeCustomerMap(
+      makeCustomer('c1', '田中', '太郎'),
+      makeCustomer('c2', '佐藤', '花子'),
+    );
+    render(
+      <CustomerMultiSelect
+        label="同一世帯"
+        selected={[]}
+        onChange={() => {}}
+        customers={customers}
+      />
+    );
+    fireEvent.click(screen.getByText('選択'));
+    const searchInput = screen.getByPlaceholderText('名前・住所で検索...');
+    fireEvent.change(searchInput, { target: { value: '田中' } });
+    expect(screen.getByText('田中 太郎')).toBeInTheDocument();
+    expect(screen.queryByText('佐藤 花子')).not.toBeInTheDocument();
+  });
+
+  it('should filter customers by search query (address)', () => {
+    const customers = makeCustomerMap(
+      makeCustomer('c1', '田中', '太郎', '鹿児島市'),
+      makeCustomer('c2', '佐藤', '花子', '東京都'),
+    );
+    render(
+      <CustomerMultiSelect
+        label="同一施設"
+        selected={[]}
+        onChange={() => {}}
+        customers={customers}
+      />
+    );
+    fireEvent.click(screen.getByText('選択'));
+    const searchInput = screen.getByPlaceholderText('名前・住所で検索...');
+    fireEvent.change(searchInput, { target: { value: '鹿児島' } });
+    expect(screen.getByText('田中 太郎')).toBeInTheDocument();
+    expect(screen.queryByText('佐藤 花子')).not.toBeInTheDocument();
+  });
+
+  it('should call onChange with selected ids on confirm', () => {
+    const onChange = vi.fn();
+    const customers = makeCustomerMap(
+      makeCustomer('c1', '田中', '太郎'),
+      makeCustomer('c2', '佐藤', '花子'),
+    );
+    render(
+      <CustomerMultiSelect
+        label="同一世帯"
+        selected={[]}
+        onChange={onChange}
+        customers={customers}
+      />
+    );
+    fireEvent.click(screen.getByText('選択'));
+    // c1をチェック
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    // 確定ボタン
+    fireEvent.click(screen.getByText('確定（1名）'));
+    expect(onChange).toHaveBeenCalledWith(['c1']);
+  });
+
+  it('should show fallback id for unknown customer', () => {
+    render(
+      <CustomerMultiSelect
+        label="同一世帯"
+        selected={['unknown-id']}
+        onChange={() => {}}
+        customers={new Map()}
+      />
+    );
+    expect(screen.getByText('unknown-id')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- `CustomerMultiSelect` コンポーネント新規作成（`StaffMultiSelect` と同パターン）
- `CustomerEditDialog` に同一世帯（`same_household_customer_ids`）・同一施設（`same_facility_customer_ids`）の選択UIを追加
- 名前・ふりがな・住所での検索、自己排除、Badge表示＋削除に対応
- 双方向同期はPR #134で実装済みのため追加不要

## Changes (3 files, +388/-1)

| ファイル | 変更 |
|---------|------|
| `CustomerMultiSelect.tsx` | 新規コンポーネント（名前・住所検索、Badge表示） |
| `CustomerEditDialog.tsx` | MultiSelect組み込み + useCustomers追加 |
| `CustomerMultiSelect.test.tsx` | Vitest 8件（表示・検索・除外・確定・削除） |

## Test plan

- [x] CustomerMultiSelect: 8テスト pass
- [x] 関連テストスイート: 186テスト pass（firestore, validation, masters）
- [x] tsc --noEmit: 今回の変更による新規エラー 0件

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)