### PR TITLE
test: allowed_staff_ids Seedデータ追加+Optimizer制約テスト拡充

### DIFF
--- a/optimizer/tests/test_constraints/test_allowed_staff.py
+++ b/optimizer/tests/test_constraints/test_allowed_staff.py
@@ -10,6 +10,9 @@ from optimizer.models import (
     OptimizationInput,
     Order,
     StaffConstraint,
+    StaffConstraintType,
+    StaffUnavailability,
+    UnavailableSlot,
 )
 
 
@@ -37,6 +40,30 @@ def _o(id: str, cid: str) -> Order:
     )
 
 
+def _unavail(staff_id: str, date: str = "2025-01-06") -> StaffUnavailability:
+    return StaffUnavailability(
+        staff_id=staff_id, week_start_date=date,
+        unavailable_slots=[UnavailableSlot(date=date, all_day=True)],
+    )
+
+
+def _allowed_with_unavailabilities(
+    unavailable_staff_ids: list[str],
+) -> OptimizationInput:
+    """allowed=[H001,H002], helpers=[H001,H002,H003] の共通セットアップ"""
+    return OptimizationInput(
+        customers=[_c("C1", allowed=["H001", "H002"])],
+        helpers=[_h("H001"), _h("H002"), _h("H003")],
+        orders=[_o("O1", "C1")],
+        travel_times=[],
+        staff_unavailabilities=[_unavail(sid) for sid in unavailable_staff_ids],
+        staff_constraints=[
+            StaffConstraint(customer_id="C1", staff_id="H001", constraint_type=StaffConstraintType.ALLOWED),
+            StaffConstraint(customer_id="C1", staff_id="H002", constraint_type=StaffConstraintType.ALLOWED),
+        ],
+    )
+
+
 class TestAllowedStaffConstraint:
     def test_allowed_empty_no_restriction(self) -> None:
         """allowed_staff_ids が空 → 制限なし（全スタッフ割り当て可）"""
@@ -60,8 +87,8 @@ class TestAllowedStaffConstraint:
             orders=[_o("O1", "C1")],
             travel_times=[], staff_unavailabilities=[],
             staff_constraints=[
-                StaffConstraint(customer_id="C1", staff_id="H001", constraint_type="allowed"),
-                StaffConstraint(customer_id="C1", staff_id="H002", constraint_type="allowed"),
+                StaffConstraint(customer_id="C1", staff_id="H001", constraint_type=StaffConstraintType.ALLOWED),
+                StaffConstraint(customer_id="C1", staff_id="H002", constraint_type=StaffConstraintType.ALLOWED),
             ],
         )
         result = solve(inp)
@@ -79,8 +106,8 @@ class TestAllowedStaffConstraint:
             orders=[_o("O1", "C1")],
             travel_times=[], staff_unavailabilities=[],
             staff_constraints=[
-                StaffConstraint(customer_id="C1", staff_id="H001", constraint_type="allowed"),
-                StaffConstraint(customer_id="C1", staff_id="H001", constraint_type="ng"),
+                StaffConstraint(customer_id="C1", staff_id="H001", constraint_type=StaffConstraintType.ALLOWED),
+                StaffConstraint(customer_id="C1", staff_id="H001", constraint_type=StaffConstraintType.NG),
             ],
         )
         result = solve(inp)
@@ -96,9 +123,22 @@ class TestAllowedStaffConstraint:
             orders=[_o("O1", "C1")],
             travel_times=[], staff_unavailabilities=[],
             staff_constraints=[
-                StaffConstraint(customer_id="C1", staff_id="H001", constraint_type="allowed"),
+                StaffConstraint(customer_id="C1", staff_id="H001", constraint_type=StaffConstraintType.ALLOWED),
             ],
         )
         result = solve(inp)
         assert result.status == "Optimal"
         assert result.assignments[0].staff_ids == ["H001"]
+
+    def test_all_allowed_staff_unavailable_infeasible(self) -> None:
+        """全allowedスタッフが希望休 → 割り当て不可 → Infeasible"""
+        result = solve(_allowed_with_unavailabilities(["H001", "H002"]))
+        # H001/H002は希望休、H003はallowed外 → 割り当て不可
+        assert result.status == "Infeasible"
+
+    def test_partial_allowed_staff_unavailable_optimal(self) -> None:
+        """allowedスタッフの一部が希望休 → 残りで割り当て可"""
+        result = solve(_allowed_with_unavailabilities(["H001"]))
+        assert result.status == "Optimal"
+        # H001は希望休なので H002 が割り当てられる
+        assert result.assignments[0].staff_ids == ["H002"]

--- a/optimizer/tests/test_csv_loader.py
+++ b/optimizer/tests/test_csv_loader.py
@@ -109,12 +109,17 @@ class TestLoadStaffUnavailabilities:
 class TestLoadStaffConstraints:
     def test_loaded(self, seed_data_dir: Path) -> None:
         constraints = load_staff_constraints(seed_data_dir)
-        assert len(constraints) == 19
+        assert len(constraints) == 21
 
     def test_ng_count(self, seed_data_dir: Path) -> None:
         constraints = load_staff_constraints(seed_data_dir)
         ng = [c for c in constraints if c.constraint_type == "ng"]
         assert len(ng) == 7
+
+    def test_allowed_count(self, seed_data_dir: Path) -> None:
+        constraints = load_staff_constraints(seed_data_dir)
+        allowed = [c for c in constraints if c.constraint_type == "allowed"]
+        assert len(allowed) == 2
 
 
 class TestGenerateOrdersLinkedOrders:
@@ -162,4 +167,4 @@ class TestLoadOptimizationInput:
         assert len(inp.helpers) == 20
         assert len(inp.orders) == 184
         assert len(inp.travel_times) > 0
-        assert len(inp.staff_constraints) == 19
+        assert len(inp.staff_constraints) == 21

--- a/seed/data/customer-staff-constraints.csv
+++ b/seed/data/customer-staff-constraints.csv
@@ -18,3 +18,5 @@ C038,H003,preferred
 C042,H016,preferred
 C048,H009,preferred
 C048,H015,preferred
+C010,H001,allowed
+C010,H009,allowed

--- a/seed/tests/import.test.ts
+++ b/seed/tests/import.test.ts
@@ -132,14 +132,26 @@ describe('Firestore import integration', () => {
     const helperIds = new Set(helpersSnap.docs.map((d) => d.id));
 
     const customersSnap = await db.collection('customers').get();
+    const staffFields = ['ng_staff_ids', 'preferred_staff_ids', 'allowed_staff_ids'] as const;
     for (const doc of customersSnap.docs) {
       const data = doc.data();
-      for (const staffId of data.ng_staff_ids) {
-        expect(helperIds.has(staffId)).toBe(true);
-      }
-      for (const staffId of data.preferred_staff_ids) {
-        expect(helperIds.has(staffId)).toBe(true);
+      for (const field of staffFields) {
+        for (const staffId of data[field] ?? []) {
+          expect(helperIds.has(staffId), `${doc.id}.${field}: ${staffId} not in helpers`).toBe(true);
+        }
       }
     }
+  });
+
+  it('should have allowed_staff_ids for C010 from seed constraints', async () => {
+    const db = getFirestore();
+    const doc = await db.collection('customers').doc('C010').get();
+    expect(doc.exists).toBe(true);
+
+    const data = doc.data()!;
+    expect(data.allowed_staff_ids).toBeInstanceOf(Array);
+    expect(data.allowed_staff_ids).toContain('H001');
+    expect(data.allowed_staff_ids).toContain('H009');
+    expect(data.allowed_staff_ids).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- Seed CSV に `allowed` 制約データを追加し、CI統合テストで `allowed_staff_ids` の全パスを検証可能に
- Optimizer: 全allowedスタッフ不在→Infeasible / 一部不在→Optimalの2テストケース追加
- import.test.ts: `allowed_staff_ids` の参照整合性チェック + C010固有テスト追加
- `/simplify` レビュー反映: `_unavail()` ヘルパー抽出、`StaffConstraintType` enum化、ループ統一

## Test plan

- [x] Optimizer全テスト: 321 passed（allowed_staff 6件含む）
- [x] Web全テスト (vitest): 562 passed
- [x] csv_loader: allowed_count テスト追加済み
- [x] seed import.test.ts: C010 allowed_staff_ids 検証追加済み（CI Emulator環境で実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)