### PR TITLE
fix: 同一世帯・施設の自己参照フィルタを正しく条件判定

### DIFF
--- a/web/src/components/masters/CustomerDetailSheet.tsx
+++ b/web/src/components/masters/CustomerDetailSheet.tsx
@@ -74,6 +74,9 @@ export function CustomerDetailSheet({
     .filter(Boolean) as Helper[];
   const preferredSet = new Set(customer.preferred_staff_ids);
 
+  const householdIds = (customer.same_household_customer_ids ?? []).filter((id) => id !== customer.id);
+  const facilityIds = (customer.same_facility_customer_ids ?? []).filter((id) => id !== customer.id);
+
   const hasContact =
     customer.home_care_office ||
     customer.care_manager_name ||
@@ -133,14 +136,12 @@ export function CustomerDetailSheet({
                 label="性別要件"
                 value={GENDER_REQUIREMENT_LABELS[customer.gender_requirement ?? 'any'] ?? '指定なし'}
               />
-              {customer.same_household_customer_ids?.length > 0 && (
+              {householdIds.length > 0 && (
                 <InfoRow
                   label="同一世帯"
                   value={
                     <div className="flex flex-wrap gap-1.5">
-                      {customer.same_household_customer_ids
-                        .filter((id) => id !== customer.id)
-                        .map((id) => {
+                      {householdIds.map((id) => {
                         const c = customers.get(id);
                         return (
                           <Badge key={id} variant="outline">
@@ -152,14 +153,12 @@ export function CustomerDetailSheet({
                   }
                 />
               )}
-              {customer.same_facility_customer_ids?.length > 0 && (
+              {facilityIds.length > 0 && (
                 <InfoRow
                   label="同一施設"
                   value={
                     <div className="flex flex-wrap gap-1.5">
-                      {customer.same_facility_customer_ids
-                        .filter((id) => id !== customer.id)
-                        .map((id) => {
+                      {facilityIds.map((id) => {
                         const c = customers.get(id);
                         return (
                           <Badge key={id} variant="outline">

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -177,14 +177,34 @@ describe('CustomerDetailSheet', () => {
     expect(screen.getByText('中村 五郎')).toBeInTheDocument();
   });
 
-  it('同一世帯・同一施設に自己IDが含まれる場合はフィルタされる', () => {
+  it('同一世帯に自己IDが含まれる場合はフィルタされる', () => {
     const self = makeCustomer({ id: 'cust-1', same_household_customer_ids: ['cust-1', 'C002'] });
     render(<CustomerDetailSheet {...defaultProps} customer={self} />);
     expect(screen.getByText('同一世帯')).toBeInTheDocument();
     expect(screen.getByText('C002')).toBeInTheDocument();
-    // 自分自身のIDはBadgeに表示されない
     const badges = screen.getByText('C002').parentElement;
     expect(badges?.textContent).not.toContain('cust-1');
+  });
+
+  it('同一施設に自己IDが含まれる場合はフィルタされる', () => {
+    const self = makeCustomer({ id: 'cust-1', same_facility_customer_ids: ['cust-1', 'C010'] });
+    render(<CustomerDetailSheet {...defaultProps} customer={self} />);
+    expect(screen.getByText('同一施設')).toBeInTheDocument();
+    expect(screen.getByText('C010')).toBeInTheDocument();
+    const badges = screen.getByText('C010').parentElement;
+    expect(badges?.textContent).not.toContain('cust-1');
+  });
+
+  it('同一世帯が自己IDのみの場合はセクション非表示', () => {
+    const self = makeCustomer({ id: 'cust-1', same_household_customer_ids: ['cust-1'] });
+    render(<CustomerDetailSheet {...defaultProps} customer={self} />);
+    expect(screen.queryByText('同一世帯')).not.toBeInTheDocument();
+  });
+
+  it('同一施設が自己IDのみの場合はセクション非表示', () => {
+    const self = makeCustomer({ id: 'cust-1', same_facility_customer_ids: ['cust-1'] });
+    render(<CustomerDetailSheet {...defaultProps} customer={self} />);
+    expect(screen.queryByText('同一施設')).not.toBeInTheDocument();
   });
 
   it('同一世帯・同一施設が空のとき表示されない', () => {


### PR DESCRIPTION
## Summary

- 自己参照ID（`customer.id`）をフィルタした**後の**配列長でセクション表示を判定
- `householdIds` / `facilityIds` 変数に切り出してフィルタ前の配列で判定するバグを修正
- 自己IDのみの場合に空セクションが表示される問題を解消

## Test plan

- [x] Vitest 28テスト全パス（+3件追加: 施設自己参照、世帯自己IDのみ非表示、施設自己IDのみ非表示）
- [x] 全テストスイート 547テスト全パス
- [ ] CI全テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)