### PR TITLE
feat: 同一世帯・同一施設のDetailSheet表示を名前Badgeに改善

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -327,6 +327,7 @@ export default function CustomersPage() {
         onClose={() => setDetailOpen(false)}
         onEdit={handleDetailEdit}
         helpers={helpers}
+        customers={customers}
       />
 
       <CustomerEditDialog

--- a/web/src/app/masters/weekly-schedule/page.tsx
+++ b/web/src/app/masters/weekly-schedule/page.tsx
@@ -216,6 +216,7 @@ export default function WeeklySchedulePage() {
         onClose={() => setDetailOpen(false)}
         onEdit={handleDetailEdit}
         helpers={helpers}
+        customers={customers}
       />
 
       {canEditCustomers && (

--- a/web/src/components/masters/CustomerDetailSheet.tsx
+++ b/web/src/components/masters/CustomerDetailSheet.tsx
@@ -31,6 +31,7 @@ interface CustomerDetailSheetProps {
   onClose: () => void;
   onEdit: () => void;
   helpers: Map<string, Helper>;
+  customers: Map<string, Customer>;
 }
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
@@ -56,6 +57,7 @@ export function CustomerDetailSheet({
   onClose,
   onEdit,
   helpers,
+  customers,
 }: CustomerDetailSheetProps) {
   const { serviceTypes } = useServiceTypes();
 
@@ -132,10 +134,38 @@ export function CustomerDetailSheet({
                 value={GENDER_REQUIREMENT_LABELS[customer.gender_requirement ?? 'any'] ?? '指定なし'}
               />
               {customer.same_household_customer_ids?.length > 0 && (
-                <InfoRow label="同一世帯" value={customer.same_household_customer_ids.join(', ')} />
+                <InfoRow
+                  label="同一世帯"
+                  value={
+                    <div className="flex flex-wrap gap-1.5">
+                      {customer.same_household_customer_ids.map((id) => {
+                        const c = customers.get(id);
+                        return (
+                          <Badge key={id} variant="outline">
+                            {c ? `${c.name.family} ${c.name.given}` : id}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  }
+                />
               )}
               {customer.same_facility_customer_ids?.length > 0 && (
-                <InfoRow label="同一施設" value={customer.same_facility_customer_ids.join(', ')} />
+                <InfoRow
+                  label="同一施設"
+                  value={
+                    <div className="flex flex-wrap gap-1.5">
+                      {customer.same_facility_customer_ids.map((id) => {
+                        const c = customers.get(id);
+                        return (
+                          <Badge key={id} variant="outline">
+                            {c ? `${c.name.family} ${c.name.given}` : id}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  }
+                />
               )}
             </div>
           </section>

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -69,6 +69,7 @@ const defaultProps = {
   onClose: vi.fn(),
   onEdit: vi.fn(),
   helpers: new Map<string, Helper>(),
+  customers: new Map<string, Customer>(),
 };
 
 describe('CustomerDetailSheet', () => {
@@ -144,14 +145,24 @@ describe('CustomerDetailSheet', () => {
     expect(screen.getByTestId('allowed-staff-preferred-h-3')).toBeInTheDocument();
   });
 
-  it('同一世帯メンバーが設定されている場合にIDが表示される', () => {
+  it('同一世帯メンバーが設定されている場合にBadgeで表示される（IDフォールバック）', () => {
     const customer = makeCustomer({ same_household_customer_ids: ['C002', 'C003'] });
     render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
     expect(screen.getByText('同一世帯')).toBeInTheDocument();
-    expect(screen.getByText('C002, C003')).toBeInTheDocument();
+    // customers Map に該当がないのでIDがそのまま表示される
+    expect(screen.getByText('C002')).toBeInTheDocument();
+    expect(screen.getByText('C003')).toBeInTheDocument();
   });
 
-  it('同一施設メンバーが設定されている場合にIDが表示される', () => {
+  it('同一世帯メンバーのcustomers Map該当時に名前で表示される', () => {
+    const c2 = makeCustomer({ id: 'C002', name: { family: '佐藤', given: '次郎' } });
+    const customersMap = new Map([['C002', c2]]);
+    const customer = makeCustomer({ same_household_customer_ids: ['C002'] });
+    render(<CustomerDetailSheet {...defaultProps} customer={customer} customers={customersMap} />);
+    expect(screen.getByText('佐藤 次郎')).toBeInTheDocument();
+  });
+
+  it('同一施設メンバーが設定されている場合にBadgeで表示される', () => {
     const customer = makeCustomer({ same_facility_customer_ids: ['C010'] });
     render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
     expect(screen.getByText('同一施設')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- CustomerDetailSheet の同一世帯・同一施設セクションを、カンマ区切りIDからBadge+利用者名表示に変更
- `customers` Map を参照して名前解決、該当なしの場合はIDにフォールバック
- 利用者マスタ・基本予定一覧の両画面で `customers` prop を追加

## Test plan

- [x] Vitest 23テスト全パス（名前解決ケース追加済み）
- [ ] CI全テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)