### PR TITLE
fix: PR #137 品質ゲート補完 — コードレビュー指摘修正

### DIFF
--- a/firebase/__tests__/firestore.rules.test.ts
+++ b/firebase/__tests__/firestore.rules.test.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
     firestore: {
       rules: fs.readFileSync(RULES_PATH, 'utf8'),
       host: 'localhost',
-      port: 8080,
+      port: parseInt(process.env.FIRESTORE_EMULATOR_PORT ?? '8080', 10),
     },
   });
 });
@@ -451,6 +451,16 @@ describe('認証済みユーザー - helpers create', () => {
     const { employment_type: _, ...noEmploymentType } = validHelperData;
     await assertFails(
       setDoc(doc(authed.firestore(), 'helpers', 'helper-bad'), noEmploymentType)
+    );
+  });
+
+  it('emailフィールド付きで新規作成できる', async () => {
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertSucceeds(
+      setDoc(doc(authed.firestore(), 'helpers', 'helper-with-email'), {
+        ...validHelperData,
+        email: 'test@example.com',
+      })
     );
   });
 });

--- a/optimizer/pyproject.toml
+++ b/optimizer/pyproject.toml
@@ -5,7 +5,7 @@ description = "訪問介護シフト最適化エンジン"
 requires-python = ">=3.12"
 dependencies = [
     "pulp>=2.9",
-    "pydantic>=2.0",
+    "pydantic[email]>=2.0",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "gunicorn>=23.0",

--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -566,7 +566,7 @@ def notify_unavailability_reminder(
     return NotificationResponse(emails_sent=sent, recipients=recipients)
 
 
-APP_URL = "https://visitcare-shift-optimizer.web.app"
+APP_URL = os.getenv("APP_URL", "https://visitcare-shift-optimizer.web.app")
 
 _CHAT_REMINDER_TEMPLATE = (
     "[VisitCare] 希望休提出のお願い\n\n"

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -1,6 +1,6 @@
 """APIリクエスト/レスポンススキーマ"""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 
 
 class OptimizeRequest(BaseModel):
@@ -177,7 +177,7 @@ class UnavailabilityReminderRequest(BaseModel):
 class ChatReminderTarget(BaseModel):
     staff_id: str = Field(..., description="スタッフID")
     name: str = Field(..., description="スタッフ名（表示用）")
-    email: str = Field(..., description="Google Workspace メールアドレス")
+    email: EmailStr = Field(..., description="Google Workspace メールアドレス")
 
 
 class ChatReminderRequest(BaseModel):

--- a/optimizer/src/optimizer/notification/chat_sender.py
+++ b/optimizer/src/optimizer/notification/chat_sender.py
@@ -25,6 +25,9 @@ def _build_chat_service() -> Any | None:
 
         creds, _ = google.auth.default(scopes=_CHAT_SCOPES)
         return build("chat", "v1", credentials=creds)
+    except google.auth.exceptions.DefaultCredentialsError:
+        logger.error("Google 認証情報が設定されていません。ADC または SA キーを確認してください")
+        return None
     except Exception:
         logger.exception("Google Chat API サービスの構築に失敗しました")
         return None
@@ -41,7 +44,7 @@ def _find_dm_space(service: Any, user_email: str) -> str | None:
         ).execute()
         return dm.get("name")
     except Exception:
-        logger.warning("DM スペースが見つかりません: %s", user_email)
+        logger.exception("DM スペース取得で予期しないエラー: %s", user_email)
         return None
 
 

--- a/web/src/app/masters/unavailability/page.tsx
+++ b/web/src/app/masters/unavailability/page.tsx
@@ -279,12 +279,9 @@ export default function UnavailabilityPage() {
         onClose={() => setChatDialogOpen(false)}
         weekStart={format(weekStart, 'yyyy-MM-dd')}
         helpers={helpers}
-        unsubmittedStaffIds={submittedStaffIds.size > 0
-          ? new Set(
-              Array.from(helpers.keys()).filter((id) => !submittedStaffIds.has(id))
-            )
-          : new Set(helpers.keys())
-        }
+        unsubmittedStaffIds={new Set(
+          Array.from(helpers.keys()).filter((id) => !submittedStaffIds.has(id))
+        )}
       />
     </div>
   );

--- a/web/src/components/unavailability/ChatReminderDialog.tsx
+++ b/web/src/components/unavailability/ChatReminderDialog.tsx
@@ -42,7 +42,8 @@ export function ChatReminderDialog({
         const aUnsub = unsubmittedStaffIds.has(a.id) ? 0 : 1;
         const bUnsub = unsubmittedStaffIds.has(b.id) ? 0 : 1;
         if (aUnsub !== bUnsub) return aUnsub - bUnsub;
-        return a.name.family.localeCompare(b.name.family, 'ja');
+        return a.name.family.localeCompare(b.name.family, 'ja') ||
+          a.name.given.localeCompare(b.name.given, 'ja');
       });
   }, [helpers, unsubmittedStaffIds]);
 


### PR DESCRIPTION
## Summary

PR #137（Google Chat DM催促機能）のコードレビューで検出された品質問題を修正。

### HIGH（修正済み）
- **EmailStr バリデーション**: `ChatReminderTarget.email` に Pydantic `EmailStr` を適用。不正メールがChat APIに到達する経路を遮断
- **例外分類の改善**: `chat_sender.py` で `DefaultCredentialsError` を先に捕捉し、運用時のデバッグ性を向上。DMスペース取得エラーを `logger.exception` に昇格
- **ロジック簡素化**: `page.tsx` の `unsubmittedStaffIds` 計算の冗長な三項演算子を統一

### LOW（修正済み）
- **APP_URL 環境変数化**: ステージング環境対応
- **同姓ソート**: `ChatReminderDialog` で同姓時の二次ソート（given）追加

### テスト
- Firestore ルールテスト: emailフィールド付きヘルパー作成テスト追加 + ポート環境変数対応

## Test plan

- [x] Web tests: 474 passed
- [x] Optimizer tests: 306 passed
- [x] Firestore rules tests: 107 passed（emailテスト含む、エミュレータ起動時）

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)