### PR TITLE
fix: 希望休日付フィルタ・権限境界・週切替リセットの3件修正

### DIFF
--- a/optimizer/src/optimizer/api/auth.py
+++ b/optimizer/src/optimizer/api/auth.py
@@ -79,9 +79,6 @@ async def require_manager_or_above(request: Request) -> dict | None:
         return None
 
     role = decoded.get("role")
-    if role is None:
-        return decoded
-
     if role not in ("admin", "service_manager"):
         raise HTTPException(status_code=403, detail="権限がありません")
     return decoded

--- a/optimizer/tests/test_auth.py
+++ b/optimizer/tests/test_auth.py
@@ -165,8 +165,8 @@ class TestRequireManagerOrAbove:
             assert resp.status_code == 403
             assert "権限がありません" in resp.json()["detail"]
 
-    def test_no_role_allowed(self) -> None:
-        """roleなし（Custom Claims未設定）で200（デモ互換）"""
+    def test_no_role_denied(self) -> None:
+        """roleなし（Custom Claims未設定）は403拒否"""
         decoded = {"uid": "no-role-1", "email": "user@example.com"}
         with patch("optimizer.api.auth.ALLOW_UNAUTHENTICATED", False), \
              patch("optimizer.api.auth._get_firebase_app"), \
@@ -179,7 +179,7 @@ class TestRequireManagerOrAbove:
 
             client = TestClient(app)
             resp = client.get("/test", headers={"Authorization": "Bearer t"})
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
     def test_unauthenticated_mode_skips(self) -> None:
         """ALLOW_UNAUTHENTICATED=trueでスキップ"""

--- a/web/src/hooks/useOrders.ts
+++ b/web/src/hooks/useOrders.ts
@@ -12,6 +12,10 @@ export function useOrders(weekStart: Date) {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    setOrders([]);
+    setLoading(true);
+    setError(null);
+
     const weekStartTs = Timestamp.fromDate(weekStart);
     const q = query(
       collection(getDb(), 'orders'),

--- a/web/src/hooks/useStaffUnavailability.ts
+++ b/web/src/hooks/useStaffUnavailability.ts
@@ -12,6 +12,10 @@ export function useStaffUnavailability(weekStart: Date) {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    setUnavailability([]);
+    setLoading(true);
+    setError(null);
+
     const weekStartTs = Timestamp.fromDate(weekStart);
     const q = query(
       collection(getDb(), 'staff_unavailability'),

--- a/web/src/lib/constraints/__tests__/checker.test.ts
+++ b/web/src/lib/constraints/__tests__/checker.test.ts
@@ -153,6 +153,55 @@ describe('checkConstraints', () => {
     expect(violations.some((v) => v.type === 'unavailability')).toBe(true);
   });
 
+  it('別日の希望休（終日）はオーダー日に影響しない', () => {
+    const helpers = new Map([['H001', makeHelper()]]);
+    const customers = new Map([['C001', makeCustomer()]]);
+    // オーダーは1/6（月）、希望休は1/7（火）
+    const unavailability: StaffUnavailability[] = [{
+      id: 'U002',
+      staff_id: 'H001',
+      week_start_date: new Date('2025-01-06'),
+      unavailable_slots: [{ date: new Date('2025-01-07'), all_day: true }],
+      submitted_at: new Date(),
+    }];
+    const result = checkConstraints({
+      orders: [makeOrder({ date: new Date('2025-01-06') })],
+      helpers,
+      customers,
+      unavailability,
+      day: 'monday',
+    });
+    const violations = result.get('O001') ?? [];
+    expect(violations.some((v) => v.type === 'unavailability')).toBe(false);
+  });
+
+  it('別日の希望休（時間帯）はオーダー日に影響しない', () => {
+    const helpers = new Map([['H001', makeHelper()]]);
+    const customers = new Map([['C001', makeCustomer()]]);
+    // オーダーは1/6（月）09:00-10:00、希望休は1/7（火）09:00-12:00
+    const unavailability: StaffUnavailability[] = [{
+      id: 'U003',
+      staff_id: 'H001',
+      week_start_date: new Date('2025-01-06'),
+      unavailable_slots: [{
+        date: new Date('2025-01-07'),
+        all_day: false,
+        start_time: '09:00',
+        end_time: '12:00',
+      }],
+      submitted_at: new Date(),
+    }];
+    const result = checkConstraints({
+      orders: [makeOrder({ date: new Date('2025-01-06') })],
+      helpers,
+      customers,
+      unavailability,
+      day: 'monday',
+    });
+    const violations = result.get('O001') ?? [];
+    expect(violations.some((v) => v.type === 'unavailability')).toBe(false);
+  });
+
   it('serviceTypes の requires_physical_care_cert=true → 資格なしで違反', () => {
     const helpers = new Map([['H001', makeHelper({ can_physical_care: false })]]);
     const customers = new Map([['C001', makeCustomer()]]);

--- a/web/src/lib/constraints/checker.ts
+++ b/web/src/lib/constraints/checker.ts
@@ -8,6 +8,12 @@ function timeToMinutes(time: string): number {
   return h * 60 + m;
 }
 
+function isSameDate(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+}
+
 export type ViolationSeverity = 'error' | 'warning';
 
 export interface Violation {
@@ -161,10 +167,11 @@ export function checkConstraints(input: CheckInput): ViolationMap {
         }
       }
 
-      // 希望休
+      // 希望休（オーダーと同じ日付のスロットのみ判定）
       const staffUnavail = input.unavailability.filter((u) => u.staff_id === staffId);
       for (const u of staffUnavail) {
         for (const slot of u.unavailable_slots) {
+          if (!isSameDate(slot.date, order.date)) continue;
           if (slot.all_day) {
             addViolation({
               orderId: order.id,

--- a/web/src/lib/dnd/__tests__/validation.test.ts
+++ b/web/src/lib/dnd/__tests__/validation.test.ts
@@ -202,6 +202,43 @@ describe('validateDrop', () => {
       const result = validateDrop(input);
       expect(result.allowed).toBe(false);
     });
+
+    it('別日の希望休（終日）はオーダー日に影響しない → 許可', () => {
+      const input = baseInput();
+      // オーダーは2/9（月）、希望休は2/10（火）
+      input.order = makeOrder({ date: new Date('2026-02-09') });
+      input.unavailability = [{
+        id: 'unavail-3',
+        staff_id: 'helper-b',
+        week_start_date: new Date('2026-02-09'),
+        unavailable_slots: [{ date: new Date('2026-02-10'), all_day: true }],
+        submitted_at: new Date(),
+      }];
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('別日の希望休（時間帯）はオーダー日に影響しない → 許可', () => {
+      const input = baseInput();
+      // オーダーは2/9（月）09:00-10:00、希望休は2/10（火）09:00-12:00
+      input.order = makeOrder({ date: new Date('2026-02-09') });
+      input.unavailability = [{
+        id: 'unavail-4',
+        staff_id: 'helper-b',
+        week_start_date: new Date('2026-02-09'),
+        unavailable_slots: [{
+          date: new Date('2026-02-10'),
+          all_day: false,
+          start_time: '09:00',
+          end_time: '12:00',
+        }],
+        submitted_at: new Date(),
+      }];
+
+      const result = validateDrop(input);
+      expect(result.allowed).toBe(true);
+    });
   });
 
   describe('warning制約（ドロップ許可+警告）', () => {

--- a/web/src/lib/dnd/validation.ts
+++ b/web/src/lib/dnd/validation.ts
@@ -9,6 +9,12 @@ function timeToMinutes(time: string): number {
   return h * 60 + m;
 }
 
+function isSameDate(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+}
+
 interface ValidateDropInput {
   order: Order;
   targetHelperId: string;
@@ -83,10 +89,11 @@ export function validateDrop(input: ValidateDropInput): DropValidationResult {
     }
   }
 
-  // 希望休
+  // 希望休（オーダーと同じ日付のスロットのみ判定）
   const staffUnavail = unavailability.filter((u) => u.staff_id === targetHelperId);
   for (const u of staffUnavail) {
     for (const slot of u.unavailable_slots) {
+      if (!isSameDate(slot.date, order.date)) continue;
       if (slot.all_day) {
         return { allowed: false, reason: `${helper.name.family} は希望休（終日）です` };
       }


### PR DESCRIPTION
## Summary

Codex セカンドオピニオンレビューで検出された High 優先度 3 件を修正:

- **希望休判定の日付フィルタ追加**: `slot.date` と `order.date` の日付比較を追加。別日の希望休がオーダー日に誤適用されるバグを修正（`validation.ts`, `checker.ts`）
- **権限境界の修正**: `require_manager_or_above()` で role 未設定ユーザーを 403 拒否に変更（`auth.py`）
- **週切り替え時のデータリセット**: `useOrders` / `useStaffUnavailability` で weekStart 変更時に state を初期化（前週データの表示を防止）

## Test plan

- [x] Web 全テスト: 513 passed
- [x] Optimizer 全テスト: 319 passed
- [x] 希望休日付フィルタ: validation.test.ts +2件, checker.test.ts +2件（別日の終日/時間帯希望休が影響しないことを確認）
- [x] 権限テスト: test_auth.py の `test_no_role_denied` を 403 期待に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)