### PR TITLE
fix: E2E flaky test タイムアウト延長

### DIFF
--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -205,5 +205,5 @@ export async function dragOrderHorizontally(page: Page, source: Locator, offsetX
  */
 export async function waitForToast(page: Page, text: string | RegExp) {
   const toast = page.locator('[data-sonner-toast]').filter({ hasText: text });
-  await expect(toast.first()).toBeVisible({ timeout: 15_000 });
+  await expect(toast.first()).toBeVisible({ timeout: 20_000 });
 }

--- a/web/e2e/schedule-interactions.spec.ts
+++ b/web/e2e/schedule-interactions.spec.ts
@@ -11,7 +11,7 @@ test.describe('スケジュール画面インタラクション', () => {
     const firstBar = page.locator('[data-testid^="gantt-bar-"]').first();
     await firstBar.click({ force: true });
 
-    await expect(page.locator('[data-testid="order-detail-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="order-detail-panel"]')).toBeVisible({ timeout: 10_000 });
   });
 
   test('OrderDetailPanelに利用者名・時間・サービス種別が表示される', async ({ page }) => {
@@ -22,7 +22,7 @@ test.describe('スケジュール画面インタラクション', () => {
     await firstBar.click({ force: true });
 
     const panel = page.locator('[data-testid="order-detail-panel"]');
-    await expect(panel).toBeVisible();
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     // 時間セクション
     await expect(panel.getByText('時間', { exact: true })).toBeVisible();
@@ -41,7 +41,7 @@ test.describe('スケジュール画面インタラクション', () => {
     await firstBar.click({ force: true });
 
     const panel = page.locator('[data-testid="order-detail-panel"]');
-    await expect(panel).toBeVisible();
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     await page.keyboard.press('Escape');
     await expect(panel).toBeHidden();


### PR DESCRIPTION
## Summary

- `schedule-interactions.spec.ts`: `order-detail-panel` の `toBeVisible()` に `timeout: 10_000` を追加（3箇所）
  - CI環境での描画遅延によりデフォルト5000msでタイムアウトしていた
- `helpers.ts`: `waitForToast` のタイムアウトを `15_000` → `20_000` に延長
  - D&D後のFirestore Emulator書き込み遅延＋トースト描画でタイムアウトしていた

## Test plan

- [x] 変更はタイムアウト値のみ（ロジック変更なし）
- [ ] CI E2E テスト全パス確認

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)