### PR TITLE
fix: 住所正規化をNFKC統一 + テストギャップ解消

### DIFF
--- a/optimizer/src/optimizer/data/normalize_address.py
+++ b/optimizer/src/optimizer/data/normalize_address.py
@@ -15,7 +15,7 @@ def normalize_address(address: str) -> str:
     s = unicodedata.normalize("NFKC", address)
 
     # ハイフン系文字の統一
-    s = re.sub(r"[‐―ー‒–—﹣－]", "-", s)
+    s = re.sub(r"[‐―ー‒–—﹣－−]", "-", s)
 
     # 連続空白を1つに統合 + トリム
     s = re.sub(r"\s+", " ", s).strip()

--- a/optimizer/tests/test_normalize_address.py
+++ b/optimizer/tests/test_normalize_address.py
@@ -1,0 +1,50 @@
+"""住所正規化のテスト — TS版 (web/src/lib/normalize-address.ts) と同一ケース"""
+
+from optimizer.data.normalize_address import normalize_address
+
+
+class TestNormalizeAddress:
+    def test_fullwidth_ascii_to_halfwidth(self) -> None:
+        assert normalize_address("東京都新宿区１−２−３") == "東京都新宿区1-2-3"
+
+    def test_halfwidth_katakana_to_fullwidth(self) -> None:
+        assert normalize_address("ｶﾅ町") == "カナ町"
+
+    def test_fullwidth_space_to_halfwidth(self) -> None:
+        assert normalize_address("東京都\u3000新宿区") == "東京都 新宿区"
+
+    def test_collapse_multiple_spaces(self) -> None:
+        assert normalize_address("東京都   新宿区") == "東京都 新宿区"
+
+    def test_trim_whitespace(self) -> None:
+        assert normalize_address("  東京都新宿区  ") == "東京都新宿区"
+
+    def test_unify_hyphens(self) -> None:
+        assert normalize_address("1‐2") == "1-2"
+        assert normalize_address("1―2") == "1-2"
+        assert normalize_address("1ー2") == "1-2"
+        assert normalize_address("1–2") == "1-2"
+        assert normalize_address("1—2") == "1-2"
+        assert normalize_address("1﹣2") == "1-2"
+        assert normalize_address("1－2") == "1-2"
+        # U+2212 MINUS SIGN
+        assert normalize_address("1\u22122") == "1-2"
+
+    def test_combined_normalization(self) -> None:
+        assert normalize_address("\u3000東京都\u3000新宿区１ー２ー３\u3000") == "東京都 新宿区1-2-3"
+
+    def test_empty_string(self) -> None:
+        assert normalize_address("") == ""
+
+    def test_already_normalized(self) -> None:
+        assert normalize_address("東京都新宿区1-2-3") == "東京都新宿区1-2-3"
+
+    def test_cross_platform_consistency(self) -> None:
+        """TS版と同一の期待値（クロスプラットフォーム一貫性）"""
+        cases = [
+            ("大阪市北区１丁目２−３", "大阪市北区1丁目2-3"),
+            ("ﾏﾝｼｮﾝ名\u3000１０２号", "マンション名 102号"),
+            ("渋谷区神南１ー１ー１", "渋谷区神南1-1-1"),
+        ]
+        for input_addr, expected in cases:
+            assert normalize_address(input_addr) == expected

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -144,6 +144,26 @@ describe('CustomerDetailSheet', () => {
     expect(screen.getByTestId('allowed-staff-preferred-h-3')).toBeInTheDocument();
   });
 
+  it('同一世帯メンバーが設定されている場合にIDが表示される', () => {
+    const customer = makeCustomer({ same_household_customer_ids: ['C002', 'C003'] });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    expect(screen.getByText('同一世帯')).toBeInTheDocument();
+    expect(screen.getByText('C002, C003')).toBeInTheDocument();
+  });
+
+  it('同一施設メンバーが設定されている場合にIDが表示される', () => {
+    const customer = makeCustomer({ same_facility_customer_ids: ['C010'] });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    expect(screen.getByText('同一施設')).toBeInTheDocument();
+    expect(screen.getByText('C010')).toBeInTheDocument();
+  });
+
+  it('同一世帯・同一施設が空のとき表示されない', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    expect(screen.queryByText('同一世帯')).not.toBeInTheDocument();
+    expect(screen.queryByText('同一施設')).not.toBeInTheDocument();
+  });
+
   it('allowed_staff_ids が空のとき「入れるスタッフ」セクションが表示されない', () => {
     render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
     expect(screen.queryByTestId('allowed-staff-badges')).not.toBeInTheDocument();

--- a/web/src/lib/__tests__/normalize-address.test.ts
+++ b/web/src/lib/__tests__/normalize-address.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAddress } from '../normalize-address';
+
+describe('normalizeAddress', () => {
+  it('全角英数字を半角に変換する', () => {
+    expect(normalizeAddress('東京都新宿区１−２−３')).toBe('東京都新宿区1-2-3');
+  });
+
+  it('半角カナを全角カナに変換する', () => {
+    expect(normalizeAddress('ｶﾅ町')).toBe('カナ町');
+  });
+
+  it('全角スペースを半角スペースに変換する', () => {
+    expect(normalizeAddress('東京都　新宿区')).toBe('東京都 新宿区');
+  });
+
+  it('連続する空白を1つに統合する', () => {
+    expect(normalizeAddress('東京都   新宿区')).toBe('東京都 新宿区');
+  });
+
+  it('前後の空白を除去する', () => {
+    expect(normalizeAddress('  東京都新宿区  ')).toBe('東京都新宿区');
+  });
+
+  it('ハイフン系文字を統一する', () => {
+    // 各種ハイフン: ‐ ― ー ‒ – — ﹣ －
+    expect(normalizeAddress('1‐2')).toBe('1-2');
+    expect(normalizeAddress('1―2')).toBe('1-2');
+    expect(normalizeAddress('1ー2')).toBe('1-2');
+    expect(normalizeAddress('1–2')).toBe('1-2');
+    expect(normalizeAddress('1—2')).toBe('1-2');
+    expect(normalizeAddress('1﹣2')).toBe('1-2');
+    expect(normalizeAddress('1－2')).toBe('1-2');
+    // U+2212 MINUS SIGN
+    expect(normalizeAddress('1\u22122')).toBe('1-2');
+  });
+
+  it('複合的な正規化が正しく行われる', () => {
+    expect(normalizeAddress('　東京都　新宿区１ー２ー３　')).toBe('東京都 新宿区1-2-3');
+  });
+
+  it('空文字列を処理できる', () => {
+    expect(normalizeAddress('')).toBe('');
+  });
+
+  it('正規化不要な文字列はそのまま返す', () => {
+    expect(normalizeAddress('東京都新宿区1-2-3')).toBe('東京都新宿区1-2-3');
+  });
+
+  it('Python版と同一の結果を返す（クロスプラットフォーム一貫性）', () => {
+    // Python: unicodedata.normalize("NFKC", ...) と同一結果
+    const cases = [
+      ['大阪市北区１丁目２−３', '大阪市北区1丁目2-3'],
+      ['ﾏﾝｼｮﾝ名　１０２号', 'マンション名 102号'],
+      ['渋谷区神南１ー１ー１', '渋谷区神南1-1-1'],
+    ];
+    for (const [input, expected] of cases) {
+      expect(normalizeAddress(input)).toBe(expected);
+    }
+  });
+});

--- a/web/src/lib/normalize-address.ts
+++ b/web/src/lib/normalize-address.ts
@@ -2,24 +2,18 @@
  * 住所正規化 — 同一住所判定に使用
  *
  * 正規化ルール:
- * 1. 全角英数字・記号 → 半角
- * 2. 半角カナ → 全角カナ
+ * 1. NFKC正規化（全角英数字→半角、半角カナ→全角カナ etc.）
+ * 2. ハイフン系文字の統一（‐ ― ー ‒ – — ﹣ － → -)
  * 3. 連続する空白を1つに統合し、前後の空白を除去
- * 4. ハイフン系文字の統一（‐ ― ー ‒ – — ﹣ － → -)
+ *
+ * ※ Python版 (optimizer/data/normalize_address.py) と同一ロジック
  */
 export function normalizeAddress(address: string): string {
-  let s = address;
-
-  // 全角英数字・記号 → 半角 (U+FF01-FF5E → U+0021-007E)
-  s = s.replace(/[\uFF01-\uFF5E]/g, (ch) =>
-    String.fromCharCode(ch.charCodeAt(0) - 0xFEE0)
-  );
-
-  // 全角スペース → 半角スペース
-  s = s.replace(/\u3000/g, ' ');
+  // NFKC正規化 (全角英数字→半角、半角カナ→全角カナ etc.)
+  let s = address.normalize('NFKC');
 
   // ハイフン系文字の統一
-  s = s.replace(/[‐―ー‒–—﹣－]/g, '-');
+  s = s.replace(/[‐―ー‒–—﹣－−]/g, '-');
 
   // 連続空白を1つに統合 + トリム
   s = s.replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
## Summary

- TS版 `normalizeAddress()` を手動変換から `String.normalize('NFKC')` に変更し、Python版と同一ロジックに統一
- 半角カナ（例: `ｶﾅ町`）がTS/Pythonで異なる結果になる不一致を解消
- U+2212 MINUS SIGN をハイフン統一対象に追加（TS/Python両方）
- 住所正規化テストを TS/Python 各10件新規追加（クロスプラットフォーム一貫性テスト含む）
- CustomerDetailSheet に同一世帯/施設表示テスト3件追加

### 修正された不一致
| 入力 | 旧TS | Python | 修正後TS |
|------|------|--------|---------|
| `ｶﾅ町` | `ｶﾅ町` | `カナ町` | `カナ町` |
| `1−2` (U+2212) | `1−2` | `1−2` | `1-2` |

## Test plan

- [x] TS normalize-address: 10 passed
- [x] Python test_normalize_address: 10 passed
- [x] CustomerDetailSheet: 22 passed（+3件追加）
- [x] Web全テスト: 509 passed
- [x] Optimizer全テスト: 319 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)