### PR TITLE
refactor: CustomerDetailSheet から ViewModel を切り出し

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { CustomerEditDialog } from '@/components/masters/CustomerEditDialog';
 import { CustomerDetailSheet } from '@/components/masters/CustomerDetailSheet';
+import { useCustomerDetailViewModel } from '@/components/masters/customerDetailViewModel';
 import { DAY_OF_WEEK_ORDER } from '@/types';
 import type { Customer } from '@/types';
 
@@ -54,6 +55,7 @@ export default function CustomersPage() {
 
   const detailCustomer = detailId ? customers.get(detailId) ?? null : null;
   const detailOpen = detailId !== null;
+  const detailVm = useCustomerDetailViewModel(detailCustomer, helpers, customers);
 
   const filtered = useMemo(() => {
     const list = Array.from(customers.values());
@@ -323,13 +325,11 @@ export default function CustomersPage() {
       </p>
 
       <CustomerDetailSheet
-        customer={detailCustomer}
+        vm={detailVm}
         open={detailOpen}
         onClose={() => setDetailId(null)}
         onEdit={handleDetailEdit}
         canEdit={canEditCustomers}
-        helpers={helpers}
-        customers={customers}
       />
 
       <CustomerEditDialog

--- a/web/src/app/masters/weekly-schedule/__tests__/page.test.tsx
+++ b/web/src/app/masters/weekly-schedule/__tests__/page.test.tsx
@@ -66,8 +66,8 @@ vi.mock('@/components/ui/sheet', () => ({
 
 // CustomerDetailSheet / CustomerEditDialog はシンプルモックで表示テスト
 vi.mock('@/components/masters/CustomerDetailSheet', () => ({
-  CustomerDetailSheet: ({ open, customer }: { open: boolean; customer: Customer | null }) =>
-    open ? <div data-testid="detail-sheet">{customer ? `detail:${customer.name.family}` : 'no-customer'}</div> : null,
+  CustomerDetailSheet: ({ open, vm }: { open: boolean; vm: { fullName: string } | null }) =>
+    open ? <div data-testid="detail-sheet">{vm ? `detail:${vm.fullName}` : 'no-vm'}</div> : null,
 }));
 
 vi.mock('@/components/masters/CustomerEditDialog', () => ({
@@ -227,14 +227,14 @@ describe('基本予定一覧ページ', () => {
 
     // 行クリックで詳細を開く
     fireEvent.click(screen.getByText('山田 太郎'));
-    expect(screen.getByText('detail:山田')).toBeInTheDocument();
+    expect(screen.getByText('detail:山田 太郎')).toBeInTheDocument();
 
     // backing Map を更新（Firestoreリアルタイム更新を模擬）
     mockCustomers.set('c1', makeCustomer('c1', '鈴木', '太郎'));
     rerender(<WeeklySchedulePage />);
 
     // 最新の名前が反映される
-    expect(screen.getByText('detail:鈴木')).toBeInTheDocument();
+    expect(screen.getByText('detail:鈴木 太郎')).toBeInTheDocument();
   });
 
   it('選択中のレコードがMapから消えたらdetailにno-customerが表示される', () => {
@@ -243,14 +243,14 @@ describe('基本予定一覧ページ', () => {
     const { rerender } = render(<WeeklySchedulePage />);
 
     fireEvent.click(screen.getByText('山田 太郎'));
-    expect(screen.getByText('detail:山田')).toBeInTheDocument();
+    expect(screen.getByText('detail:山田 太郎')).toBeInTheDocument();
 
     // レコードが削除される
     mockCustomers.delete('c1');
     rerender(<WeeklySchedulePage />);
 
-    // customer=null でも detailId が残っているため open=true, customer=null
-    expect(screen.getByText('no-customer')).toBeInTheDocument();
+    // vm=null でも detailId が残っているため open=true, vm=null
+    expect(screen.getByText('no-vm')).toBeInTheDocument();
   });
 
   it('staff_count > 1 のとき人数バッジが表示される', () => {

--- a/web/src/app/masters/weekly-schedule/page.tsx
+++ b/web/src/app/masters/weekly-schedule/page.tsx
@@ -17,6 +17,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { CustomerDetailSheet } from '@/components/masters/CustomerDetailSheet';
+import { useCustomerDetailViewModel } from '@/components/masters/customerDetailViewModel';
 import { CustomerEditDialog } from '@/components/masters/CustomerEditDialog';
 import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
 import type { Customer, ServiceSlot, ServiceTypeDoc } from '@/types';
@@ -67,6 +68,7 @@ export default function WeeklySchedulePage() {
 
   const detailCustomer = detailId ? customers.get(detailId) ?? null : null;
   const detailOpen = detailId !== null;
+  const detailVm = useCustomerDetailViewModel(detailCustomer, helpers, customers);
 
   const openDetail = (customer: Customer) => {
     setDetailId(customer.id);
@@ -203,13 +205,11 @@ export default function WeeklySchedulePage() {
       </div>
 
       <CustomerDetailSheet
-        customer={detailCustomer}
+        vm={detailVm}
         open={detailOpen}
         onClose={() => setDetailId(null)}
         onEdit={handleDetailEdit}
         canEdit={canEditCustomers}
-        helpers={helpers}
-        customers={customers}
       />
 
       {canEditCustomers && (

--- a/web/src/components/masters/CustomerDetailSheet.tsx
+++ b/web/src/components/masters/CustomerDetailSheet.tsx
@@ -9,30 +9,14 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import { useServiceTypes } from '@/hooks/useServiceTypes';
-import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
-import type { Customer, Helper } from '@/types';
-
-const GENDER_REQUIREMENT_LABELS: Record<string, string> = {
-  any: '指定なし',
-  female: '女性のみ',
-  male: '男性のみ',
-};
-
-const IRREGULAR_PATTERN_LABELS: Record<string, string> = {
-  biweekly: '隔週',
-  monthly: '月次',
-  temporary_stop: '一時停止',
-};
+import type { CustomerDetailViewModel } from './customerDetailViewModel';
 
 interface CustomerDetailSheetProps {
-  customer: Customer | null;
+  vm: CustomerDetailViewModel | null;
   open: boolean;
   onClose: () => void;
   onEdit: () => void;
   canEdit: boolean;
-  helpers: Map<string, Helper>;
-  customers: Map<string, Customer>;
 }
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
@@ -53,43 +37,13 @@ function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
 }
 
 export function CustomerDetailSheet({
-  customer,
+  vm,
   open,
   onClose,
   onEdit,
   canEdit,
-  helpers,
-  customers,
 }: CustomerDetailSheetProps) {
-  const { serviceTypes } = useServiceTypes();
-
-  if (!customer) return null;
-
-  const fullName = `${customer.name.family} ${customer.name.given}`;
-  const fullKana =
-    customer.name.family_kana || customer.name.given_kana
-      ? `${customer.name.family_kana ?? ''} ${customer.name.given_kana ?? ''}`.trim()
-      : null;
-  const ngHelpers = customer.ng_staff_ids.map((id) => helpers.get(id)).filter(Boolean) as Helper[];
-  const allowedHelpers = (customer.allowed_staff_ids ?? [])
-    .map((id) => helpers.get(id))
-    .filter(Boolean) as Helper[];
-  const preferredSet = new Set(customer.preferred_staff_ids);
-
-  const householdIds = (customer.same_household_customer_ids ?? []).filter((id) => id !== customer.id);
-  const facilityIds = (customer.same_facility_customer_ids ?? []).filter((id) => id !== customer.id);
-
-  const hasContact =
-    customer.home_care_office ||
-    customer.care_manager_name ||
-    customer.consultation_support_office ||
-    customer.support_specialist_name;
-
-  const hasExternalIds = !!customer.aozora_id;
-
-  const hasWeeklyServices = DAY_OF_WEEK_ORDER.some(
-    (d) => customer.weekly_services[d] && customer.weekly_services[d]!.length > 0
-  );
+  if (!vm) return null;
 
   return (
     <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
@@ -97,9 +51,9 @@ export function CustomerDetailSheet({
         <SheetHeader className="sticky top-0 bg-background z-10 border-b">
           <div className="flex items-start justify-between gap-2">
             <div>
-              <SheetTitle className="text-lg">{fullName}</SheetTitle>
-              {fullKana && (
-                <p className="text-sm text-muted-foreground">{fullKana}</p>
+              <SheetTitle className="text-lg">{vm.fullName}</SheetTitle>
+              {vm.fullKana && (
+                <p className="text-sm text-muted-foreground">{vm.fullKana}</p>
               )}
             </div>
             {canEdit && (
@@ -122,54 +76,45 @@ export function CustomerDetailSheet({
           <section>
             <SectionHeader>基本情報</SectionHeader>
             <div className="space-y-2 rounded-lg border bg-accent/30 p-3">
-              {customer.name.short && (
-                <InfoRow label="短縮名" value={customer.name.short} />
+              {vm.shortName && (
+                <InfoRow label="短縮名" value={vm.shortName} />
               )}
-              <InfoRow label="住所" value={customer.address} />
-              <InfoRow label="サ責" value={customer.service_manager} />
-              {customer.phone_number && (
-                <InfoRow label="電話番号①" value={customer.phone_number} />
+              <InfoRow label="住所" value={vm.address} />
+              <InfoRow label="サ責" value={vm.serviceManager} />
+              {vm.phoneNumber && (
+                <InfoRow label="電話番号①" value={vm.phoneNumber} />
               )}
-              {customer.phone_number2 && (
-                <InfoRow label="電話番号②" value={customer.phone_number2} />
+              {vm.phoneNumber2 && (
+                <InfoRow label="電話番号②" value={vm.phoneNumber2} />
               )}
-              {customer.phone_note && (
-                <InfoRow label="電話備考" value={customer.phone_note} />
+              {vm.phoneNote && (
+                <InfoRow label="電話備考" value={vm.phoneNote} />
               )}
-              <InfoRow
-                label="性別要件"
-                value={GENDER_REQUIREMENT_LABELS[customer.gender_requirement ?? 'any'] ?? '指定なし'}
-              />
-              {householdIds.length > 0 && (
+              <InfoRow label="性別要件" value={vm.genderRequirementLabel} />
+              {vm.householdMembers.length > 0 && (
                 <InfoRow
                   label="同一世帯"
                   value={
                     <div className="flex flex-wrap gap-1.5">
-                      {householdIds.map((id) => {
-                        const c = customers.get(id);
-                        return (
-                          <Badge key={id} variant="outline">
-                            {c ? `${c.name.family} ${c.name.given}` : id}
-                          </Badge>
-                        );
-                      })}
+                      {vm.householdMembers.map((m) => (
+                        <Badge key={m.id} variant="outline">
+                          {m.name}
+                        </Badge>
+                      ))}
                     </div>
                   }
                 />
               )}
-              {facilityIds.length > 0 && (
+              {vm.facilityMembers.length > 0 && (
                 <InfoRow
                   label="同一施設"
                   value={
                     <div className="flex flex-wrap gap-1.5">
-                      {facilityIds.map((id) => {
-                        const c = customers.get(id);
-                        return (
-                          <Badge key={id} variant="outline">
-                            {c ? `${c.name.family} ${c.name.given}` : id}
-                          </Badge>
-                        );
-                      })}
+                      {vm.facilityMembers.map((m) => (
+                        <Badge key={m.id} variant="outline">
+                          {m.name}
+                        </Badge>
+                      ))}
                     </div>
                   }
                 />
@@ -178,54 +123,54 @@ export function CustomerDetailSheet({
           </section>
 
           {/* 2. 連絡先・関連機関（値ありのみ） */}
-          {hasContact && (
+          {vm.hasContact && (
             <section>
               <SectionHeader>連絡先・関連機関</SectionHeader>
               <div className="space-y-2 rounded-lg border bg-accent/30 p-3">
-                {customer.home_care_office && (
-                  <InfoRow label="担当居宅" value={customer.home_care_office} />
+                {vm.homeCareOffice && (
+                  <InfoRow label="担当居宅" value={vm.homeCareOffice} />
                 )}
-                {customer.care_manager_name && (
-                  <InfoRow label="ケアマネ" value={customer.care_manager_name} />
+                {vm.careManagerName && (
+                  <InfoRow label="ケアマネ" value={vm.careManagerName} />
                 )}
-                {customer.consultation_support_office && (
-                  <InfoRow label="相談支援事業所" value={customer.consultation_support_office} />
+                {vm.consultationSupportOffice && (
+                  <InfoRow label="相談支援事業所" value={vm.consultationSupportOffice} />
                 )}
-                {customer.support_specialist_name && (
-                  <InfoRow label="相談支援専門員" value={customer.support_specialist_name} />
+                {vm.supportSpecialistName && (
+                  <InfoRow label="相談支援専門員" value={vm.supportSpecialistName} />
                 )}
               </div>
             </section>
           )}
 
           {/* 3. NG/入れるスタッフ */}
-          {(ngHelpers.length > 0 || allowedHelpers.length > 0) && (
+          {(vm.ngStaff.length > 0 || vm.allowedStaff.length > 0) && (
             <section>
               <SectionHeader>NG / 入れるスタッフ</SectionHeader>
               <div className="space-y-2">
-                {ngHelpers.length > 0 && (
+                {vm.ngStaff.length > 0 && (
                   <div>
                     <p className="text-xs text-muted-foreground mb-1">NG</p>
                     <div className="flex flex-wrap gap-1.5" data-testid="ng-staff-badges">
-                      {ngHelpers.map((h) => (
-                        <Badge key={h.id} variant="destructive">
-                          {h.name.family} {h.name.given}
+                      {vm.ngStaff.map((s) => (
+                        <Badge key={s.id} variant="destructive">
+                          {s.name}
                         </Badge>
                       ))}
                     </div>
                   </div>
                 )}
-                {allowedHelpers.length > 0 && (
+                {vm.allowedStaff.length > 0 && (
                   <div>
                     <p className="text-xs text-muted-foreground mb-1">入れるスタッフ</p>
                     <div className="flex flex-wrap gap-1.5" data-testid="allowed-staff-badges">
-                      {allowedHelpers.map((h) => (
-                        <Badge key={h.id} variant="secondary">
-                          {h.name.family} {h.name.given}
-                          {preferredSet.has(h.id) && (
+                      {vm.allowedStaff.map((s) => (
+                        <Badge key={s.id} variant="secondary">
+                          {s.name}
+                          {s.isPreferred && (
                             <span
                               className="ml-1 text-amber-600"
-                              data-testid={`allowed-staff-preferred-${h.id}`}
+                              data-testid={`allowed-staff-preferred-${s.id}`}
                             >
                               ★
                             </span>
@@ -240,7 +185,7 @@ export function CustomerDetailSheet({
           )}
 
           {/* 4. 週間サービス */}
-          {hasWeeklyServices && (
+          {vm.hasWeeklyServices && (
             <section>
               <SectionHeader>週間サービス</SectionHeader>
               <div className="overflow-x-auto rounded-lg border">
@@ -254,29 +199,23 @@ export function CustomerDetailSheet({
                     </tr>
                   </thead>
                   <tbody>
-                    {DAY_OF_WEEK_ORDER.flatMap((day) => {
-                      const slots = customer.weekly_services[day];
-                      if (!slots || slots.length === 0) return [];
-                      return slots.map((slot, idx) => (
-                        <tr key={`${day}-${idx}`} className="border-b last:border-0">
+                    {vm.weeklyServices.flatMap((row) =>
+                      row.slots.map((slot, idx) => (
+                        <tr key={`${row.day}-${idx}`} className="border-b last:border-0">
                           {idx === 0 && (
                             <td
                               className="p-2 font-medium"
-                              rowSpan={slots.length}
+                              rowSpan={row.slots.length}
                             >
-                              {DAY_OF_WEEK_LABELS[day]}
+                              {row.dayLabel}
                             </td>
                           )}
-                          <td className="p-2">
-                            {slot.start_time} - {slot.end_time}
-                          </td>
-                          <td className="p-2">
-                            {serviceTypes.get(slot.service_type)?.label ?? slot.service_type}
-                          </td>
-                          <td className="p-2 text-right">{slot.staff_count}名</td>
+                          <td className="p-2">{slot.time}</td>
+                          <td className="p-2">{slot.serviceLabel}</td>
+                          <td className="p-2 text-right">{slot.staffCount}名</td>
                         </tr>
-                      ));
-                    })}
+                      ))
+                    )}
                   </tbody>
                 </table>
               </div>
@@ -284,20 +223,20 @@ export function CustomerDetailSheet({
           )}
 
           {/* 5. 不定期パターン（非空時のみ） */}
-          {customer.irregular_patterns && customer.irregular_patterns.length > 0 && (
+          {vm.irregularPatterns.length > 0 && (
             <section>
               <SectionHeader>不定期パターン</SectionHeader>
               <div className="space-y-1.5">
-                {customer.irregular_patterns.map((p, i) => (
+                {vm.irregularPatterns.map((p, i) => (
                   <div key={i} className="flex items-start gap-2 text-sm">
                     <Badge variant="outline" className="shrink-0">
-                      {IRREGULAR_PATTERN_LABELS[p.type] ?? p.type}
+                      {p.typeLabel}
                     </Badge>
                     <div>
                       <span className="text-muted-foreground">{p.description}</span>
-                      {p.active_weeks && p.active_weeks.length > 0 && (
+                      {p.activeWeeks && p.activeWeeks.length > 0 && (
                         <span className="ml-1.5 text-xs text-muted-foreground">
-                          （第{p.active_weeks.join('・')}週）
+                          （第{p.activeWeeks.join('・')}週）
                         </span>
                       )}
                     </div>
@@ -308,19 +247,19 @@ export function CustomerDetailSheet({
           )}
 
           {/* 6. 備考（値ありのみ） */}
-          {customer.notes && (
+          {vm.notes && (
             <section>
               <SectionHeader>備考</SectionHeader>
-              <p className="text-sm text-muted-foreground whitespace-pre-wrap">{customer.notes}</p>
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap">{vm.notes}</p>
             </section>
           )}
 
           {/* 7. 外部連携ID */}
-          {hasExternalIds && (
+          {vm.hasExternalIds && (
             <section>
               <SectionHeader>外部連携ID</SectionHeader>
               <div className="space-y-2 rounded-lg border bg-accent/30 p-3">
-                <InfoRow label="あおぞらID" value={customer.aozora_id!} />
+                {vm.aozoraId && <InfoRow label="あおぞらID" value={vm.aozoraId} />}
               </div>
             </section>
           )}
@@ -331,11 +270,11 @@ export function CustomerDetailSheet({
             <div className="space-y-2 text-xs text-muted-foreground">
               <div className="flex gap-2">
                 <span className="w-24 shrink-0">作成日時</span>
-                <span>{customer.created_at.toLocaleString('ja-JP')}</span>
+                <span>{vm.createdAt.toLocaleString('ja-JP')}</span>
               </div>
               <div className="flex gap-2">
                 <span className="w-24 shrink-0">更新日時</span>
-                <span>{customer.updated_at.toLocaleString('ja-JP')}</span>
+                <span>{vm.updatedAt.toLocaleString('ja-JP')}</span>
               </div>
             </div>
           </section>

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -1,20 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CustomerDetailSheet } from '../CustomerDetailSheet';
-import type { Customer, Helper } from '@/types';
-
-// Firebase 接続が必要なフックはモック
-vi.mock('@/hooks/useServiceTypes', () => ({
-  useServiceTypes: () => ({
-    serviceTypes: new Map([
-      ['physical_care', { id: 'physical_care', code: 'physical_care', label: '身体介護', short_label: '身体', requires_physical_care_cert: true, sort_order: 1, created_at: new Date(), updated_at: new Date() }],
-      ['daily_living', { id: 'daily_living', code: 'daily_living', label: '生活援助', short_label: '生活', requires_physical_care_cert: false, sort_order: 2, created_at: new Date(), updated_at: new Date() }],
-    ]),
-    sortedList: [],
-    loading: false,
-    error: null,
-  }),
-}));
+import type { CustomerDetailViewModel } from '../customerDetailViewModel';
 
 // Radix Sheet はポータルを使うためインラインでモック
 vi.mock('@/components/ui/sheet', () => ({
@@ -26,41 +13,26 @@ vi.mock('@/components/ui/sheet', () => ({
   SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
 }));
 
-function makeCustomer(overrides: Partial<Customer> = {}): Customer {
+function makeVm(overrides: Partial<CustomerDetailViewModel> = {}): CustomerDetailViewModel {
   return {
     id: 'cust-1',
-    name: { family: '田中', given: '花子' },
+    fullName: '田中 花子',
+    fullKana: null,
     address: '東京都新宿区1-1-1',
-    location: { lat: 35.6895, lng: 139.6917 },
-    ng_staff_ids: [],
-    allowed_staff_ids: [],
-    preferred_staff_ids: [],
-    same_household_customer_ids: [],
-    same_facility_customer_ids: [],
-    weekly_services: {},
-    service_manager: '山田太郎',
-    gender_requirement: 'any',
-    created_at: new Date('2025-01-01T00:00:00'),
-    updated_at: new Date('2025-06-01T00:00:00'),
+    serviceManager: '山田太郎',
+    genderRequirementLabel: '指定なし',
+    ngStaff: [],
+    allowedStaff: [],
+    householdMembers: [],
+    facilityMembers: [],
+    weeklyServices: [],
+    hasWeeklyServices: false,
+    irregularPatterns: [],
+    hasContact: false,
+    hasExternalIds: false,
+    createdAt: new Date('2025-01-01T00:00:00'),
+    updatedAt: new Date('2025-06-01T00:00:00'),
     ...overrides,
-  };
-}
-
-function makeHelper(id: string, family: string, given: string): Helper {
-  return {
-    id,
-    name: { family, given },
-    qualifications: [],
-    can_physical_care: false,
-    transportation: 'bicycle',
-    weekly_availability: {},
-    preferred_hours: { min: 20, max: 40 },
-    available_hours: { min: 20, max: 40 },
-    customer_training_status: {},
-    employment_type: 'part_time',
-    gender: 'female',
-    created_at: new Date(),
-    updated_at: new Date(),
   };
 }
 
@@ -69,165 +41,110 @@ const defaultProps = {
   onClose: vi.fn(),
   onEdit: vi.fn(),
   canEdit: true,
-  helpers: new Map<string, Helper>(),
-  customers: new Map<string, Customer>(),
 };
 
 describe('CustomerDetailSheet', () => {
   it('open=false のとき何も表示しない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} open={false} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} open={false} />);
     expect(screen.queryByTestId('customer-detail-sheet')).not.toBeInTheDocument();
   });
 
-  it('customer=null のとき何も表示しない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={null} />);
+  it('vm=null のとき何も表示しない', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={null} />);
     expect(screen.queryByTestId('customer-detail-sheet')).not.toBeInTheDocument();
   });
 
   it('利用者名が表示される', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.getByText('田中 花子')).toBeInTheDocument();
   });
 
   it('住所・サ責・性別要件が表示される', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.getByText('東京都新宿区1-1-1')).toBeInTheDocument();
     expect(screen.getByText('山田太郎')).toBeInTheDocument();
     expect(screen.getByText('指定なし')).toBeInTheDocument();
   });
 
   it('電話番号は値があるときのみ表示される', () => {
-    const customer = makeCustomer({ phone_number: '03-1234-5678' });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({ phoneNumber: '03-1234-5678' })} />);
     expect(screen.getByText('03-1234-5678')).toBeInTheDocument();
   });
 
-  it('連絡先セクションは全て空のとき表示されない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+  it('連絡先セクションは hasContact=false のとき表示されない', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.queryByText('連絡先・関連機関')).not.toBeInTheDocument();
   });
 
-  it('担当居宅が設定されている場合に連絡先セクションが表示される', () => {
-    const customer = makeCustomer({
-      home_care_office: 'ケアセンター新宿',
-      care_manager_name: '佐藤ケアマネ',
-    });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+  it('連絡先セクションは hasContact=true のとき表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      hasContact: true,
+      homeCareOffice: 'ケアセンター新宿',
+      careManagerName: '佐藤ケアマネ',
+    })} />);
     expect(screen.getByText('ケアセンター新宿')).toBeInTheDocument();
     expect(screen.getByText('佐藤ケアマネ')).toBeInTheDocument();
   });
 
   it('NGスタッフのバッジが表示される', () => {
-    const helper = makeHelper('h-1', '鈴木', '一郎');
-    const helpers = new Map([['h-1', helper]]);
-    const customer = makeCustomer({ ng_staff_ids: ['h-1'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} helpers={helpers} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      ngStaff: [{ id: 'h-1', name: '鈴木 一郎', isPreferred: false }],
+    })} />);
     expect(screen.getByTestId('ng-staff-badges')).toBeInTheDocument();
     expect(screen.getByText('鈴木 一郎')).toBeInTheDocument();
   });
 
-  it('allowed_staff_ids に値があるとき「入れるスタッフ」セクションが表示される', () => {
-    const helper = makeHelper('h-2', '高橋', '二郎');
-    const helpers = new Map([['h-2', helper]]);
-    const customer = makeCustomer({ allowed_staff_ids: ['h-2'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} helpers={helpers} />);
+  it('allowed_staff に値があるとき「入れるスタッフ」セクションが表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      allowedStaff: [{ id: 'h-2', name: '高橋 二郎', isPreferred: false }],
+    })} />);
     expect(screen.getByTestId('allowed-staff-badges')).toBeInTheDocument();
     expect(screen.getByText('高橋 二郎')).toBeInTheDocument();
   });
 
-  it('preferred_staff_ids に含まれるスタッフに推奨マークが表示される', () => {
-    const helper = makeHelper('h-3', '伊藤', '三郎');
-    const helpers = new Map([['h-3', helper]]);
-    const customer = makeCustomer({
-      allowed_staff_ids: ['h-3'],
-      preferred_staff_ids: ['h-3'],
-    });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} helpers={helpers} />);
+  it('preferred フラグのあるスタッフに推奨マークが表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      allowedStaff: [{ id: 'h-3', name: '伊藤 三郎', isPreferred: true }],
+    })} />);
     expect(screen.getByTestId('allowed-staff-preferred-h-3')).toBeInTheDocument();
   });
 
-  it('同一世帯メンバーが設定されている場合にBadgeで表示される（IDフォールバック）', () => {
-    const customer = makeCustomer({ same_household_customer_ids: ['C002', 'C003'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+  it('同一世帯メンバーがBadgeで表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      householdMembers: [{ id: 'C002', name: '佐藤 次郎' }],
+    })} />);
     expect(screen.getByText('同一世帯')).toBeInTheDocument();
-    // customers Map に該当がないのでIDがそのまま表示される
-    expect(screen.getByText('C002')).toBeInTheDocument();
-    expect(screen.getByText('C003')).toBeInTheDocument();
-  });
-
-  it('同一世帯メンバーのcustomers Map該当時に名前で表示される', () => {
-    const c2 = makeCustomer({ id: 'C002', name: { family: '佐藤', given: '次郎' } });
-    const customersMap = new Map([['C002', c2]]);
-    const customer = makeCustomer({ same_household_customer_ids: ['C002'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} customers={customersMap} />);
     expect(screen.getByText('佐藤 次郎')).toBeInTheDocument();
   });
 
-  it('同一施設メンバーが設定されている場合にBadgeで表示される', () => {
-    const customer = makeCustomer({ same_facility_customer_ids: ['C010'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+  it('同一施設メンバーがBadgeで表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      facilityMembers: [{ id: 'C010', name: '中村 五郎' }],
+    })} />);
     expect(screen.getByText('同一施設')).toBeInTheDocument();
-    expect(screen.getByText('C010')).toBeInTheDocument();
-  });
-
-  it('同一施設メンバーのcustomers Map該当時に名前で表示される', () => {
-    const c10 = makeCustomer({ id: 'C010', name: { family: '中村', given: '五郎' } });
-    const customersMap = new Map([['C010', c10]]);
-    const customer = makeCustomer({ same_facility_customer_ids: ['C010'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} customers={customersMap} />);
     expect(screen.getByText('中村 五郎')).toBeInTheDocument();
   });
 
-  it('同一世帯に自己IDが含まれる場合はフィルタされる', () => {
-    const self = makeCustomer({ id: 'cust-1', same_household_customer_ids: ['cust-1', 'C002'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={self} />);
-    expect(screen.getByText('同一世帯')).toBeInTheDocument();
-    expect(screen.getByText('C002')).toBeInTheDocument();
-    const badges = screen.getByText('C002').parentElement;
-    expect(badges?.textContent).not.toContain('cust-1');
-  });
-
-  it('同一施設に自己IDが含まれる場合はフィルタされる', () => {
-    const self = makeCustomer({ id: 'cust-1', same_facility_customer_ids: ['cust-1', 'C010'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={self} />);
-    expect(screen.getByText('同一施設')).toBeInTheDocument();
-    expect(screen.getByText('C010')).toBeInTheDocument();
-    const badges = screen.getByText('C010').parentElement;
-    expect(badges?.textContent).not.toContain('cust-1');
-  });
-
-  it('同一世帯が自己IDのみの場合はセクション非表示', () => {
-    const self = makeCustomer({ id: 'cust-1', same_household_customer_ids: ['cust-1'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={self} />);
-    expect(screen.queryByText('同一世帯')).not.toBeInTheDocument();
-  });
-
-  it('同一施設が自己IDのみの場合はセクション非表示', () => {
-    const self = makeCustomer({ id: 'cust-1', same_facility_customer_ids: ['cust-1'] });
-    render(<CustomerDetailSheet {...defaultProps} customer={self} />);
-    expect(screen.queryByText('同一施設')).not.toBeInTheDocument();
-  });
-
   it('同一世帯・同一施設が空のとき表示されない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.queryByText('同一世帯')).not.toBeInTheDocument();
     expect(screen.queryByText('同一施設')).not.toBeInTheDocument();
   });
 
-  it('allowed_staff_ids が空のとき「入れるスタッフ」セクションが表示されない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+  it('allowed_staff が空のとき「入れるスタッフ」セクションが表示されない', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.queryByTestId('allowed-staff-badges')).not.toBeInTheDocument();
   });
 
   it('週間サービスが設定されている場合にテーブルが表示される', () => {
-    const customer = makeCustomer({
-      weekly_services: {
-        monday: [
-          { start_time: '09:00', end_time: '10:00', service_type: 'physical_care', staff_count: 1 },
-        ],
-      },
-    });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      hasWeeklyServices: true,
+      weeklyServices: [{
+        day: 'monday',
+        dayLabel: '月',
+        slots: [{ time: '09:00 - 10:00', serviceLabel: '身体介護', staffCount: 1 }],
+      }],
+    })} />);
     expect(screen.getByText('月')).toBeInTheDocument();
     expect(screen.getByText('09:00 - 10:00')).toBeInTheDocument();
     expect(screen.getByText('身体介護')).toBeInTheDocument();
@@ -235,54 +152,51 @@ describe('CustomerDetailSheet', () => {
   });
 
   it('週間サービスが空のとき週間サービスセクションが表示されない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.queryByText('週間サービス')).not.toBeInTheDocument();
   });
 
   it('備考が設定されている場合に表示される', () => {
-    const customer = makeCustomer({ notes: '特記事項あり' });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({ notes: '特記事項あり' })} />);
     expect(screen.getByText('特記事項あり')).toBeInTheDocument();
   });
 
   it('備考が未設定のとき備考セクションが表示されない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.queryByText('備考')).not.toBeInTheDocument();
   });
 
   it('あおぞらIDがある場合に外部連携IDセクションが表示される', () => {
-    const customer = makeCustomer({ aozora_id: 'AO-001' });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({ hasExternalIds: true, aozoraId: 'AO-001' })} />);
     expect(screen.getByText('AO-001')).toBeInTheDocument();
   });
 
   it('外部IDが全て空のとき外部連携IDセクションが表示されない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.queryByText('外部連携ID')).not.toBeInTheDocument();
   });
 
   it('編集ボタンクリックで onEdit が呼ばれる', () => {
     const onEdit = vi.fn();
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} onEdit={onEdit} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} onEdit={onEdit} />);
     fireEvent.click(screen.getByTestId('customer-detail-edit-button'));
     expect(onEdit).toHaveBeenCalledOnce();
   });
 
   it('canEdit=false のとき編集ボタンが表示されない', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} canEdit={false} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} canEdit={false} />);
     expect(screen.queryByTestId('customer-detail-edit-button')).not.toBeInTheDocument();
   });
 
   it('canEdit=true のとき編集ボタンが表示される', () => {
-    render(<CustomerDetailSheet {...defaultProps} customer={makeCustomer()} canEdit={true} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} canEdit={true} />);
     expect(screen.getByTestId('customer-detail-edit-button')).toBeInTheDocument();
   });
 
   it('不定期パターンが設定されている場合に表示される', () => {
-    const customer = makeCustomer({
-      irregular_patterns: [{ type: 'biweekly', description: '第1・3週のみ' }],
-    });
-    render(<CustomerDetailSheet {...defaultProps} customer={customer} />);
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      irregularPatterns: [{ typeLabel: '隔週', description: '第1・3週のみ' }],
+    })} />);
     expect(screen.getByText('隔週')).toBeInTheDocument();
     expect(screen.getByText('第1・3週のみ')).toBeInTheDocument();
   });

--- a/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
+++ b/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { buildCustomerDetailViewModel } from '../customerDetailViewModel';
+import type { Customer, Helper, ServiceTypeDoc } from '@/types';
+
+function makeCustomer(overrides: Partial<Customer> = {}): Customer {
+  return {
+    id: 'cust-1',
+    name: { family: '田中', given: '花子' },
+    address: '東京都新宿区1-1-1',
+    location: { lat: 35.6895, lng: 139.6917 },
+    ng_staff_ids: [],
+    allowed_staff_ids: [],
+    preferred_staff_ids: [],
+    same_household_customer_ids: [],
+    same_facility_customer_ids: [],
+    weekly_services: {},
+    service_manager: '山田太郎',
+    gender_requirement: 'any',
+    created_at: new Date('2025-01-01T00:00:00'),
+    updated_at: new Date('2025-06-01T00:00:00'),
+    ...overrides,
+  };
+}
+
+function makeHelper(id: string, family: string, given: string): Helper {
+  return {
+    id,
+    name: { family, given },
+    qualifications: [],
+    can_physical_care: false,
+    transportation: 'bicycle',
+    weekly_availability: {},
+    preferred_hours: { min: 20, max: 40 },
+    available_hours: { min: 20, max: 40 },
+    customer_training_status: {},
+    employment_type: 'part_time',
+    gender: 'female',
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+const emptyHelpers = new Map<string, Helper>();
+const emptyCustomers = new Map<string, Customer>();
+const emptyServiceTypes = new Map<string, ServiceTypeDoc>();
+
+const sampleServiceTypes = new Map<string, ServiceTypeDoc>([
+  ['physical_care', {
+    id: 'physical_care', code: 'physical_care', label: '身体介護',
+    short_label: '身体', requires_physical_care_cert: true, sort_order: 1,
+    category: 'care', duration: '60分以上', care_level: 'level1', units: 100,
+    created_at: new Date(), updated_at: new Date(),
+  } as ServiceTypeDoc],
+]);
+
+describe('buildCustomerDetailViewModel', () => {
+  it('基本フィールドが正しく変換される', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer(), emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.fullName).toBe('田中 花子');
+    expect(vm.address).toBe('東京都新宿区1-1-1');
+    expect(vm.serviceManager).toBe('山田太郎');
+    expect(vm.genderRequirementLabel).toBe('指定なし');
+  });
+
+  it('ふりがながある場合 fullKana が設定される', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({ name: { family: '田中', given: '花子', family_kana: 'たなか', given_kana: 'はなこ' } }),
+      emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.fullKana).toBe('たなか はなこ');
+  });
+
+  it('ふりがながない場合 fullKana が null', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer(), emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.fullKana).toBeNull();
+  });
+
+  it('NGスタッフがヘルパーMapから名前解決される', () => {
+    const helpers = new Map([['h-1', makeHelper('h-1', '鈴木', '一郎')]]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({ ng_staff_ids: ['h-1'] }),
+      helpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.ngStaff).toEqual([{ id: 'h-1', name: '鈴木 一郎', isPreferred: false }]);
+  });
+
+  it('NGスタッフでヘルパーMapに存在しないIDはフィルタされる', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({ ng_staff_ids: ['h-unknown'] }),
+      emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.ngStaff).toEqual([]);
+  });
+
+  it('allowedStaff に preferred フラグが正しく設定される', () => {
+    const helpers = new Map([
+      ['h-1', makeHelper('h-1', '鈴木', '一郎')],
+      ['h-2', makeHelper('h-2', '高橋', '二郎')],
+    ]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({
+        allowed_staff_ids: ['h-1', 'h-2'],
+        preferred_staff_ids: ['h-2'],
+      }),
+      helpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.allowedStaff[0].isPreferred).toBe(false);
+    expect(vm.allowedStaff[1].isPreferred).toBe(true);
+  });
+
+  it('同一世帯メンバーの名前解決（Map該当/非該当）', () => {
+    const c2 = makeCustomer({ id: 'C002', name: { family: '佐藤', given: '次郎' } });
+    const customersMap = new Map([['C002', c2]]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({ same_household_customer_ids: ['C002', 'C003'] }),
+      emptyHelpers, customersMap, emptyServiceTypes,
+    );
+    expect(vm.householdMembers).toEqual([
+      { id: 'C002', name: '佐藤 次郎' },
+      { id: 'C003', name: 'C003' },
+    ]);
+  });
+
+  it('同一世帯に自己IDが含まれる場合はフィルタされる', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({ id: 'cust-1', same_household_customer_ids: ['cust-1', 'C002'] }),
+      emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.householdMembers.map((m) => m.id)).toEqual(['C002']);
+  });
+
+  it('同一施設メンバーの名前解決', () => {
+    const c10 = makeCustomer({ id: 'C010', name: { family: '中村', given: '五郎' } });
+    const customersMap = new Map([['C010', c10]]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({ same_facility_customer_ids: ['C010'] }),
+      emptyHelpers, customersMap, emptyServiceTypes,
+    );
+    expect(vm.facilityMembers).toEqual([{ id: 'C010', name: '中村 五郎' }]);
+  });
+
+  it('週間サービスのservice_typeがlabelに解決される', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({
+        weekly_services: {
+          monday: [{ start_time: '09:00', end_time: '10:00', service_type: 'physical_care', staff_count: 1 }],
+        },
+      }),
+      emptyHelpers, emptyCustomers, sampleServiceTypes,
+    );
+    expect(vm.weeklyServices).toHaveLength(1);
+    expect(vm.weeklyServices[0].dayLabel).toBe('月');
+    expect(vm.weeklyServices[0].slots[0].serviceLabel).toBe('身体介護');
+    expect(vm.weeklyServices[0].slots[0].time).toBe('09:00 - 10:00');
+    expect(vm.hasWeeklyServices).toBe(true);
+  });
+
+  it('未知のservice_typeはコードがそのまま使われる', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({
+        weekly_services: {
+          tuesday: [{ start_time: '10:00', end_time: '11:00', service_type: 'unknown_type', staff_count: 2 }],
+        },
+      }),
+      emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.weeklyServices[0].slots[0].serviceLabel).toBe('unknown_type');
+  });
+
+  it('不定期パターンのtype labelが解決される', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({
+        irregular_patterns: [{ type: 'biweekly', description: '第1・3週のみ', active_weeks: [1, 3] }],
+      }),
+      emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.irregularPatterns).toEqual([
+      { typeLabel: '隔週', description: '第1・3週のみ', activeWeeks: [1, 3] },
+    ]);
+  });
+
+  it('hasContact が連絡先フィールドの有無を反映する', () => {
+    const vmNo = buildCustomerDetailViewModel(
+      makeCustomer(), emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vmNo.hasContact).toBe(false);
+
+    const vmYes = buildCustomerDetailViewModel(
+      makeCustomer({ home_care_office: 'ケアセンター' }),
+      emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vmYes.hasContact).toBe(true);
+  });
+
+  it('性別要件ラベルが正しく変換される', () => {
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({ gender_requirement: 'female' }),
+      emptyHelpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.genderRequirementLabel).toBe('女性のみ');
+  });
+});

--- a/web/src/components/masters/customerDetailViewModel.ts
+++ b/web/src/components/masters/customerDetailViewModel.ts
@@ -1,0 +1,204 @@
+import { useMemo } from 'react';
+import { useServiceTypes } from '@/hooks/useServiceTypes';
+import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
+import type { Customer, Helper, ServiceTypeDoc, DayOfWeek } from '@/types';
+
+// ── 表示ラベル定数 ──────────────────────────────────────────
+const GENDER_REQUIREMENT_LABELS: Record<string, string> = {
+  any: '指定なし',
+  female: '女性のみ',
+  male: '男性のみ',
+};
+
+const IRREGULAR_PATTERN_LABELS: Record<string, string> = {
+  biweekly: '隔週',
+  monthly: '月次',
+  temporary_stop: '一時停止',
+};
+
+// ── ViewModel型定義 ─────────────────────────────────────────
+
+export interface ResolvedStaff {
+  id: string;
+  name: string;
+  isPreferred: boolean;
+}
+
+export interface WeeklyServiceRow {
+  day: DayOfWeek;
+  dayLabel: string;
+  slots: {
+    time: string;
+    serviceLabel: string;
+    staffCount: number;
+  }[];
+}
+
+export interface IrregularPatternRow {
+  typeLabel: string;
+  description: string;
+  activeWeeks?: number[];
+}
+
+export interface CustomerDetailViewModel {
+  id: string;
+  fullName: string;
+  fullKana: string | null;
+  shortName?: string;
+  address: string;
+  serviceManager: string;
+  phoneNumber?: string;
+  phoneNumber2?: string;
+  phoneNote?: string;
+  genderRequirementLabel: string;
+
+  ngStaff: ResolvedStaff[];
+  allowedStaff: ResolvedStaff[];
+  householdMembers: { id: string; name: string }[];
+  facilityMembers: { id: string; name: string }[];
+
+  weeklyServices: WeeklyServiceRow[];
+  hasWeeklyServices: boolean;
+
+  irregularPatterns: IrregularPatternRow[];
+
+  homeCareOffice?: string;
+  careManagerName?: string;
+  consultationSupportOffice?: string;
+  supportSpecialistName?: string;
+  hasContact: boolean;
+
+  notes?: string;
+  aozoraId?: string;
+  hasExternalIds: boolean;
+
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// ── ビルダー純粋関数 ────────────────────────────────────────
+
+function resolveStaffName(id: string, helpers: Map<string, Helper>): string {
+  const h = helpers.get(id);
+  return h ? `${h.name.family} ${h.name.given}` : id;
+}
+
+function resolveCustomerName(id: string, customers: Map<string, Customer>): string {
+  const c = customers.get(id);
+  return c ? `${c.name.family} ${c.name.given}` : id;
+}
+
+export function buildCustomerDetailViewModel(
+  customer: Customer,
+  helpers: Map<string, Helper>,
+  customers: Map<string, Customer>,
+  serviceTypes: Map<string, ServiceTypeDoc>,
+): CustomerDetailViewModel {
+  const fullName = `${customer.name.family} ${customer.name.given}`;
+  const fullKana =
+    customer.name.family_kana || customer.name.given_kana
+      ? `${customer.name.family_kana ?? ''} ${customer.name.given_kana ?? ''}`.trim()
+      : null;
+
+  const preferredSet = new Set(customer.preferred_staff_ids);
+
+  const ngStaff: ResolvedStaff[] = customer.ng_staff_ids
+    .filter((id) => helpers.has(id))
+    .map((id) => ({
+      id,
+      name: resolveStaffName(id, helpers),
+      isPreferred: false,
+    }));
+
+  const allowedStaff: ResolvedStaff[] = (customer.allowed_staff_ids ?? [])
+    .filter((id) => helpers.has(id))
+    .map((id) => ({
+      id,
+      name: resolveStaffName(id, helpers),
+      isPreferred: preferredSet.has(id),
+    }));
+
+  const householdMembers = (customer.same_household_customer_ids ?? [])
+    .filter((id) => id !== customer.id)
+    .map((id) => ({ id, name: resolveCustomerName(id, customers) }));
+
+  const facilityMembers = (customer.same_facility_customer_ids ?? [])
+    .filter((id) => id !== customer.id)
+    .map((id) => ({ id, name: resolveCustomerName(id, customers) }));
+
+  const weeklyServices: WeeklyServiceRow[] = DAY_OF_WEEK_ORDER
+    .filter((day) => customer.weekly_services[day] && customer.weekly_services[day]!.length > 0)
+    .map((day) => ({
+      day,
+      dayLabel: DAY_OF_WEEK_LABELS[day],
+      slots: customer.weekly_services[day]!.map((slot) => ({
+        time: `${slot.start_time} - ${slot.end_time}`,
+        serviceLabel: serviceTypes.get(slot.service_type)?.label ?? slot.service_type,
+        staffCount: slot.staff_count,
+      })),
+    }));
+
+  const irregularPatterns: IrregularPatternRow[] = (customer.irregular_patterns ?? []).map((p) => ({
+    typeLabel: IRREGULAR_PATTERN_LABELS[p.type] ?? p.type,
+    description: p.description,
+    activeWeeks: p.active_weeks,
+  }));
+
+  const hasContact = !!(
+    customer.home_care_office ||
+    customer.care_manager_name ||
+    customer.consultation_support_office ||
+    customer.support_specialist_name
+  );
+
+  return {
+    id: customer.id,
+    fullName,
+    fullKana,
+    shortName: customer.name.short,
+    address: customer.address,
+    serviceManager: customer.service_manager,
+    phoneNumber: customer.phone_number,
+    phoneNumber2: customer.phone_number2,
+    phoneNote: customer.phone_note,
+    genderRequirementLabel:
+      GENDER_REQUIREMENT_LABELS[customer.gender_requirement ?? 'any'] ?? '指定なし',
+
+    ngStaff,
+    allowedStaff,
+    householdMembers,
+    facilityMembers,
+
+    weeklyServices,
+    hasWeeklyServices: weeklyServices.length > 0,
+
+    irregularPatterns,
+
+    homeCareOffice: customer.home_care_office,
+    careManagerName: customer.care_manager_name,
+    consultationSupportOffice: customer.consultation_support_office,
+    supportSpecialistName: customer.support_specialist_name,
+    hasContact,
+
+    notes: customer.notes,
+    aozoraId: customer.aozora_id,
+    hasExternalIds: !!customer.aozora_id,
+
+    createdAt: customer.created_at,
+    updatedAt: customer.updated_at,
+  };
+}
+
+// ── React Hook ──────────────────────────────────────────────
+
+export function useCustomerDetailViewModel(
+  customer: Customer | null,
+  helpers: Map<string, Helper>,
+  customers: Map<string, Customer>,
+): CustomerDetailViewModel | null {
+  const { serviceTypes } = useServiceTypes();
+  return useMemo(
+    () => customer ? buildCustomerDetailViewModel(customer, helpers, customers, serviceTypes) : null,
+    [customer, helpers, customers, serviceTypes],
+  );
+}


### PR DESCRIPTION
## Summary

- `buildCustomerDetailViewModel()` 純粋関数を新設: helpers/customers/serviceTypes Map からデータ解決 → `CustomerDetailViewModel` に変換
- `useCustomerDetailViewModel()` フックを新設: `useServiceTypes()` 呼び出し + `useMemo` ラッパー付き
- `CustomerDetailSheet`: props を `vm: CustomerDetailViewModel | null` のみに簡素化（Maps・hooks 依存を排除）
- 両ページ（customers / weekly-schedule）でフックを利用するように更新
- `aozoraId!` non-null assertion を条件ガード（`vm.aozoraId &&`）に修正

## Test plan

- [x] `customerDetailViewModel.test.ts` 14件（純粋関数のみ、Reactモック不要）
- [x] `CustomerDetailSheet.test.tsx` 22件（ViewModel ファクトリで簡潔に）
- [x] `weekly-schedule/page.test.tsx` 10件
- [x] 全テスト: 562 passed
- [x] TSC: 今回の変更による新規エラー 0件

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)