### PR TITLE
fix: 本番テンプレートの AUTH_MODE を required に変更

### DIFF
--- a/web/.env.production.example
+++ b/web/.env.production.example
@@ -13,8 +13,8 @@ NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
 # エミュレータ無効
 NEXT_PUBLIC_USE_EMULATOR=false
 
-# 認証モード
-NEXT_PUBLIC_AUTH_MODE=demo
+# 認証モード（本番: required = Googleログイン必須, demo = 匿名認証で全権限許可）
+NEXT_PUBLIC_AUTH_MODE=required
 
 # 最適化API URL
 NEXT_PUBLIC_OPTIMIZER_API_URL=https://your-cloud-run-url


### PR DESCRIPTION
## Summary

- `.env.production.example` の `NEXT_PUBLIC_AUTH_MODE` を `demo` → `required` に変更
- 本番テンプレートからコピーした際にデモモード（匿名認証＋全権限許可）のまま運用されるリスクを防止

## セキュリティ評価（Issue #154）

| レイヤー | hasNoRole() の扱い | 状態 |
|---------|:--:|:--:|
| Firestore ルール | 許可 | ⚠️ デモモード互換（案Bで段階的対応） |
| バックエンド API | 拒否 (403) | ✅ |
| フロントエンド UI | AUTH_MODE依存 | ✅ (required時は拒否) |

### 今回のスコープ（案A）
- [x] `.env.production.example` のデフォルトを `required` に変更

### 後続対応（案B: 本番公開前）
- [ ] `ci.yml` デプロイステップの `NEXT_PUBLIC_AUTH_MODE` を `required` に変更
- [ ] Google認証の Authorized domains 設定
- [ ] Firestore ルールの `hasNoRole()` を `isDemoMode()` ゲート付きに変更

## Test plan

- [x] テンプレートファイルのみの変更（ロジック変更なし）
- [x] CI/CDのビルド・テストステップは `demo` のまま（テスト環境に影響なし）

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)