### PR TITLE
fix: canEdit propを必須化してfail-closed設計に変更

### DIFF
--- a/web/src/components/masters/CustomerDetailSheet.tsx
+++ b/web/src/components/masters/CustomerDetailSheet.tsx
@@ -30,7 +30,7 @@ interface CustomerDetailSheetProps {
   open: boolean;
   onClose: () => void;
   onEdit: () => void;
-  canEdit?: boolean;
+  canEdit: boolean;
   helpers: Map<string, Helper>;
   customers: Map<string, Customer>;
 }
@@ -57,7 +57,7 @@ export function CustomerDetailSheet({
   open,
   onClose,
   onEdit,
-  canEdit = true,
+  canEdit,
   helpers,
   customers,
 }: CustomerDetailSheetProps) {

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -68,6 +68,7 @@ const defaultProps = {
   open: true,
   onClose: vi.fn(),
   onEdit: vi.fn(),
+  canEdit: true,
   helpers: new Map<string, Helper>(),
   customers: new Map<string, Customer>(),
 };
@@ -274,11 +275,6 @@ describe('CustomerDetailSheet', () => {
 
   it('canEdit=true のとき編集ボタンが表示される', () => {
     render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} canEdit={true} />);
-    expect(screen.getByTestId('customer-detail-edit-button')).toBeInTheDocument();
-  });
-
-  it('canEdit 未指定（デフォルト）のとき編集ボタンが表示される', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
     expect(screen.getByTestId('customer-detail-edit-button')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- `CustomerDetailSheet`の`canEdit`propを`optional (default true)`から`required`に変更
- 権限系propはfail-closed（デフォルト拒否）であるべき — Codexレビュー High指摘対応
- 呼び出し元2箇所は既に明示的に`canEdit={canEditCustomers}`を渡しているため影響なし

## Test plan

- [x] `canEdit=false`/`canEdit=true`テスト維持（30テスト全パス）
- [x] 全549テストパス
- [x] tsc: 今回の変更ファイルにエラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)