### PR TITLE
chore: checker.ts getStaffCount重複解消 + LATEST.mdテスト件数更新

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -291,7 +291,7 @@ cd optimizer && .venv/bin/pytest tests/ -v  # pytest
 
 ## 最新テスト結果サマリー（2026-03-08）
 - **Optimizer**: 297件 pass ✅
-- **Web (Next.js)**: **490件 pass** ✅（+29: OptimizeButton事前チェック7件 + WeeklySchedulePage 9件 + E2Eテスト拡充関連）
+- **Web (Next.js)**: **521件 pass** ✅（+31: useScheduleData loading 7件 + checker training整合性 1件 + household/facility関連 23件）
 - **Firestore Rules**: 107件 pass
 - **E2E Tests (Playwright)**: **66テスト** pass（+2: Undo/Redo初期状態 + D&D→Undo→Redoフロー）
 - **CI/CD**: PR #147 CI全4ジョブGREEN

--- a/web/src/lib/constraints/checker.ts
+++ b/web/src/lib/constraints/checker.ts
@@ -51,12 +51,12 @@ export function checkConstraints(input: CheckInput): ViolationMap {
 
   const assignedOrders = input.orders.filter((o) => o.assigned_staff_ids.length > 0);
 
-  // staff_count 違反チェック（オーダー単位）
   for (const order of assignedOrders) {
     const customer = input.customers.get(order.customer_id);
     const staffCount = getStaffCount(order, customer, input.day);
     const assignedCount = order.assigned_staff_ids.length;
 
+    // staff_count 違反チェック（オーダー単位）
     if (assignedCount > 0 && assignedCount < staffCount) {
       addViolation({
         orderId: order.id,
@@ -72,10 +72,6 @@ export function checkConstraints(input: CheckInput): ViolationMap {
         message: `必要人数超過（必要: ${staffCount}人、割当: ${assignedCount}人）`,
       });
     }
-  }
-
-  for (const order of assignedOrders) {
-    const customer = input.customers.get(order.customer_id);
 
     for (const staffId of order.assigned_staff_ids) {
       const helper = input.helpers.get(staffId);
@@ -108,7 +104,6 @@ export function checkConstraints(input: CheckInput): ViolationMap {
 
       // 研修状態（複数人体制なら同行可能のため warning に降格）
       const trainingStatus = helper.customer_training_status[order.customer_id];
-      const staffCount = getStaffCount(order, customer, input.day);
       if (trainingStatus === 'not_visited') {
         if (staffCount > 1) {
           addViolation({


### PR DESCRIPTION
## Summary

- `checker.ts`: staff_count違反チェックとスタッフ別チェックの2ループを統合し、`getStaffCount` の重複呼び出しを解消（ロジック変更なし）
- `LATEST.md`: Webテスト件数を490→521に更新

## Test plan

- [x] checker.test.ts 28件 pass
- [x] Web全体 521件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)