### PR TITLE
fix: helpers_not_submitted の型安全性改善

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -554,7 +554,7 @@ def notify_unavailability_reminder(
     recipients = list_manager_emails()
     subject, html = render_unavailability_reminder(
         target_week_start=req.target_week_start,
-        helpers_not_submitted=req.helpers_not_submitted,
+        helpers_not_submitted=[h.model_dump() for h in req.helpers_not_submitted],
     )
     sender_email = _get_sender_email()
     sent = send_email(recipients, subject, html, sender_email=sender_email)

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -158,15 +158,20 @@ class ShiftChangedNotifyRequest(BaseModel):
     changes: list[ShiftChangeDetail] = Field(..., min_length=1)
 
 
+class HelperNotSubmitted(BaseModel):
+    id: str = Field(..., description="スタッフID")
+    name: str = Field(..., description="スタッフ名（表示用）")
+
+
 class UnavailabilityReminderRequest(BaseModel):
     target_week_start: str = Field(
         ...,
         pattern=r"^\d{4}-\d{2}-\d{2}$",
         description="催促対象週の開始日 YYYY-MM-DD",
     )
-    helpers_not_submitted: list[dict] = Field(
+    helpers_not_submitted: list[HelperNotSubmitted] = Field(
         ...,
-        description="未提出ヘルパーのリスト [{id, name}]",
+        description="未提出ヘルパーのリスト",
     )
 
 

--- a/optimizer/src/optimizer/notification/templates.py
+++ b/optimizer/src/optimizer/notification/templates.py
@@ -136,7 +136,7 @@ $style
 
 def render_unavailability_reminder(
     target_week_start: str,
-    helpers_not_submitted: list[dict],
+    helpers_not_submitted: list[dict[str, str]],
 ) -> tuple[str, str]:
     """(subject, html_content) を返す"""
     items = "".join(f"<li>{h['name']}</li>" for h in helpers_not_submitted)


### PR DESCRIPTION
## Summary

- `UnavailabilityReminderRequest.helpers_not_submitted` を `list[dict]` → `list[HelperNotSubmitted]` に変更
- API境界でPydanticによる `id`/`name` フィールドのバリデーションが有効に
- `templates.py` の型アノテーションも `list[dict[str, str]]` に明確化
- FE側の型 `Array<{ id: string; name: string }>` とは既に一致しており変更不要

## Test plan

- [x] `pytest tests/test_notification.py` — 23 passed
- [x] `pytest tests/test_api.py` — 16 passed
- [x] FE型との整合性確認済み

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)