### PR TITLE
test: マスタタブ遷移テスト全5タブ化 + getByRole統一

### DIFF
--- a/web/e2e/masters.spec.ts
+++ b/web/e2e/masters.spec.ts
@@ -150,15 +150,23 @@ test.describe('利用者マスタ 検索・フィルター機能', () => {
 });
 
 test.describe('マスタ管理タブナビゲーション', () => {
-  test('利用者→ヘルパー→希望休のタブ切替が動作する', async ({ page }) => {
+  test('全5タブの切替が動作する', async ({ page }) => {
     await goToMasters(page, 'customers');
     await expect(page.getByRole('table')).toBeVisible({ timeout: 15_000 });
 
-    // ヘルパータブをクリック（TabsTrigger内のLink）
+    // ヘルパータブ
     await page.getByRole('tab', { name: /ヘルパー/ }).click();
     await expect(page).toHaveURL(/\/masters\/helpers/);
 
-    // 希望休タブをクリック
+    // サービス種別タブ
+    await page.getByRole('tab', { name: /サービス種別/ }).click();
+    await expect(page).toHaveURL(/\/masters\/service-types/);
+
+    // 基本予定タブ
+    await page.getByRole('tab', { name: /基本予定/ }).click();
+    await expect(page).toHaveURL(/\/masters\/weekly-schedule/);
+
+    // 希望休タブ
     await page.getByRole('tab', { name: /希望休/ }).click();
     await expect(page).toHaveURL(/\/masters\/unavailability/);
   });

--- a/web/e2e/schedule.spec.ts
+++ b/web/e2e/schedule.spec.ts
@@ -52,7 +52,7 @@ test.describe('スケジュール画面', () => {
     // ドロップダウンメニューを開く
     const menuTrigger = page.locator('header button').last();
     await menuTrigger.click();
-    await page.getByText('実行履歴').click();
+    await page.getByRole('menuitem', { name: '実行履歴' }).click();
     await expect(page).toHaveURL(/\/history/);
   });
 });


### PR DESCRIPTION
## Summary

- `masters.spec.ts`: タブ遷移テストを3タブ→5タブに拡張（service-types, weekly-schedule 追加）
- `schedule.spec.ts`: `getByText('実行履歴')` → `getByRole('menuitem')` に統一（曖昧マッチ防止）

## Test plan

- [x] E2E: 全5タブ（利用者→ヘルパー→サービス種別→基本予定→希望休）の遷移確認
- [x] E2E: メニューから履歴画面への遷移が `getByRole` で動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)