### PR TITLE
fix: findSingleBarInRow フォールバックのbar/row不整合を修正

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,7 +1,7 @@
 # ハンドオフメモ - visitcare-shift-optimizer
 
-**最終更新**: 2026-03-08（品質ゲート補完 PR #139/#141/#143/#144 マージ済み）
-**現在のフェーズ**: Phase 0-5b 完了 → 実績確認・月次レポート・Google Sheetsエクスポート（本番動作確認済み）・マスタ拡張（不定期パターン・外部連携ID・分断勤務・徒歩距離上限・サービス種別→介護保険105種・性別制約・新マスタフィールド・研修状態3段階・週全体ビュー・service_typesマスタ化 Phase 1-3・制約チェック UI 拡張・メール通知・利用者軸ビュー・基本予定一覧・Gmail API DWD送信実装・staff_count複数割当・travel_times D&D統合・ガント幅バグ修正・利用者軸フォント統一・seed複数週対応・通知設定Firestore/UI管理化・マスタ詳細シート追加・ファビコン追加・E2Eテスト拡充・利用者マスタ表示/検索拡充・ふりがなソート/あかさたなフィルター・基本予定一覧詳細シート・手動編集バーアンバーデザイン刷新・Undo/Redo機能・iPad横向きレスポンシブ対応・allowed_staff_ids ホワイトリスト + 事前チェック・same_household/facility_customer_ids移行・利用者編集UI同一世帯/施設MultiSelect・Google Chat DM催促）実装済み・マージ済み
+**最終更新**: 2026-03-09（E2E D&D flakiness改善 PR #149 マージ済み）
+**現在のフェーズ**: Phase 0-5b 完了 → 実績確認・月次レポート・Google Sheetsエクスポート（本番動作確認済み）・マスタ拡張（不定期パターン・外部連携ID・分断勤務・徒歩距離上限・サービス種別→介護保険105種・性別制約・新マスタフィールド・研修状態3段階・週全体ビュー・service_typesマスタ化 Phase 1-3・制約チェック UI 拡張・メール通知・利用者軸ビュー・基本予定一覧・Gmail API DWD送信実装・staff_count複数割当・travel_times D&D統合・ガント幅バグ修正・利用者軸フォント統一・seed複数週対応・通知設定Firestore/UI管理化・マスタ詳細シート追加・ファビコン追加・E2Eテスト拡充・利用者マスタ表示/検索拡充・ふりがなソート/あかさたなフィルター・基本予定一覧詳細シート・手動編集バーアンバーデザイン刷新・Undo/Redo機能・iPad横向きレスポンシブ対応・allowed_staff_ids ホワイトリスト + 事前チェック・same_household/facility_customer_ids移行・利用者編集UI同一世帯/施設MultiSelect・Google Chat DM催促・E2E D&D flakiness改善）実装済み・マージ済み
 
 ## 完了済み（詳細は `docs/handoff/archive/2026-02-detailed-history.md` を参照）
 
@@ -58,6 +58,16 @@ cd optimizer && .venv/bin/pytest tests/ -v  # pytest
 - PR時: test-optimizer + test-web 並列実行
 - main push時: テスト通過後にCloud Build + Firebase Hosting + Firestoreルール 並列デプロイ
 - 必要なGitHub Secrets: `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`
+
+## 直近の実装（2026-03-09）
+
+- **fix (#149, 2026-03-09)** ✅: E2E D&D flakiness改善 — ドラッグ操作の座標安定性を強化（CI: 3回連続GREEN 63 passed, 1 flaky, 0 failed）
+  - `dragOrderToTarget()`: ドラッグ開始後にターゲット位置を再スクロール → freshDropBoxで座標再取得。stale drop座標による落下失敗を削減（NOTE: mousedown中のscrollIntoViewIfNeededはdnd-kit座標deltaをずらすリスク、ビューポート拡大で緩和）
+  - `findSingleBarInRow()`: N回の非同期DOM問い合わせ（bars.count() ループ）→ 単一`page.evaluate()`呼び出しに最適化。strict mode違反リスク低減、Emulator RPC呼び出し削減
+  - `dragOrderHorizontally()`: コメント整備（dnd-kit PointerSensor 5px距離確実トリガーの詳細説明）
+  - E2Eテスト: `toBeLessThanOrEqual(0)` → `toBe(0)` に修正（キャンセル時トースト非表示の意図明確化）
+  - ローカル検証: 6 passed, 2 flaky (Emulator並列ロード), 0 logic failures
+  - 他テストへの副作用: なし（D&D機構のみ変更）
 
 ## 直近の実装（2026-03-08）
 

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -94,10 +94,12 @@ export async function findSingleBarInRow(page: Page): Promise<{ bar: Locator; ro
     return { bar: row.locator('[data-testid^="gantt-bar-"]').first(), row };
   }
 
-  // フォールバック: 最初のバーとその行（strict mode violation のリスクあり）
+  // フォールバック: 最初のバーとその実際の親行を返す
   console.warn('findSingleBarInRow: no single-bar row found, falling back to first bar');
   const firstBar = page.locator('[data-testid^="gantt-bar-"]').first();
-  return { bar: firstBar, row: ganttRows.first() };
+  // barの実際の親gantt-rowを取得（barとrowの不整合を防止）
+  const parentRow = firstBar.locator('xpath=ancestor::*[starts-with(@data-testid,"gantt-row-")]').first();
+  return { bar: firstBar, row: parentRow };
 }
 
 /**


### PR DESCRIPTION
## Summary

- `findSingleBarInRow` のフォールバックパスで `ganttRows.first()` を返していたが、`firstBar` がその行に含まれる保証がなかった
- xpath ancestor で `firstBar` の実際の親 `gantt-row` を取得するよう修正
- Codex独立レビュー（PR #149）の non-blocking 指摘への構造的対応

## Changes (1 file, +2/-2 実質)

- `web/e2e/helpers.ts`: フォールバック時に `ganttRows.first()` → `firstBar.locator('xpath=ancestor::...')` に変更

## Test plan

- [x] CI E2Eテスト通過確認（フォールバックパスは通常発動しないが、発動時の正確性を保証）
- [x] 他のテストへの影響なし（変更はフォールバックパスのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)