### PR TITLE
refactor: detailTarget stale data を ID ベース参照に修正

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -51,9 +51,9 @@ export default function CustomersPage() {
   const [editTarget, setEditTarget] = useState<Customer | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [detailId, setDetailId] = useState<string | null>(null);
-  const [detailOpen, setDetailOpen] = useState(false);
 
   const detailCustomer = detailId ? customers.get(detailId) ?? null : null;
+  const detailOpen = detailId !== null;
 
   const filtered = useMemo(() => {
     const list = Array.from(customers.values());
@@ -114,11 +114,10 @@ export default function CustomersPage() {
 
   const openDetail = (customer: Customer) => {
     setDetailId(customer.id);
-    setDetailOpen(true);
   };
 
   const handleDetailEdit = () => {
-    setDetailOpen(false);
+    setDetailId(null);
     if (detailCustomer) openEdit(detailCustomer);
   };
 
@@ -326,7 +325,7 @@ export default function CustomersPage() {
       <CustomerDetailSheet
         customer={detailCustomer}
         open={detailOpen}
-        onClose={() => setDetailOpen(false)}
+        onClose={() => setDetailId(null)}
         onEdit={handleDetailEdit}
         canEdit={canEditCustomers}
         helpers={helpers}

--- a/web/src/app/masters/helpers/page.tsx
+++ b/web/src/app/masters/helpers/page.tsx
@@ -38,9 +38,9 @@ export default function HelpersPage() {
   const [editTarget, setEditTarget] = useState<Helper | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [detailId, setDetailId] = useState<string | null>(null);
-  const [detailOpen, setDetailOpen] = useState(false);
 
   const detailHelper = detailId ? helpers.get(detailId) ?? null : null;
+  const detailOpen = detailId !== null;
 
   const filtered = useMemo(() => {
     const list = Array.from(helpers.values());
@@ -66,11 +66,10 @@ export default function HelpersPage() {
 
   const openDetail = (helper: Helper) => {
     setDetailId(helper.id);
-    setDetailOpen(true);
   };
 
   const handleDetailEdit = () => {
-    setDetailOpen(false);
+    setDetailId(null);
     if (detailHelper) openEdit(detailHelper);
   };
 
@@ -197,7 +196,7 @@ export default function HelpersPage() {
       <HelperDetailSheet
         helper={detailHelper}
         open={detailOpen}
-        onClose={() => setDetailOpen(false)}
+        onClose={() => setDetailId(null)}
         onEdit={handleDetailEdit}
         canEdit={canEditHelpers}
         customers={customers}

--- a/web/src/app/masters/weekly-schedule/__tests__/page.test.tsx
+++ b/web/src/app/masters/weekly-schedule/__tests__/page.test.tsx
@@ -64,10 +64,10 @@ vi.mock('@/components/ui/sheet', () => ({
   SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
 }));
 
-// CustomerDetailSheet / CustomerEditDialog は今回テスト対象外
+// CustomerDetailSheet / CustomerEditDialog はシンプルモックで表示テスト
 vi.mock('@/components/masters/CustomerDetailSheet', () => ({
-  CustomerDetailSheet: ({ open, customer }: { open: boolean; customer: unknown }) =>
-    open ? <div data-testid="detail-sheet">{customer ? 'detail' : ''}</div> : null,
+  CustomerDetailSheet: ({ open, customer }: { open: boolean; customer: Customer | null }) =>
+    open ? <div data-testid="detail-sheet">{customer ? `detail:${customer.name.family}` : 'no-customer'}</div> : null,
 }));
 
 vi.mock('@/components/masters/CustomerEditDialog', () => ({
@@ -218,6 +218,39 @@ describe('基本予定一覧ページ', () => {
     render(<WeeklySchedulePage />);
 
     expect(screen.getByText('unknown_type')).toBeInTheDocument();
+  });
+
+  it('詳細表示中にデータ更新されると最新値が反映される', () => {
+    mockCustomers.set('c1', makeCustomer('c1', '山田', '太郎'));
+
+    const { rerender } = render(<WeeklySchedulePage />);
+
+    // 行クリックで詳細を開く
+    fireEvent.click(screen.getByText('山田 太郎'));
+    expect(screen.getByText('detail:山田')).toBeInTheDocument();
+
+    // backing Map を更新（Firestoreリアルタイム更新を模擬）
+    mockCustomers.set('c1', makeCustomer('c1', '鈴木', '太郎'));
+    rerender(<WeeklySchedulePage />);
+
+    // 最新の名前が反映される
+    expect(screen.getByText('detail:鈴木')).toBeInTheDocument();
+  });
+
+  it('選択中のレコードがMapから消えたらdetailにno-customerが表示される', () => {
+    mockCustomers.set('c1', makeCustomer('c1', '山田', '太郎'));
+
+    const { rerender } = render(<WeeklySchedulePage />);
+
+    fireEvent.click(screen.getByText('山田 太郎'));
+    expect(screen.getByText('detail:山田')).toBeInTheDocument();
+
+    // レコードが削除される
+    mockCustomers.delete('c1');
+    rerender(<WeeklySchedulePage />);
+
+    // customer=null でも detailId が残っているため open=true, customer=null
+    expect(screen.getByText('no-customer')).toBeInTheDocument();
   });
 
   it('staff_count > 1 のとき人数バッジが表示される', () => {

--- a/web/src/app/masters/weekly-schedule/page.tsx
+++ b/web/src/app/masters/weekly-schedule/page.tsx
@@ -62,19 +62,18 @@ export default function WeeklySchedulePage() {
   const { canEditCustomers } = useAuthRole();
   const [search, setSearch] = useState('');
   const [detailId, setDetailId] = useState<string | null>(null);
-  const [detailOpen, setDetailOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<Customer | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const detailCustomer = detailId ? customers.get(detailId) ?? null : null;
+  const detailOpen = detailId !== null;
 
   const openDetail = (customer: Customer) => {
     setDetailId(customer.id);
-    setDetailOpen(true);
   };
 
   const handleDetailEdit = () => {
-    setDetailOpen(false);
+    setDetailId(null);
     if (detailCustomer) {
       setEditTarget(detailCustomer);
       setDialogOpen(true);
@@ -206,7 +205,7 @@ export default function WeeklySchedulePage() {
       <CustomerDetailSheet
         customer={detailCustomer}
         open={detailOpen}
-        onClose={() => setDetailOpen(false)}
+        onClose={() => setDetailId(null)}
         onEdit={handleDetailEdit}
         canEdit={canEditCustomers}
         helpers={helpers}


### PR DESCRIPTION
## Summary

- `detailTarget` に Customer/Helper オブジェクト丸ごと保持 → `detailId: string | null` + `Map.get()` に変更
- Firestore リアルタイム更新や編集後の反映が即座に DetailSheet に反映されるようになる
- 横展開: Issue #183 記載の customers/weekly-schedule に加え、helpers/page.tsx も同パターンを修正

## 変更ファイル

- `web/src/app/masters/customers/page.tsx`: `detailTarget` → `detailId` + `detailCustomer` 導出
- `web/src/app/masters/weekly-schedule/page.tsx`: 同上
- `web/src/app/masters/helpers/page.tsx`: `detailTarget` → `detailId` + `detailHelper` 導出

## Test plan

- [x] weekly-schedule テスト全10件パス
- [x] tsc --noEmit: 本番コードに新規エラー0件
- [x] 全3ファイルの detailTarget 参照が ID ベースに統一済み

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)