### PR TITLE
fix: HelperDetailSheetの編集ボタンを権限に応じて非表示にする

### DIFF
--- a/web/src/app/masters/helpers/page.tsx
+++ b/web/src/app/masters/helpers/page.tsx
@@ -197,6 +197,7 @@ export default function HelpersPage() {
         open={detailOpen}
         onClose={() => setDetailOpen(false)}
         onEdit={handleDetailEdit}
+        canEdit={canEditHelpers}
         customers={customers}
       />
 

--- a/web/src/components/masters/HelperDetailSheet.tsx
+++ b/web/src/components/masters/HelperDetailSheet.tsx
@@ -45,6 +45,7 @@ interface HelperDetailSheetProps {
   open: boolean;
   onClose: () => void;
   onEdit: () => void;
+  canEdit: boolean;
   customers: Map<string, Customer>;
 }
 
@@ -70,6 +71,7 @@ export function HelperDetailSheet({
   open,
   onClose,
   onEdit,
+  canEdit,
   customers,
 }: HelperDetailSheetProps) {
   if (!helper) return null;
@@ -90,16 +92,18 @@ export function HelperDetailSheet({
         <SheetHeader className="sticky top-0 bg-background z-10 border-b">
           <div className="flex items-start justify-between gap-2">
             <SheetTitle className="text-lg">{fullName}</SheetTitle>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={onEdit}
-              data-testid="helper-detail-edit-button"
-              className="shrink-0"
-            >
-              <Pencil className="mr-1 h-3.5 w-3.5" />
-              編集
-            </Button>
+            {canEdit && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onEdit}
+                data-testid="helper-detail-edit-button"
+                className="shrink-0"
+              >
+                <Pencil className="mr-1 h-3.5 w-3.5" />
+                編集
+              </Button>
+            )}
           </div>
         </SheetHeader>
 

--- a/web/src/components/masters/__tests__/HelperDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/HelperDetailSheet.test.tsx
@@ -55,6 +55,7 @@ const defaultProps = {
   open: true,
   onClose: vi.fn(),
   onEdit: vi.fn(),
+  canEdit: true,
   customers: new Map<string, Customer>(),
 };
 
@@ -152,6 +153,16 @@ describe('HelperDetailSheet', () => {
     render(<HelperDetailSheet {...defaultProps} helper={makeHelper()} onEdit={onEdit} />);
     fireEvent.click(screen.getByTestId('helper-detail-edit-button'));
     expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it('canEdit=false のとき編集ボタンが表示されない', () => {
+    render(<HelperDetailSheet {...defaultProps} helper={makeHelper()} canEdit={false} />);
+    expect(screen.queryByTestId('helper-detail-edit-button')).not.toBeInTheDocument();
+  });
+
+  it('canEdit=true のとき編集ボタンが表示される', () => {
+    render(<HelperDetailSheet {...defaultProps} helper={makeHelper()} canEdit={true} />);
+    expect(screen.getByTestId('helper-detail-edit-button')).toBeInTheDocument();
   });
 
   it('短縮名がある場合に表示される', () => {


### PR DESCRIPTION
## Summary

- `HelperDetailSheet`に`canEdit: boolean`propを追加（必須、fail-closed設計）
- `helpers/page.tsx`で`canEditHelpers`を渡す
- PR #180（CustomerDetailSheet）と同じ権限チェック漏れの横展開修正

## Test plan

- [x] `canEdit=false`で編集ボタン非表示テスト追加
- [x] `canEdit=true`で編集ボタン表示テスト追加
- [x] 全551テストパス
- [x] tsc: 変更ファイルにエラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)