### PR TITLE
refactor: ViewModel の hasWeeklyServices 削除と useServiceTypes 外部化

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { Plus, Pencil, Search, ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
 import { useCustomers } from '@/hooks/useCustomers';
 import { useHelpers } from '@/hooks/useHelpers';
+import { useServiceTypes } from '@/hooks/useServiceTypes';
 import { useAuthRole } from '@/lib/auth/AuthProvider';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -45,6 +46,7 @@ const KANA_ROWS: { label: string; chars: Set<string> }[] = [
 export default function CustomersPage() {
   const { customers, loading } = useCustomers();
   const { helpers } = useHelpers();
+  const { serviceTypes } = useServiceTypes();
   const { canEditCustomers } = useAuthRole();
   const [search, setSearch] = useState('');
   const [sortKana, setSortKana] = useState<'asc' | 'desc' | null>(null);
@@ -55,7 +57,7 @@ export default function CustomersPage() {
 
   const detailCustomer = detailId ? customers.get(detailId) ?? null : null;
   const detailOpen = detailId !== null;
-  const detailVm = useCustomerDetailViewModel(detailCustomer, helpers, customers);
+  const detailVm = useCustomerDetailViewModel(detailCustomer, helpers, customers, serviceTypes);
 
   const filtered = useMemo(() => {
     const list = Array.from(customers.values());

--- a/web/src/app/masters/weekly-schedule/page.tsx
+++ b/web/src/app/masters/weekly-schedule/page.tsx
@@ -68,7 +68,7 @@ export default function WeeklySchedulePage() {
 
   const detailCustomer = detailId ? customers.get(detailId) ?? null : null;
   const detailOpen = detailId !== null;
-  const detailVm = useCustomerDetailViewModel(detailCustomer, helpers, customers);
+  const detailVm = useCustomerDetailViewModel(detailCustomer, helpers, customers, serviceTypes);
 
   const openDetail = (customer: Customer) => {
     setDetailId(customer.id);

--- a/web/src/components/masters/CustomerDetailSheet.tsx
+++ b/web/src/components/masters/CustomerDetailSheet.tsx
@@ -185,7 +185,7 @@ export function CustomerDetailSheet({
           )}
 
           {/* 4. 週間サービス */}
-          {vm.hasWeeklyServices && (
+          {vm.weeklyServices.length > 0 && (
             <section>
               <SectionHeader>週間サービス</SectionHeader>
               <div className="overflow-x-auto rounded-lg border">

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -26,7 +26,6 @@ function makeVm(overrides: Partial<CustomerDetailViewModel> = {}): CustomerDetai
     householdMembers: [],
     facilityMembers: [],
     weeklyServices: [],
-    hasWeeklyServices: false,
     irregularPatterns: [],
     hasContact: false,
     hasExternalIds: false,
@@ -138,7 +137,6 @@ describe('CustomerDetailSheet', () => {
 
   it('週間サービスが設定されている場合にテーブルが表示される', () => {
     render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
-      hasWeeklyServices: true,
       weeklyServices: [{
         day: 'monday',
         dayLabel: '月',

--- a/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
+++ b/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
@@ -156,7 +156,7 @@ describe('buildCustomerDetailViewModel', () => {
     expect(vm.weeklyServices[0].dayLabel).toBe('月');
     expect(vm.weeklyServices[0].slots[0].serviceLabel).toBe('身体介護');
     expect(vm.weeklyServices[0].slots[0].time).toBe('09:00 - 10:00');
-    expect(vm.hasWeeklyServices).toBe(true);
+    expect(vm.weeklyServices.length).toBeGreaterThan(0);
   });
 
   it('未知のservice_typeはコードがそのまま使われる', () => {

--- a/web/src/components/masters/customerDetailViewModel.ts
+++ b/web/src/components/masters/customerDetailViewModel.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useServiceTypes } from '@/hooks/useServiceTypes';
 import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
 import type { Customer, Helper, ServiceTypeDoc, DayOfWeek } from '@/types';
 
@@ -58,7 +57,6 @@ export interface CustomerDetailViewModel {
   facilityMembers: { id: string; name: string }[];
 
   weeklyServices: WeeklyServiceRow[];
-  hasWeeklyServices: boolean;
 
   irregularPatterns: IrregularPatternRow[];
 
@@ -170,7 +168,6 @@ export function buildCustomerDetailViewModel(
     facilityMembers,
 
     weeklyServices,
-    hasWeeklyServices: weeklyServices.length > 0,
 
     irregularPatterns,
 
@@ -195,8 +192,8 @@ export function useCustomerDetailViewModel(
   customer: Customer | null,
   helpers: Map<string, Helper>,
   customers: Map<string, Customer>,
+  serviceTypes: Map<string, ServiceTypeDoc>,
 ): CustomerDetailViewModel | null {
-  const { serviceTypes } = useServiceTypes();
   return useMemo(
     () => customer ? buildCustomerDetailViewModel(customer, helpers, customers, serviceTypes) : null,
     [customer, helpers, customers, serviceTypes],


### PR DESCRIPTION
## Summary

- `hasWeeklyServices` フィールドを削除し `weeklyServices.length > 0` で直接判定
- `useCustomerDetailViewModel` から内部 `useServiceTypes()` 呼び出しを除去し、引数で `serviceTypes` を受け取るよう変更（weekly-schedule での二重呼び出し解消）

## Test plan

- [x] 全テスト: 562 passed
- [x] TSC: 新規エラー 0件

Closes #191
Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)