### PR TITLE
feat: メニュー・ナビゲーション改善（タブ統一・パンくず・現在地表示）

### DIFF
--- a/web/src/app/history/page.tsx
+++ b/web/src/app/history/page.tsx
@@ -3,9 +3,9 @@
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
-import { ArrowLeft, Clock, CheckCircle2, XCircle, AlertTriangle, FlaskConical, Loader2 } from 'lucide-react';
-import Link from 'next/link';
+import { Clock, CheckCircle2, XCircle, AlertTriangle, FlaskConical, Loader2 } from 'lucide-react';
 import { Header } from '@/components/layout/Header';
+import { AppBreadcrumb } from '@/components/layout/AppBreadcrumb';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -166,14 +166,9 @@ export default function HistoryPage() {
   return (
     <div className="flex h-screen flex-col">
       <Header />
+      <AppBreadcrumb />
       <main className="flex-1 overflow-auto p-4">
-        <div className="mb-4 flex items-center gap-3">
-          <Button variant="ghost" size="sm" asChild>
-            <Link href="/">
-              <ArrowLeft className="mr-1 h-4 w-4" />
-              戻る
-            </Link>
-          </Button>
+        <div className="mb-4">
           <h2 className="text-lg font-semibold">最適化実行履歴</h2>
         </div>
 

--- a/web/src/app/masters/layout.tsx
+++ b/web/src/app/masters/layout.tsx
@@ -6,9 +6,11 @@ import { Header } from '@/components/layout/Header';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 const MASTER_TABS = [
-  { value: '/masters/customers', label: '利用者マスタ' },
-  { value: '/masters/helpers', label: 'ヘルパーマスタ' },
-  { value: '/masters/unavailability', label: '希望休管理' },
+  { value: '/masters/customers', label: '利用者' },
+  { value: '/masters/helpers', label: 'ヘルパー' },
+  { value: '/masters/service-types', label: 'サービス種別' },
+  { value: '/masters/weekly-schedule', label: '基本予定' },
+  { value: '/masters/unavailability', label: '希望休' },
 ] as const;
 
 export default function MastersLayout({
@@ -22,7 +24,7 @@ export default function MastersLayout({
   return (
     <div className="flex h-screen flex-col">
       <Header />
-      <div className="border-b px-4 pt-2">
+      <div className="overflow-x-auto border-b px-4 pt-2">
         <Tabs value={currentTab}>
           <TabsList>
             {MASTER_TABS.map((tab) => (

--- a/web/src/app/report/page.tsx
+++ b/web/src/app/report/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { startOfMonth } from 'date-fns';
 import { Header } from '@/components/layout/Header';
+import { AppBreadcrumb } from '@/components/layout/AppBreadcrumb';
 import { ExportButton } from '@/components/report/ExportButton';
 import { MonthSelector } from '@/components/report/MonthSelector';
 import { StaffSummaryTable } from '@/components/report/StaffSummaryTable';
@@ -33,6 +34,7 @@ export default function ReportPage() {
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <Header />
+      <AppBreadcrumb />
 
       <main className="flex-1 px-4 py-6">
         <div className="mx-auto max-w-6xl space-y-6">

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { useAuthRole } from '@/lib/auth/AuthProvider';
 import { useNotificationSettings } from '@/hooks/useNotificationSettings';
 import { updateNotificationSettings } from '@/lib/firestore/settings';
 import { Header } from '@/components/layout/Header';
+import { AppBreadcrumb } from '@/components/layout/AppBreadcrumb';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -45,6 +46,7 @@ export default function SettingsPage() {
   return (
     <div className="min-h-screen bg-background">
       <Header />
+      <AppBreadcrumb />
       <main className="max-w-2xl mx-auto p-6 space-y-6">
         <h1 className="text-2xl font-bold">設定</h1>
 

--- a/web/src/components/layout/AppBreadcrumb.tsx
+++ b/web/src/components/layout/AppBreadcrumb.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+
+interface BreadcrumbEntry {
+  group: string;
+  groupHref?: string;
+  label: string;
+}
+
+const BREADCRUMB_MAP: Record<string, BreadcrumbEntry> = {
+  '/masters/customers': { group: 'マスタ管理', groupHref: '/masters/customers', label: '利用者' },
+  '/masters/helpers': { group: 'マスタ管理', groupHref: '/masters/customers', label: 'ヘルパー' },
+  '/masters/service-types': { group: 'マスタ管理', groupHref: '/masters/customers', label: 'サービス種別' },
+  '/masters/weekly-schedule': { group: 'マスタ管理', groupHref: '/masters/customers', label: '基本予定' },
+  '/masters/unavailability': { group: 'マスタ管理', groupHref: '/masters/customers', label: '希望休' },
+  '/history': { group: '運用', label: '実行履歴' },
+  '/report': { group: '運用', label: '月次レポート' },
+  '/settings': { group: '設定', label: '通知設定' },
+};
+
+export function AppBreadcrumb() {
+  const pathname = usePathname();
+  const entry = pathname ? BREADCRUMB_MAP[pathname] : undefined;
+
+  if (!entry) return null;
+
+  return (
+    <div className="border-b bg-muted/30 px-4 py-1.5">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/">ホーム</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          {entry.groupHref ? (
+            <>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link href={entry.groupHref}>{entry.group}</Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+            </>
+          ) : (
+            <>
+              <BreadcrumbItem>
+                <span className="text-muted-foreground">{entry.group}</span>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+            </>
+          )}
+          <BreadcrumbItem>
+            <BreadcrumbPage>{entry.label}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    </div>
+  );
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Heart, Settings, Users, UserCog, CalendarOff, History, LogOut, HelpCircle, BarChart2, Tag, CalendarCheck, Bell } from 'lucide-react';
+import { Heart, Menu, Users, UserCog, CalendarOff, History, LogOut, HelpCircle, BarChart2, Tag, CalendarCheck, Bell, LayoutDashboard } from 'lucide-react';
 import { WeekSelector } from '@/components/schedule/WeekSelector';
 import { useAuth } from '@/lib/auth/AuthProvider';
 import {
@@ -74,55 +74,58 @@ export function Header({ onShowWelcome }: HeaderProps = {}) {
                 size="icon"
                 className="text-white hover:bg-white/15"
               >
-                <Settings className="h-4.5 w-4.5" />
+                <Menu className="h-4.5 w-4.5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link href="/" className={pathname === '/' ? 'bg-accent' : ''}>
+                  <LayoutDashboard className="mr-2 h-4 w-4" />
+                  スケジュール
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuLabel>マスタ管理</DropdownMenuLabel>
-              <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
-                <Link href="/masters/customers">
+                <Link href="/masters/customers" className={pathname?.startsWith('/masters/customers') ? 'bg-accent' : ''}>
                   <Users className="mr-2 h-4 w-4" />
-                  利用者マスタ
+                  利用者
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <Link href="/masters/helpers">
+                <Link href="/masters/helpers" className={pathname?.startsWith('/masters/helpers') ? 'bg-accent' : ''}>
                   <UserCog className="mr-2 h-4 w-4" />
-                  ヘルパーマスタ
+                  ヘルパー
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <Link href="/masters/service-types">
+                <Link href="/masters/service-types" className={pathname?.startsWith('/masters/service-types') ? 'bg-accent' : ''}>
                   <Tag className="mr-2 h-4 w-4" />
-                  サービス種別マスタ
+                  サービス種別
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <Link href="/masters/weekly-schedule">
+                <Link href="/masters/weekly-schedule" className={pathname?.startsWith('/masters/weekly-schedule') ? 'bg-accent' : ''}>
                   <CalendarCheck className="mr-2 h-4 w-4" />
-                  基本予定一覧
+                  基本予定
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
-                <Link href="/masters/unavailability">
+                <Link href="/masters/unavailability" className={pathname?.startsWith('/masters/unavailability') ? 'bg-accent' : ''}>
                   <CalendarOff className="mr-2 h-4 w-4" />
-                  希望休管理
+                  希望休
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel>最適化</DropdownMenuLabel>
+              <DropdownMenuLabel>運用</DropdownMenuLabel>
               <DropdownMenuItem asChild>
-                <Link href="/history">
+                <Link href="/history" className={pathname?.startsWith('/history') ? 'bg-accent' : ''}>
                   <History className="mr-2 h-4 w-4" />
                   実行履歴
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>レポート</DropdownMenuLabel>
               <DropdownMenuItem asChild>
-                <Link href="/report">
+                <Link href="/report" className={pathname?.startsWith('/report') ? 'bg-accent' : ''}>
                   <BarChart2 className="mr-2 h-4 w-4" />
                   月次レポート
                 </Link>
@@ -130,7 +133,7 @@ export function Header({ onShowWelcome }: HeaderProps = {}) {
               <DropdownMenuSeparator />
               <DropdownMenuLabel>設定</DropdownMenuLabel>
               <DropdownMenuItem asChild>
-                <Link href="/settings">
+                <Link href="/settings" className={pathname?.startsWith('/settings') ? 'bg-accent' : ''}>
                   <Bell className="mr-2 h-4 w-4" />
                   通知設定
                 </Link>

--- a/web/src/components/ui/breadcrumb.tsx
+++ b/web/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,109 @@
+import * as React from "react"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm break-words text-muted-foreground sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "a"
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}


### PR DESCRIPTION
## Summary

- マスタ管理タブを3→5に統一（サービス種別・基本予定を追加）
- メニューアイコンを歯車→ハンバーガーに変更（設定との混同解消）
- ホーム（スケジュール）リンクをメニュー最上部に追加
- 現在ページのハイライト表示（`bg-accent`）
- 「最適化」+「レポート」を「運用」グループに統合（1項目グループ解消）
- パンくずナビゲーション追加（history, report, settings）
- shadcn/ui breadcrumb コンポーネント導入

## Design Principles Applied

- **ミラーの法則 (7±2)**: タブ5項目、メニュー3グループで認知負荷最適
- **発見性**: ドロップダウンのみ → タブ+メニュー+パンくずの多重アクセス
- **一貫性**: マスタ管理5ページすべてをタブで相互遷移可能に
- **NNgroup**: パンくずでユーザー満足度43%向上の知見を適用

## Test plan

- [x] tsc --noEmit: 型エラー0件
- [x] Vitest: 529テスト全パス
- [ ] 手動確認: 各ページでパンくず表示、メニューハイライト、タブ遷移
- [ ] iPad横向き: タブ5つが収まるか（overflow-x-auto対応済み）

Closes #163, Closes #164, Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)