### PR TITLE
fix: CustomerDetailSheetの編集ボタンを権限に応じて非表示にする

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -326,6 +326,7 @@ export default function CustomersPage() {
         open={detailOpen}
         onClose={() => setDetailOpen(false)}
         onEdit={handleDetailEdit}
+        canEdit={canEditCustomers}
         helpers={helpers}
         customers={customers}
       />

--- a/web/src/app/masters/weekly-schedule/page.tsx
+++ b/web/src/app/masters/weekly-schedule/page.tsx
@@ -215,6 +215,7 @@ export default function WeeklySchedulePage() {
         open={detailOpen}
         onClose={() => setDetailOpen(false)}
         onEdit={handleDetailEdit}
+        canEdit={canEditCustomers}
         helpers={helpers}
         customers={customers}
       />

--- a/web/src/components/masters/CustomerDetailSheet.tsx
+++ b/web/src/components/masters/CustomerDetailSheet.tsx
@@ -30,6 +30,7 @@ interface CustomerDetailSheetProps {
   open: boolean;
   onClose: () => void;
   onEdit: () => void;
+  canEdit?: boolean;
   helpers: Map<string, Helper>;
   customers: Map<string, Customer>;
 }
@@ -56,6 +57,7 @@ export function CustomerDetailSheet({
   open,
   onClose,
   onEdit,
+  canEdit = true,
   helpers,
   customers,
 }: CustomerDetailSheetProps) {
@@ -100,16 +102,18 @@ export function CustomerDetailSheet({
                 <p className="text-sm text-muted-foreground">{fullKana}</p>
               )}
             </div>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={onEdit}
-              data-testid="customer-detail-edit-button"
-              className="shrink-0"
-            >
-              <Pencil className="mr-1 h-3.5 w-3.5" />
-              編集
-            </Button>
+            {canEdit && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onEdit}
+                data-testid="customer-detail-edit-button"
+                className="shrink-0"
+              >
+                <Pencil className="mr-1 h-3.5 w-3.5" />
+                編集
+              </Button>
+            )}
           </div>
         </SheetHeader>
 

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -267,6 +267,21 @@ describe('CustomerDetailSheet', () => {
     expect(onEdit).toHaveBeenCalledOnce();
   });
 
+  it('canEdit=false のとき編集ボタンが表示されない', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} canEdit={false} />);
+    expect(screen.queryByTestId('customer-detail-edit-button')).not.toBeInTheDocument();
+  });
+
+  it('canEdit=true のとき編集ボタンが表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} canEdit={true} />);
+    expect(screen.getByTestId('customer-detail-edit-button')).toBeInTheDocument();
+  });
+
+  it('canEdit 未指定（デフォルト）のとき編集ボタンが表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    expect(screen.getByTestId('customer-detail-edit-button')).toBeInTheDocument();
+  });
+
   it('不定期パターンが設定されている場合に表示される', () => {
     const customer = makeCustomer({
       irregular_patterns: [{ type: 'biweekly', description: '第1・3週のみ' }],


### PR DESCRIPTION
## Summary

- `CustomerDetailSheet`に`canEdit`propを追加し、`false`の場合は編集ボタンを非表示
- `customers/page.tsx`と`weekly-schedule/page.tsx`で`canEditCustomers`を渡すように変更
- 閲覧専用ユーザーに編集ボタンが表示されていたセキュリティバグを修正

Closes #178

## Test plan

- [x] `canEdit=false`で編集ボタン非表示を確認するテスト追加
- [x] `canEdit=true`で編集ボタン表示を確認するテスト追加
- [x] `canEdit`未指定（デフォルト`true`）で後方互換性を確認するテスト追加
- [x] 全550テストパス
- [x] tsc --noEmit: 今回の変更による新規エラー 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)