### PR TITLE
fix: PR #166のUI変更に伴うE2Eテスト同期

### DIFF
--- a/web/e2e/history.spec.ts
+++ b/web/e2e/history.spec.ts
@@ -8,9 +8,9 @@ test.describe('最適化履歴画面', () => {
     await expect(page.getByText('最適化実行履歴')).toBeVisible();
   });
 
-  test('戻るボタンでスケジュール画面に遷移できる', async ({ page }) => {
+  test('パンくずのホームリンクでスケジュール画面に遷移できる', async ({ page }) => {
     await goToHistory(page);
-    await page.getByRole('link', { name: /戻る/ }).click();
+    await page.getByRole('link', { name: 'ホーム' }).click();
     await expect(page).toHaveURL('/');
   });
 

--- a/web/e2e/schedule.spec.ts
+++ b/web/e2e/schedule.spec.ts
@@ -39,11 +39,11 @@ test.describe('スケジュール画面', () => {
 
   test('ヘッダーのドロップダウンメニューが開ける', async ({ page }) => {
     await goToSchedule(page);
-    // Settings アイコンボタン（ヘッダー内の最後のボタン）
+    // メニューボタン（ヘッダー内の最後のボタン）
     const menuTrigger = page.locator('header button').last();
     await menuTrigger.click();
-    await expect(page.getByText('利用者マスタ')).toBeVisible();
-    await expect(page.getByText('ヘルパーマスタ')).toBeVisible();
+    await expect(page.getByText('利用者')).toBeVisible();
+    await expect(page.getByText('ヘルパー')).toBeVisible();
     await expect(page.getByText('実行履歴')).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

- PR #166でメニューラベルを短縮（「利用者マスタ」→「利用者」等）した際、E2Eテストの更新が漏れていた
- 「戻る」ボタン削除に伴い、history.spec.tsのテストをパンくずナビゲーションテストに置換

## Changes

- `schedule.spec.ts:45-46`: `getByText('利用者マスタ')` → `getByText('利用者')` 等
- `history.spec.ts:11-14`: 「戻る」ボタンテスト → パンくず「ホーム」リンクテスト

## Test plan

- [x] E2EテストのテキストマッチがUI変更後のラベルと一致
- [ ] CI E2Eテスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)