### PR TITLE
fix: Codex Medium指摘3件修正（training整合性・travel_timesロード・LATEST.md）

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,6 +1,6 @@
 # ハンドオフメモ - visitcare-shift-optimizer
 
-**最終更新**: 2026-03-09（Codexレビュー指摘対応 PR #151, #152 マージ済み）
+**最終更新**: 2026-03-08（Codexレビュー Medium指摘対応 PR #158 マージ予定）
 **現在のフェーズ**: Phase 0-5b 完了 → 実績確認・月次レポート・Google Sheetsエクスポート（本番動作確認済み）・マスタ拡張（不定期パターン・外部連携ID・分断勤務・徒歩距離上限・サービス種別→介護保険105種・性別制約・新マスタフィールド・研修状態3段階・週全体ビュー・service_typesマスタ化 Phase 1-3・制約チェック UI 拡張・メール通知・利用者軸ビュー・基本予定一覧・Gmail API DWD送信実装・staff_count複数割当・travel_times D&D統合・ガント幅バグ修正・利用者軸フォント統一・seed複数週対応・通知設定Firestore/UI管理化・マスタ詳細シート追加・ファビコン追加・E2Eテスト拡充・利用者マスタ表示/検索拡充・ふりがなソート/あかさたなフィルター・基本予定一覧詳細シート・手動編集バーアンバーデザイン刷新・Undo/Redo機能・iPad横向きレスポンシブ対応・allowed_staff_ids ホワイトリスト + 事前チェック・same_household/facility_customer_ids移行・利用者編集UI同一世帯/施設MultiSelect・Google Chat DM催促・E2E D&D flakiness改善）実装済み・マージ済み
 
 ## 完了済み（詳細は `docs/handoff/archive/2026-02-detailed-history.md` を参照）
@@ -58,6 +58,25 @@ cd optimizer && .venv/bin/pytest tests/ -v  # pytest
 - PR時: test-optimizer + test-web 並列実行
 - main push時: テスト通過後にCloud Build + Firebase Hosting + Firestoreルール 並列デプロイ
 - 必要なGitHub Secrets: `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`
+
+## 直近の実装（2026-03-08 Codex Medium対応）
+
+- **fix (#158, 2026-03-08)** ✅: Codex Medium指摘3件修正
+  - `checker.ts`: not_visited + 複数人体制 → error から warning に降格（validation.ts / optimizer と整合性統一）
+  - `useScheduleData.ts`: `travelTimesLoading` を combined `loading` に追加（travel_times ロード前の制約チェック漏れ防止）
+  - `LATEST.md`: PR #155〜#157 の内容を追記
+
+- **fix (#157, 2026-03-08)** ✅: 希望休日付フィルタ・権限境界・週切替リセットの3件修正（Codex High指摘対応）
+  - `validation.ts` / `checker.ts`: 希望休 `slot.date` と `order.date` の日付比較 `isSameDate()` を追加（別日の希望休が誤適用されるバグ修正）
+  - `auth.py`: `require_manager_or_above()` で role claim 未設定ユーザーを403拒否に変更（セキュリティ修正）
+  - `useOrders.ts` / `useStaffUnavailability.ts`: 週切替時に state を初期化（前週データ残留防止）
+  - テスト: validation.test.ts +2件、checker.test.ts +2件、test_auth.py 期待値変更
+
+- **fix (#156, 2026-03-08)** ✅: 住所正規化をNFKC統一 + テストギャップ解消
+  - `normalize-address.ts` / `normalize_address.py`: NFKC正規化を統一適用
+  - テスト追加: 全角数字・全角ハイフン・スペース正規化のエッジケース
+
+- **docs (#155, 2026-03-08)** ✅: LATEST.md に PR #151, #152 の内容を追記
 
 ## 直近の実装（2026-03-09）
 

--- a/web/src/hooks/useScheduleData.ts
+++ b/web/src/hooks/useScheduleData.ts
@@ -32,9 +32,9 @@ export function useScheduleData(weekStart: Date) {
   const { customers, loading: customersLoading } = useCustomers();
   const { orders, loading: ordersLoading } = useOrders(weekStart);
   const { unavailability, loading: unavailabilityLoading } = useStaffUnavailability(weekStart);
-  const { travelTimeLookup } = useTravelTimes();
+  const { travelTimeLookup, loading: travelTimesLoading } = useTravelTimes();
 
-  const loading = helpersLoading || customersLoading || ordersLoading || unavailabilityLoading;
+  const loading = helpersLoading || customersLoading || ordersLoading || unavailabilityLoading || travelTimesLoading;
 
   const ordersByDay = useMemo(() => {
     const map: Record<DayOfWeek, Order[]> = {

--- a/web/src/lib/constraints/__tests__/checker.test.ts
+++ b/web/src/lib/constraints/__tests__/checker.test.ts
@@ -340,6 +340,25 @@ describe('checkConstraints', () => {
       const violations = result.get('O001') ?? [];
       expect(violations.some((v) => v.type === 'training')).toBe(false);
     });
+
+    it('not_visited + staff_count>1（複数人体制）→ warning（error ではない）', () => {
+      const helpers = new Map([
+        ['H001', makeHelper({ id: 'H001', customer_training_status: { C001: 'not_visited' } })],
+        ['H002', makeHelper({ id: 'H002', name: { family: '鈴木', given: '次郎' } })],
+      ]);
+      const customers = new Map([['C001', makeCustomer()]]);
+      const result = checkConstraints({
+        orders: [makeOrder({ assigned_staff_ids: ['H001', 'H002'], staff_count: 2 })],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      const violations = result.get('O001') ?? [];
+      const trainingViolations = violations.filter((v) => v.type === 'training' && v.staffId === 'H001');
+      expect(trainingViolations.length).toBe(1);
+      expect(trainingViolations[0].severity).toBe('warning');
+    });
   });
 
   describe('staff_count 違反', () => {

--- a/web/src/lib/constraints/checker.ts
+++ b/web/src/lib/constraints/checker.ts
@@ -106,16 +106,27 @@ export function checkConstraints(input: CheckInput): ViolationMap {
         }
       }
 
-      // 研修状態
+      // 研修状態（複数人体制なら同行可能のため warning に降格）
       const trainingStatus = helper.customer_training_status[order.customer_id];
+      const staffCount = getStaffCount(order, customer, input.day);
       if (trainingStatus === 'not_visited') {
-        addViolation({
-          orderId: order.id,
-          staffId,
-          type: 'training',
-          severity: 'error',
-          message: `${helper.name.family} は未訪問（研修未開始）`,
-        });
+        if (staffCount > 1) {
+          addViolation({
+            orderId: order.id,
+            staffId,
+            type: 'training',
+            severity: 'warning',
+            message: `${helper.name.family} は未訪問（複数人体制のため同行可能）`,
+          });
+        } else {
+          addViolation({
+            orderId: order.id,
+            staffId,
+            type: 'training',
+            severity: 'error',
+            message: `${helper.name.family} は未訪問（研修未開始）`,
+          });
+        }
       } else if (trainingStatus === 'training') {
         addViolation({
           orderId: order.id,


### PR DESCRIPTION
## Summary

- `checker.ts`: not_visited + 複数人体制(staff_count>1) → error から warning に降格（validation.ts / optimizer.py と整合性統一）
- `useScheduleData.ts`: `useTravelTimes()` の `loading` フラグを combined `loading` に追加（travel_times ロード前の制約チェック漏れ防止）
- `LATEST.md`: PR #155〜#157 の内容を追記

## Background

Codex セカンドオピニオンレビューで検出された Medium 優先度の指摘3件:
- **#4 制約ロジック二重実装**: `checker.ts` が `staff_count` を無視して not_visited を常に error にしていた。`validation.ts`（D&D）と `optimizer.py`（ソルバー）では複数人体制なら許可/warning
- **#6 travel_times ロード完了条件**: `useScheduleData` が `travelTimesLoading` を `loading` に含めておらず、travel_times ロード前にUIが描画されていた

## Test plan

- [x] checker.test.ts: not_visited + staff_count>1 → warning テスト追加（28件全パス）
- [x] Web全テスト: 514 passed
- [x] tsc --noEmit: 今回の変更ファイルにエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)