### PR TITLE
feat: Google Chat DM催促機能（希望休未提出スタッフへの個別送信）

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -59,6 +59,9 @@ from optimizer.api.schemas import (
     ShiftChangedNotifyRequest,
     ShiftConfirmedNotifyRequest,
     UnavailabilityReminderRequest,
+    ChatReminderRequest,
+    ChatReminderResponse,
+    ChatReminderResultItem,
 )
 from optimizer.data.firestore_loader import (
     get_firestore_client,
@@ -75,6 +78,7 @@ from optimizer.data.firestore_writer import (
 )
 from optimizer.engine.solver import SoftWeights, diagnose_infeasibility, solve
 from optimizer.models import Assignment, OptimizationParameters, OptimizationRunRecord
+from optimizer.notification.chat_sender import send_chat_dms
 from optimizer.notification.recipients import list_manager_emails
 from optimizer.notification.sender import send_email
 from optimizer.notification.templates import (
@@ -560,3 +564,55 @@ def notify_unavailability_reminder(
         len(req.helpers_not_submitted),
     )
     return NotificationResponse(emails_sent=sent, recipients=recipients)
+
+
+APP_URL = "https://visitcare-shift-optimizer.web.app"
+
+_CHAT_REMINDER_TEMPLATE = (
+    "[VisitCare] 希望休提出のお願い\n\n"
+    "{target_week}週 の希望休がまだ提出されていません。\n"
+    "お手数ですが、以下のリンクから提出をお願いします。\n\n"
+    "{app_url}/masters/unavailability"
+)
+
+
+@router.post(
+    "/notify/chat-reminder",
+    response_model=ChatReminderResponse,
+    responses={500: {"model": ErrorResponse}},
+)
+def notify_chat_reminder(
+    req: ChatReminderRequest,
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> ChatReminderResponse:
+    """希望休催促を Google Chat DM で個別送信する"""
+    message_text = req.message or _CHAT_REMINDER_TEMPLATE.format(
+        target_week=req.target_week_start,
+        app_url=APP_URL,
+    )
+
+    emails = [t.email for t in req.targets]
+    sent_count, raw_results = send_chat_dms(emails, message_text)
+
+    # raw_results を staff_id 付きに変換
+    email_to_staff = {t.email: t.staff_id for t in req.targets}
+    results = [
+        ChatReminderResultItem(
+            staff_id=email_to_staff.get(r["email"], ""),
+            email=str(r["email"]),
+            success=bool(r["success"]),
+        )
+        for r in raw_results
+    ]
+
+    logger.info(
+        "Chat DM 催促送信: sent=%d/%d",
+        sent_count,
+        len(req.targets),
+    )
+
+    return ChatReminderResponse(
+        messages_sent=sent_count,
+        total_targets=len(req.targets),
+        results=results,
+    )

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -168,3 +168,42 @@ class UnavailabilityReminderRequest(BaseModel):
         ...,
         description="未提出ヘルパーのリスト [{id, name}]",
     )
+
+
+# ---------------------------------------------------------------------------
+# Google Chat DM 催促
+# ---------------------------------------------------------------------------
+
+class ChatReminderTarget(BaseModel):
+    staff_id: str = Field(..., description="スタッフID")
+    name: str = Field(..., description="スタッフ名（表示用）")
+    email: str = Field(..., description="Google Workspace メールアドレス")
+
+
+class ChatReminderRequest(BaseModel):
+    target_week_start: str = Field(
+        ...,
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        description="催促対象週の開始日 YYYY-MM-DD",
+    )
+    targets: list[ChatReminderTarget] = Field(
+        ...,
+        min_length=1,
+        description="送信対象スタッフのリスト",
+    )
+    message: str | None = Field(
+        default=None,
+        description="カスタムメッセージ（省略時はデフォルトテンプレート使用）",
+    )
+
+
+class ChatReminderResultItem(BaseModel):
+    staff_id: str
+    email: str
+    success: bool
+
+
+class ChatReminderResponse(BaseModel):
+    messages_sent: int = Field(description="送信成功件数")
+    total_targets: int = Field(description="送信対象件数")
+    results: list[ChatReminderResultItem]

--- a/optimizer/src/optimizer/notification/chat_sender.py
+++ b/optimizer/src/optimizer/notification/chat_sender.py
@@ -1,0 +1,118 @@
+"""Google Chat API によるDM送信モジュール
+
+認証フロー:
+  サービスアカウント → chat.bot スコープ → Google Chat API
+  findDirectMessage で DM スペースを検出 → messages.create で送信
+
+Bot未設定・認証失敗時は 0 を返す（graceful degradation）。
+ローカル開発では Chat API が利用できないため送信をスキップする。
+"""
+
+import logging
+from typing import Any
+
+import google.auth  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+_CHAT_SCOPES = ["https://www.googleapis.com/auth/chat.bot"]
+
+
+def _build_chat_service() -> Any | None:
+    """Google Chat API サービスを構築する。"""
+    try:
+        from googleapiclient.discovery import build  # type: ignore[import-untyped]
+
+        creds, _ = google.auth.default(scopes=_CHAT_SCOPES)
+        return build("chat", "v1", credentials=creds)
+    except Exception:
+        logger.exception("Google Chat API サービスの構築に失敗しました")
+        return None
+
+
+def _find_dm_space(service: Any, user_email: str) -> str | None:
+    """ユーザーとの DM スペース名を取得する。
+
+    Chat App がユーザーにインストール済みであれば DM スペースが存在する。
+    """
+    try:
+        dm = service.spaces().findDirectMessage(
+            name=f"users/{user_email}"
+        ).execute()
+        return dm.get("name")
+    except Exception:
+        logger.warning("DM スペースが見つかりません: %s", user_email)
+        return None
+
+
+def send_chat_dm(user_email: str, message_text: str) -> bool:
+    """Google Chat で個人 DM を送信する。
+
+    Args:
+        user_email: 送信先ユーザーのメールアドレス
+        message_text: 送信するメッセージテキスト
+
+    Returns:
+        送信成功時 True、失敗時 False。
+    """
+    service = _build_chat_service()
+    if service is None:
+        return False
+
+    space_name = _find_dm_space(service, user_email)
+    if not space_name:
+        return False
+
+    try:
+        service.spaces().messages().create(
+            parent=space_name,
+            body={"text": message_text},
+        ).execute()
+        return True
+    except Exception:
+        logger.exception("Chat DM 送信失敗: %s", user_email)
+        return False
+
+
+def send_chat_dms(
+    user_emails: list[str],
+    message_text: str,
+) -> tuple[int, list[dict[str, str | bool]]]:
+    """複数ユーザーに Google Chat DM を一斉送信する。
+
+    Args:
+        user_emails: 送信先メールアドレスリスト
+        message_text: 送信するメッセージテキスト
+
+    Returns:
+        (送信成功件数, 各ユーザーの結果リスト [{email, success}])
+    """
+    if not user_emails:
+        return 0, []
+
+    service = _build_chat_service()
+    if service is None:
+        logger.warning("Chat API サービス構築失敗のため、全送信をスキップします")
+        return 0, [{"email": e, "success": False} for e in user_emails]
+
+    sent_count = 0
+    results: list[dict[str, str | bool]] = []
+
+    for email in user_emails:
+        space_name = _find_dm_space(service, email)
+        if not space_name:
+            results.append({"email": email, "success": False})
+            continue
+
+        try:
+            service.spaces().messages().create(
+                parent=space_name,
+                body={"text": message_text},
+            ).execute()
+            sent_count += 1
+            results.append({"email": email, "success": True})
+        except Exception:
+            logger.exception("Chat DM 送信失敗: %s", email)
+            results.append({"email": email, "success": False})
+
+    return sent_count, results

--- a/optimizer/tests/test_chat_sender.py
+++ b/optimizer/tests/test_chat_sender.py
@@ -1,0 +1,114 @@
+"""Google Chat DM 送信モジュールのテスト"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from optimizer.notification.chat_sender import send_chat_dm, send_chat_dms
+
+
+class TestSendChatDm:
+    @patch("optimizer.notification.chat_sender._build_chat_service")
+    def test_returns_false_when_service_unavailable(self, mock_build: MagicMock) -> None:
+        """Chat API サービス構築失敗時は False を返す"""
+        mock_build.return_value = None
+        assert send_chat_dm("user@example.com", "test") is False
+
+    @patch("optimizer.notification.chat_sender._build_chat_service")
+    def test_returns_false_when_dm_space_not_found(self, mock_build: MagicMock) -> None:
+        """DM スペースが見つからない場合は False を返す"""
+        mock_service = MagicMock()
+        mock_service.spaces.return_value.findDirectMessage.return_value.execute.side_effect = (
+            Exception("Not found")
+        )
+        mock_build.return_value = mock_service
+        assert send_chat_dm("user@example.com", "test") is False
+
+    @patch("optimizer.notification.chat_sender._build_chat_service")
+    def test_sends_message_successfully(self, mock_build: MagicMock) -> None:
+        """DM スペースが見つかった場合はメッセージを送信し True を返す"""
+        mock_service = MagicMock()
+        mock_service.spaces.return_value.findDirectMessage.return_value.execute.return_value = {
+            "name": "spaces/AAAA"
+        }
+        mock_build.return_value = mock_service
+
+        assert send_chat_dm("user@example.com", "Hello!") is True
+
+        mock_service.spaces.return_value.messages.return_value.create.assert_called_once_with(
+            parent="spaces/AAAA",
+            body={"text": "Hello!"},
+        )
+
+    @patch("optimizer.notification.chat_sender._build_chat_service")
+    def test_returns_false_when_message_create_fails(self, mock_build: MagicMock) -> None:
+        """メッセージ送信が失敗した場合は False を返す"""
+        mock_service = MagicMock()
+        mock_service.spaces.return_value.findDirectMessage.return_value.execute.return_value = {
+            "name": "spaces/AAAA"
+        }
+        mock_service.spaces.return_value.messages.return_value.create.return_value.execute.side_effect = (
+            Exception("Send failed")
+        )
+        mock_build.return_value = mock_service
+
+        assert send_chat_dm("user@example.com", "Hello!") is False
+
+
+class TestSendChatDms:
+    @patch("optimizer.notification.chat_sender._build_chat_service")
+    def test_returns_zero_for_empty_list(self, mock_build: MagicMock) -> None:
+        """空リストの場合は 0 件を返す"""
+        sent, results = send_chat_dms([], "test")
+        assert sent == 0
+        assert results == []
+
+    @patch("optimizer.notification.chat_sender._build_chat_service")
+    def test_returns_zero_when_service_unavailable(self, mock_build: MagicMock) -> None:
+        """Chat API サービス構築失敗時は全件失敗を返す"""
+        mock_build.return_value = None
+        sent, results = send_chat_dms(["a@example.com", "b@example.com"], "test")
+        assert sent == 0
+        assert len(results) == 2
+        assert all(r["success"] is False for r in results)
+
+    @patch("optimizer.notification.chat_sender._build_chat_service")
+    def test_partial_success(self, mock_build: MagicMock) -> None:
+        """一部成功・一部失敗のケース"""
+        mock_service = MagicMock()
+
+        def find_dm_side_effect(name: str) -> MagicMock:
+            mock_exec = MagicMock()
+            if name == "users/a@example.com":
+                mock_exec.execute.return_value = {"name": "spaces/AAA"}
+            else:
+                mock_exec.execute.side_effect = Exception("Not found")
+            return mock_exec
+
+        mock_service.spaces.return_value.findDirectMessage.side_effect = find_dm_side_effect
+        mock_build.return_value = mock_service
+
+        sent, results = send_chat_dms(
+            ["a@example.com", "b@example.com"], "Hello!"
+        )
+
+        assert sent == 1
+        assert len(results) == 2
+        assert results[0] == {"email": "a@example.com", "success": True}
+        assert results[1] == {"email": "b@example.com", "success": False}
+
+    @patch("optimizer.notification.chat_sender._build_chat_service")
+    def test_all_success(self, mock_build: MagicMock) -> None:
+        """全件成功のケース"""
+        mock_service = MagicMock()
+        mock_service.spaces.return_value.findDirectMessage.return_value.execute.return_value = {
+            "name": "spaces/DM"
+        }
+        mock_build.return_value = mock_service
+
+        sent, results = send_chat_dms(
+            ["a@example.com", "b@example.com"], "Hello!"
+        )
+
+        assert sent == 2
+        assert all(r["success"] is True for r in results)

--- a/optimizer/tests/test_notification.py
+++ b/optimizer/tests/test_notification.py
@@ -338,3 +338,83 @@ class TestNotifyEndpoints:
         )
         assert response.status_code == 200
         assert response.json()["emails_sent"] == 1
+
+    @patch("optimizer.api.routes.send_chat_dms")
+    def test_chat_reminder_success(self, mock_send: MagicMock) -> None:
+        """POST /notify/chat-reminder → 200"""
+        mock_send.return_value = (1, [
+            {"email": "staff@example.com", "success": True},
+        ])
+
+        response = client.post(
+            "/notify/chat-reminder",
+            json={
+                "target_week_start": "2026-03-10",
+                "targets": [
+                    {"staff_id": "h1", "name": "佐藤 一郎", "email": "staff@example.com"},
+                ],
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages_sent"] == 1
+        assert data["total_targets"] == 1
+        assert data["results"][0]["staff_id"] == "h1"
+        assert data["results"][0]["success"] is True
+
+    @patch("optimizer.api.routes.send_chat_dms")
+    def test_chat_reminder_partial_failure(self, mock_send: MagicMock) -> None:
+        """一部失敗でも200を返し結果に反映される"""
+        mock_send.return_value = (1, [
+            {"email": "a@example.com", "success": True},
+            {"email": "b@example.com", "success": False},
+        ])
+
+        response = client.post(
+            "/notify/chat-reminder",
+            json={
+                "target_week_start": "2026-03-10",
+                "targets": [
+                    {"staff_id": "h1", "name": "田中", "email": "a@example.com"},
+                    {"staff_id": "h2", "name": "鈴木", "email": "b@example.com"},
+                ],
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages_sent"] == 1
+        assert data["total_targets"] == 2
+
+    def test_chat_reminder_empty_targets_returns_422(self) -> None:
+        """targets が空の場合 422"""
+        response = client.post(
+            "/notify/chat-reminder",
+            json={
+                "target_week_start": "2026-03-10",
+                "targets": [],
+            },
+        )
+        assert response.status_code == 422
+
+    @patch("optimizer.api.routes.send_chat_dms")
+    def test_chat_reminder_custom_message(self, mock_send: MagicMock) -> None:
+        """カスタムメッセージが send_chat_dms に渡される"""
+        mock_send.return_value = (1, [
+            {"email": "a@example.com", "success": True},
+        ])
+
+        response = client.post(
+            "/notify/chat-reminder",
+            json={
+                "target_week_start": "2026-03-10",
+                "targets": [
+                    {"staff_id": "h1", "name": "田中", "email": "a@example.com"},
+                ],
+                "message": "カスタム催促メッセージ",
+            },
+        )
+        assert response.status_code == 200
+        mock_send.assert_called_once_with(
+            ["a@example.com"],
+            "カスタム催促メッセージ",
+        )

--- a/shared/types/helper.ts
+++ b/shared/types/helper.ts
@@ -28,6 +28,7 @@ export interface Helper {
   address?: string;
   location?: GeoLocation;
   phone_number?: string;
+  email?: string;
   created_at: Timestamp;
   updated_at: Timestamp;
 }

--- a/web/src/app/masters/unavailability/page.tsx
+++ b/web/src/app/masters/unavailability/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { Plus, Pencil, Search, ChevronLeft, ChevronRight, Mail, Loader2 } from 'lucide-react';
+import { Plus, Pencil, Search, ChevronLeft, ChevronRight, Mail, MessageSquare, Loader2 } from 'lucide-react';
 import { format, addDays, addWeeks, subWeeks, startOfWeek, differenceInCalendarDays } from 'date-fns';
 import { useHelpers } from '@/hooks/useHelpers';
 import { useAuthRole } from '@/lib/auth/AuthProvider';
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { notifyUnavailabilityReminder, OptimizeApiError } from '@/lib/api/optimizer';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { ChatReminderDialog } from '@/components/unavailability/ChatReminderDialog';
 import {
   Table,
   TableBody,
@@ -36,6 +37,7 @@ export default function UnavailabilityPage() {
   const [editTarget, setEditTarget] = useState<StaffUnavailability | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [reminderSending, setReminderSending] = useState(false);
+  const [chatDialogOpen, setChatDialogOpen] = useState(false);
 
   const loading = helpersLoading || unavailLoading;
 
@@ -123,23 +125,37 @@ export default function UnavailabilityPage() {
         <h2 className="text-lg font-bold">希望休管理</h2>
         <div className="flex items-center gap-2">
           {canEditUnavailability && helpersNotSubmitted.length > 0 && (
-            <Button
-              onClick={handleSendReminder}
-              size="sm"
-              variant="outline"
-              disabled={reminderSending}
-              title={`${helpersNotSubmitted.length}名に催促メールを送信`}
-            >
-              {reminderSending ? (
-                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-              ) : (
-                <Mail className="mr-1 h-4 w-4" />
-              )}
-              催促メール
-              <span className="ml-1 rounded-full bg-destructive px-1.5 py-0.5 text-xs text-destructive-foreground">
-                {helpersNotSubmitted.length}
-              </span>
-            </Button>
+            <>
+              <Button
+                onClick={() => setChatDialogOpen(true)}
+                size="sm"
+                variant="outline"
+                title={`${helpersNotSubmitted.length}名にChat催促を送信`}
+              >
+                <MessageSquare className="mr-1 h-4 w-4" />
+                Chat催促
+                <span className="ml-1 rounded-full bg-destructive px-1.5 py-0.5 text-xs text-destructive-foreground">
+                  {helpersNotSubmitted.length}
+                </span>
+              </Button>
+              <Button
+                onClick={handleSendReminder}
+                size="sm"
+                variant="outline"
+                disabled={reminderSending}
+                title={`${helpersNotSubmitted.length}名に催促メールを送信`}
+              >
+                {reminderSending ? (
+                  <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                ) : (
+                  <Mail className="mr-1 h-4 w-4" />
+                )}
+                催促メール
+                <span className="ml-1 rounded-full bg-destructive px-1.5 py-0.5 text-xs text-destructive-foreground">
+                  {helpersNotSubmitted.length}
+                </span>
+              </Button>
+            </>
           )}
           {(canEditUnavailability || isHelper) && (
             <Button onClick={openNew} size="sm">
@@ -256,6 +272,19 @@ export default function UnavailabilityPage() {
         unavailability={editTarget}
         helpers={helpers}
         weekStart={weekStart}
+      />
+
+      <ChatReminderDialog
+        open={chatDialogOpen}
+        onClose={() => setChatDialogOpen(false)}
+        weekStart={format(weekStart, 'yyyy-MM-dd')}
+        helpers={helpers}
+        unsubmittedStaffIds={submittedStaffIds.size > 0
+          ? new Set(
+              Array.from(helpers.keys()).filter((id) => !submittedStaffIds.has(id))
+            )
+          : new Set(helpers.keys())
+        }
       />
     </div>
   );

--- a/web/src/components/masters/HelperDetailSheet.tsx
+++ b/web/src/components/masters/HelperDetailSheet.tsx
@@ -116,6 +116,9 @@ export function HelperDetailSheet({
               {helper.phone_number && (
                 <InfoRow label="電話番号" value={helper.phone_number} />
               )}
+              {helper.email && (
+                <InfoRow label="メールアドレス" value={helper.email} />
+              )}
               {helper.address && <InfoRow label="住所" value={helper.address} />}
               <InfoRow
                 label="資格"

--- a/web/src/components/masters/HelperEditDialog.tsx
+++ b/web/src/components/masters/HelperEditDialog.tsx
@@ -201,6 +201,18 @@ export function HelperEditDialog({
                   placeholder="099-xxx-xxxx"
                 />
               </div>
+              <div className="space-y-1">
+                <Label htmlFor="email">メールアドレス（任意）</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  {...register('email')}
+                  placeholder="example@aozora-cg.com"
+                />
+                {errors.email && (
+                  <p className="text-xs text-destructive">{errors.email.message}</p>
+                )}
+              </div>
             </div>
 
             <div className="space-y-2">
@@ -498,6 +510,7 @@ function getDefaults(helper?: Helper): HelperFormValues {
       employee_number: '',
       address: '',
       phone_number: '',
+      email: '',
     };
   }
   return {
@@ -515,5 +528,6 @@ function getDefaults(helper?: Helper): HelperFormValues {
     employee_number: helper.employee_number ?? '',
     address: helper.address ?? '',
     phone_number: helper.phone_number ?? '',
+    email: helper.email ?? '',
   };
 }

--- a/web/src/components/unavailability/ChatReminderDialog.tsx
+++ b/web/src/components/unavailability/ChatReminderDialog.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { MessageSquare, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { sendChatReminder, OptimizeApiError } from '@/lib/api/optimizer';
+import { toast } from 'sonner';
+import type { Helper } from '@/types';
+
+interface ChatReminderDialogProps {
+  open: boolean;
+  onClose: () => void;
+  weekStart: string;
+  helpers: Map<string, Helper>;
+  unsubmittedStaffIds: Set<string>;
+}
+
+export function ChatReminderDialog({
+  open,
+  onClose,
+  weekStart,
+  helpers,
+  unsubmittedStaffIds,
+}: ChatReminderDialogProps) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [sending, setSending] = useState(false);
+
+  // email を持つスタッフのみ対象
+  const eligibleStaff = useMemo(() => {
+    return Array.from(helpers.values())
+      .filter((h) => h.email)
+      .sort((a, b) => {
+        // 未提出者を先に表示
+        const aUnsub = unsubmittedStaffIds.has(a.id) ? 0 : 1;
+        const bUnsub = unsubmittedStaffIds.has(b.id) ? 0 : 1;
+        if (aUnsub !== bUnsub) return aUnsub - bUnsub;
+        return a.name.family.localeCompare(b.name.family, 'ja');
+      });
+  }, [helpers, unsubmittedStaffIds]);
+
+  // ダイアログを開くたびに未提出者を自動選択
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      const autoSelected = new Set(
+        eligibleStaff
+          .filter((h) => unsubmittedStaffIds.has(h.id))
+          .map((h) => h.id)
+      );
+      setSelected(autoSelected);
+    }
+    if (!isOpen) onClose();
+  };
+
+  const toggleStaff = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selected.size === eligibleStaff.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(eligibleStaff.map((h) => h.id)));
+    }
+  };
+
+  const handleSend = async () => {
+    const targets = eligibleStaff
+      .filter((h) => selected.has(h.id))
+      .map((h) => ({
+        staff_id: h.id,
+        name: `${h.name.family} ${h.name.given}`,
+        email: h.email!,
+      }));
+
+    if (targets.length === 0) return;
+
+    setSending(true);
+    try {
+      const result = await sendChatReminder({
+        target_week_start: weekStart,
+        targets,
+      });
+      const failed = result.results.filter((r) => !r.success);
+      if (failed.length === 0) {
+        toast.success(`Chat催促送信完了: ${result.messages_sent}名に送信しました`);
+      } else {
+        toast.warning(
+          `${result.messages_sent}名に送信、${failed.length}名は失敗しました`
+        );
+      }
+      onClose();
+    } catch (err) {
+      if (err instanceof OptimizeApiError) {
+        toast.error(`送信エラー: ${err.message}`);
+      } else {
+        toast.error('Chat催促の送信に失敗しました');
+      }
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const noEmailStaff = Array.from(helpers.values()).filter(
+    (h) => !h.email && unsubmittedStaffIds.has(h.id)
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[80vh] max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            <MessageSquare className="inline mr-2 h-5 w-5" />
+            Chat催促を送信
+          </DialogTitle>
+        </DialogHeader>
+
+        <p className="text-sm text-muted-foreground">
+          {weekStart}週 の希望休が未提出のスタッフにGoogle Chat DMを送信します。
+        </p>
+
+        <div className="flex items-center justify-between border-b pb-2">
+          <label className="flex items-center gap-2 cursor-pointer text-sm">
+            <Checkbox
+              checked={selected.size === eligibleStaff.length && eligibleStaff.length > 0}
+              onCheckedChange={toggleAll}
+            />
+            全選択（{selected.size}/{eligibleStaff.length}）
+          </label>
+        </div>
+
+        <div className="max-h-60 overflow-y-auto space-y-1">
+          {eligibleStaff.map((h) => {
+            const isUnsub = unsubmittedStaffIds.has(h.id);
+            return (
+              <label
+                key={h.id}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted cursor-pointer"
+              >
+                <Checkbox
+                  checked={selected.has(h.id)}
+                  onCheckedChange={() => toggleStaff(h.id)}
+                />
+                <span className="text-sm flex-1">
+                  {h.name.family} {h.name.given}
+                </span>
+                {isUnsub && (
+                  <span className="text-xs text-destructive font-medium">未提出</span>
+                )}
+                {!isUnsub && (
+                  <span className="text-xs text-muted-foreground">提出済</span>
+                )}
+              </label>
+            );
+          })}
+          {eligibleStaff.length === 0 && (
+            <p className="text-center text-sm text-muted-foreground py-4">
+              メールアドレスが登録されたスタッフがいません
+            </p>
+          )}
+        </div>
+
+        {noEmailStaff.length > 0 && (
+          <p className="text-xs text-amber-600">
+            {noEmailStaff.map((h) => `${h.name.family} ${h.name.given}`).join('、')}
+            はメールアドレス未登録のため送信できません
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={sending}
+          >
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSend}
+            disabled={sending || selected.size === 0}
+          >
+            {sending ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <MessageSquare className="mr-1 h-4 w-4" />
+            )}
+            送信（{selected.size}名）
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/unavailability/__tests__/ChatReminderDialog.test.tsx
+++ b/web/src/components/unavailability/__tests__/ChatReminderDialog.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ChatReminderDialog } from '../ChatReminderDialog';
+import type { Helper } from '@/types';
+
+// Dialog モック
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open, onOpenChange }: { children: React.ReactNode; open: boolean; onOpenChange: (v: boolean) => void }) => {
+    // open 時に onOpenChange(true) を呼ぶ
+    if (open) {
+      // useEffect 的にコール
+      setTimeout(() => onOpenChange(true), 0);
+      return <div data-testid="dialog">{children}</div>;
+    }
+    return null;
+  },
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/lib/api/optimizer', () => ({
+  sendChatReminder: vi.fn(),
+  OptimizeApiError: class extends Error {
+    statusCode: number;
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+function makeHelper(id: string, family: string, given: string, email?: string): Helper {
+  return {
+    id,
+    name: { family, given },
+    qualifications: [],
+    can_physical_care: false,
+    transportation: 'car' as const,
+    weekly_availability: {},
+    preferred_hours: { min: 0, max: 40 },
+    available_hours: { min: 0, max: 40 },
+    customer_training_status: {},
+    employment_type: 'part_time' as const,
+    gender: 'female' as const,
+    email,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+function makeHelperMap(...entries: Helper[]): Map<string, Helper> {
+  return new Map(entries.map((h) => [h.id, h]));
+}
+
+describe('ChatReminderDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should display eligible staff with email', async () => {
+    const helpers = makeHelperMap(
+      makeHelper('h1', '田中', '太郎', 'tanaka@example.com'),
+      makeHelper('h2', '佐藤', '花子', 'sato@example.com'),
+      makeHelper('h3', '鈴木', '一郎'), // email なし
+    );
+
+    render(
+      <ChatReminderDialog
+        open={true}
+        onClose={() => {}}
+        weekStart="2026-03-09"
+        helpers={helpers}
+        unsubmittedStaffIds={new Set(['h1', 'h3'])}
+      />
+    );
+
+    // email ありの2名は表示される
+    expect(screen.getByText('田中 太郎')).toBeInTheDocument();
+    expect(screen.getByText('佐藤 花子')).toBeInTheDocument();
+    // email なしの h3 はチェックボックスリストに表示されない
+  });
+
+  it('should show warning for staff without email', () => {
+    const helpers = makeHelperMap(
+      makeHelper('h1', '田中', '太郎', 'tanaka@example.com'),
+      makeHelper('h2', '鈴木', '一郎'), // email なし, 未提出
+    );
+
+    render(
+      <ChatReminderDialog
+        open={true}
+        onClose={() => {}}
+        weekStart="2026-03-09"
+        helpers={helpers}
+        unsubmittedStaffIds={new Set(['h1', 'h2'])}
+      />
+    );
+
+    expect(screen.getByText(/鈴木 一郎.*メールアドレス未登録/)).toBeInTheDocument();
+  });
+
+  it('should show unsubmitted badge for unsubmitted staff', () => {
+    const helpers = makeHelperMap(
+      makeHelper('h1', '田中', '太郎', 'tanaka@example.com'),
+      makeHelper('h2', '佐藤', '花子', 'sato@example.com'),
+    );
+
+    render(
+      <ChatReminderDialog
+        open={true}
+        onClose={() => {}}
+        weekStart="2026-03-09"
+        helpers={helpers}
+        unsubmittedStaffIds={new Set(['h1'])}
+      />
+    );
+
+    expect(screen.getByText('未提出')).toBeInTheDocument();
+    expect(screen.getByText('提出済')).toBeInTheDocument();
+  });
+
+  it('should call sendChatReminder on send button click', async () => {
+    const { sendChatReminder } = await import('@/lib/api/optimizer');
+    const mockSend = vi.mocked(sendChatReminder);
+    mockSend.mockResolvedValue({
+      messages_sent: 1,
+      total_targets: 1,
+      results: [{ staff_id: 'h1', email: 'tanaka@example.com', success: true }],
+    });
+
+    const onClose = vi.fn();
+    const helpers = makeHelperMap(
+      makeHelper('h1', '田中', '太郎', 'tanaka@example.com'),
+    );
+
+    render(
+      <ChatReminderDialog
+        open={true}
+        onClose={onClose}
+        weekStart="2026-03-09"
+        helpers={helpers}
+        unsubmittedStaffIds={new Set(['h1'])}
+      />
+    );
+
+    // 未提出者は自動選択される → 送信ボタンをクリック
+    await waitFor(() => {
+      const sendBtn = screen.getByText('送信（1名）');
+      expect(sendBtn).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('送信（1名）'));
+
+    await waitFor(() => {
+      expect(mockSend).toHaveBeenCalledWith({
+        target_week_start: '2026-03-09',
+        targets: [{ staff_id: 'h1', name: '田中 太郎', email: 'tanaka@example.com' }],
+      });
+    });
+  });
+
+  it('should show empty message when no staff have email', () => {
+    const helpers = makeHelperMap(
+      makeHelper('h1', '田中', '太郎'), // email なし
+    );
+
+    render(
+      <ChatReminderDialog
+        open={true}
+        onClose={() => {}}
+        weekStart="2026-03-09"
+        helpers={helpers}
+        unsubmittedStaffIds={new Set(['h1'])}
+      />
+    );
+
+    expect(screen.getByText('メールアドレスが登録されたスタッフがいません')).toBeInTheDocument();
+  });
+});

--- a/web/src/lib/api/optimizer.ts
+++ b/web/src/lib/api/optimizer.ts
@@ -296,3 +296,45 @@ export async function notifyUnavailabilityReminder(params: {
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Google Chat DM 催促
+// ---------------------------------------------------------------------------
+
+export interface ChatReminderTarget {
+  staff_id: string;
+  name: string;
+  email: string;
+}
+
+export interface ChatReminderResultItem {
+  staff_id: string;
+  email: string;
+  success: boolean;
+}
+
+export interface ChatReminderResponse {
+  messages_sent: number;
+  total_targets: number;
+  results: ChatReminderResultItem[];
+}
+
+export async function sendChatReminder(params: {
+  target_week_start: string;
+  targets: ChatReminderTarget[];
+  message?: string;
+}): Promise<ChatReminderResponse> {
+  const headers = await getAuthHeaders();
+  const res = await fetchWithRetry(() =>
+    fetch(`${API_URL}/notify/chat-reminder`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    }),
+  );
+  if (!res.ok) {
+    const error: OptimizeError = await res.json();
+    throw new OptimizeApiError(res.status, error.detail);
+  }
+  return res.json();
+}

--- a/web/src/lib/validation/schemas.ts
+++ b/web/src/lib/validation/schemas.ts
@@ -111,6 +111,7 @@ export const helperSchema = z.object({
   // zodResolver は location: undefined を受け取り .optional() を通過する。
   location: geoLocationSchema.optional(),
   phone_number: z.string().optional(),
+  email: z.string().email('メールアドレスの形式が正しくありません').optional().or(z.literal('')),
 });
 
 export type HelperFormValues = z.infer<typeof helperSchema>;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -110,6 +110,7 @@ export interface Helper {
   address?: string;
   location?: GeoLocation;
   phone_number?: string;
+  email?: string;
   created_at: Date;
   updated_at: Date;
 }


### PR DESCRIPTION
## Summary

- Helper型に`email`フィールドを追加（Google Workspace メールアドレス）
- Python: `chat_sender.py` — Google Chat API経由でDM送信（サービスアカウント認証、graceful degradation）
- Python: `POST /notify/chat-reminder` エンドポイント追加（デフォルトメッセージテンプレート付き）
- Web: `ChatReminderDialog` — チェックボックスで複数スタッフを選択し一括送信
  - 未提出者の自動選択、全選択トグル、未提出/提出済バッジ
  - メールアドレス未登録スタッフの警告表示
- Web: 希望休管理ページに「Chat催促」ボタンを追加（未提出者数バッジ付き）
- ヘルパー詳細シート・編集ダイアログにメールアドレス表示/入力を追加

## Changes (14 files, +912/-18)

| レイヤー | ファイル | 変更内容 |
|---------|---------|---------|
| Shared | `shared/types/helper.ts` | `email?: string` 追加 |
| Web Types | `web/src/types/index.ts` | `email?: string` 追加 |
| Validation | `web/src/lib/validation/schemas.ts` | email Zodバリデーション追加 |
| API Client | `web/src/lib/api/optimizer.ts` | `sendChatReminder()` 関数追加 |
| UI | `ChatReminderDialog.tsx` | チェックボックス付きダイアログ（NEW） |
| UI | `unavailability/page.tsx` | Chat催促ボタン追加 |
| UI | `HelperEditDialog.tsx` | メールアドレス入力欄追加 |
| UI | `HelperDetailSheet.tsx` | メールアドレス表示追加 |
| Backend | `chat_sender.py` | Google Chat DM送信モジュール（NEW） |
| Backend | `schemas.py` | ChatReminder系Pydanticモデル追加 |
| Backend | `routes.py` | `/notify/chat-reminder` エンドポイント追加 |
| Test | `test_chat_sender.py` | 8テスト（NEW） |
| Test | `test_notification.py` | 4テスト追加 |
| Test | `ChatReminderDialog.test.tsx` | 5テスト（NEW） |

## Test plan

- [x] Python全テスト: 306 passed（chat_sender 8件 + notification endpoint 4件追加）
- [x] Vitest全テスト: 474 passed（ChatReminderDialog 5件追加）
- [x] tsc --noEmit: 新規エラー0件
- [ ] GCP設定（後続作業）: Google Chat API有効化、Chat Bot作成、SA権限付与

## Note

GCP側の設定（Chat API有効化・Bot登録・SA権限）は後続作業として別途対応します。
コード側はgraceful degradationパターンで、Chat APIが未設定でも既存機能に影響しません。

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)