### PR TITLE
fix: E2E D&Dテストのトースト待機を20秒に統一

### DIFF
--- a/web/e2e/schedule-dnd.spec.ts
+++ b/web/e2e/schedule-dnd.spec.ts
@@ -192,7 +192,7 @@ test.describe('スケジュール画面 D&D', { tag: '@dnd' }, () => {
 
     // D&D操作完了を確認: 成功/警告/エラー いずれかのトーストが表示される
     const anyToast = page.locator('[data-sonner-toast]');
-    await expect(anyToast.first()).toBeVisible({ timeout: 15_000 });
+    await expect(anyToast.first()).toBeVisible({ timeout: 20_000 });
 
     // 成功トーストの場合はバーの移動を確認
     const successToast = anyToast.filter({ hasText: /割当を変更しました/ });


### PR DESCRIPTION
## Summary

- `schedule-dnd.spec.ts:195` のインライントースト待機タイムアウトを15秒→20秒に延長
- `waitForToast` ヘルパー（PR #172で20秒に統一済み）と同じ値に合わせる
- CI環境のFirestore Emulator書き込み遅延によるフレーキー失敗を防止

## Test plan

- [x] 変更箇所は1行のみ（タイムアウト値変更）
- [ ] CIのE2Eテストが安定的にパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)