### PR TITLE
fix: テストファイルのtsc型エラー6件を修正

### DIFF
--- a/web/src/components/schedule/__tests__/OptimizeButton.test.tsx
+++ b/web/src/components/schedule/__tests__/OptimizeButton.test.tsx
@@ -5,7 +5,7 @@ import type { AllowedStaffWarning } from '@/lib/validation/allowed-staff-check';
 
 // ── モック ──────────────────────────────────────────────────────
 
-const mockCheckAllowedStaff = vi.fn<[], AllowedStaffWarning[]>();
+const mockCheckAllowedStaff = vi.fn<() => AllowedStaffWarning[]>();
 vi.mock('@/lib/validation/allowed-staff-check', () => ({
   checkAllowedStaff: (...args: unknown[]) => mockCheckAllowedStaff(),
 }));

--- a/web/src/lib/constraints/__tests__/checker.test.ts
+++ b/web/src/lib/constraints/__tests__/checker.test.ts
@@ -206,7 +206,7 @@ describe('checkConstraints', () => {
     const helpers = new Map([['H001', makeHelper({ can_physical_care: false })]]);
     const customers = new Map([['C001', makeCustomer()]]);
     const serviceTypes = new Map<string, ServiceTypeDoc>([
-      ['daily_living', { id: 'daily_living', code: 'daily_living', label: '生活援助', short_label: '生活', requires_physical_care_cert: true, sort_order: 2, created_at: new Date(), updated_at: new Date() }],
+      ['daily_living', { id: 'daily_living', code: 'daily_living', category: '訪問介護', label: '生活援助', duration: '', care_level: '', units: 0, short_label: '生活', requires_physical_care_cert: true, sort_order: 2, created_at: new Date(), updated_at: new Date() }],
     ]);
     const result = checkConstraints({
       orders: [makeOrder({ service_type: 'daily_living' })],
@@ -224,7 +224,7 @@ describe('checkConstraints', () => {
     const helpers = new Map([['H001', makeHelper({ can_physical_care: false })]]);
     const customers = new Map([['C001', makeCustomer()]]);
     const serviceTypes = new Map<string, ServiceTypeDoc>([
-      ['physical_care', { id: 'physical_care', code: 'physical_care', label: '身体介護', short_label: '身体', requires_physical_care_cert: false, sort_order: 1, created_at: new Date(), updated_at: new Date() }],
+      ['physical_care', { id: 'physical_care', code: 'physical_care', category: '訪問介護', label: '身体介護', duration: '', care_level: '', units: 0, short_label: '身体', requires_physical_care_cert: false, sort_order: 1, created_at: new Date(), updated_at: new Date() }],
     ]);
     const result = checkConstraints({
       orders: [makeOrder({ service_type: 'physical_care' })],

--- a/web/src/lib/dnd/__tests__/validation.test.ts
+++ b/web/src/lib/dnd/__tests__/validation.test.ts
@@ -126,7 +126,7 @@ describe('validateDrop', () => {
       input.order = makeOrder({ service_type: 'daily_living' });
       input.helpers.set('helper-b', makeHelper({ can_physical_care: false }));
       const serviceTypes = new Map<string, ServiceTypeDoc>([
-        ['daily_living', { id: 'daily_living', code: 'daily_living', label: '生活援助', short_label: '生活', requires_physical_care_cert: true, sort_order: 2, created_at: new Date(), updated_at: new Date() }],
+        ['daily_living', { id: 'daily_living', code: 'daily_living', category: '訪問介護', label: '生活援助', duration: '', care_level: '', units: 0, short_label: '生活', requires_physical_care_cert: true, sort_order: 2, created_at: new Date(), updated_at: new Date() }],
       ]);
 
       const result = validateDrop({ ...input, serviceTypes });
@@ -141,7 +141,7 @@ describe('validateDrop', () => {
       // physical_care はデフォルトでは資格必要だが、serviceTypes で上書き
       input.helpers.set('helper-b', makeHelper({ can_physical_care: false }));
       const serviceTypes = new Map<string, ServiceTypeDoc>([
-        ['physical_care', { id: 'physical_care', code: 'physical_care', label: '身体介護', short_label: '身体', requires_physical_care_cert: false, sort_order: 1, created_at: new Date(), updated_at: new Date() }],
+        ['physical_care', { id: 'physical_care', code: 'physical_care', category: '訪問介護', label: '身体介護', duration: '', care_level: '', units: 0, short_label: '身体', requires_physical_care_cert: false, sort_order: 1, created_at: new Date(), updated_at: new Date() }],
       ]);
 
       const result = validateDrop({ ...input, serviceTypes });

--- a/web/src/lib/firestore/__tests__/customers.test.ts
+++ b/web/src/lib/firestore/__tests__/customers.test.ts
@@ -39,7 +39,7 @@ vi.mock('firebase/firestore', () => ({
   arrayUnion: (...args: any[]) => mockArrayUnion(...args),
   arrayRemove: (...args: any[]) => mockArrayRemove(...args),
   writeBatch: (...args: any[]) => mockWriteBatch(...args),
-  runTransaction: (...args: any[]) => mockRunTransaction(...args),
+  runTransaction: (...args: any[]) => mockRunTransaction(...(args as [any, any])),
 }));
 
 vi.mock('@/lib/firebase', () => ({

--- a/web/src/lib/firestore/__tests__/helpers.test.ts
+++ b/web/src/lib/firestore/__tests__/helpers.test.ts
@@ -4,15 +4,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockAddDoc = vi.fn();
 const mockUpdateDoc = vi.fn();
 const mockServerTimestamp = vi.fn(() => 'MOCK_TIMESTAMP');
-const mockCollection = vi.fn(() => 'MOCK_COLLECTION_REF');
-const mockDoc = vi.fn(() => 'MOCK_DOC_REF');
+const mockCollection = vi.fn((..._args: any[]) => 'MOCK_COLLECTION_REF');
+const mockDoc = vi.fn((..._args: any[]) => 'MOCK_DOC_REF');
 
 vi.mock('firebase/firestore', () => ({
-  addDoc: (...args: unknown[]) => mockAddDoc(...args),
-  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  addDoc: (...args: any[]) => mockAddDoc(...args),
+  updateDoc: (...args: any[]) => mockUpdateDoc(...args),
   serverTimestamp: () => mockServerTimestamp(),
-  collection: (...args: unknown[]) => mockCollection(...args),
-  doc: (...args: unknown[]) => mockDoc(...args),
+  collection: (...args: any[]) => mockCollection(...args),
+  doc: (...args: any[]) => mockDoc(...args),
 }));
 
 vi.mock('@/lib/firebase', () => ({

--- a/web/src/lib/firestore/__tests__/service-types.test.ts
+++ b/web/src/lib/firestore/__tests__/service-types.test.ts
@@ -4,13 +4,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockSetDoc = vi.fn();
 const mockUpdateDoc = vi.fn();
 const mockServerTimestamp = vi.fn(() => 'MOCK_TIMESTAMP');
-const mockDoc = vi.fn(() => 'MOCK_DOC_REF');
+const mockDoc = vi.fn((..._args: any[]) => 'MOCK_DOC_REF');
 
 vi.mock('firebase/firestore', () => ({
-  setDoc: (...args: unknown[]) => mockSetDoc(...args),
-  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  setDoc: (...args: any[]) => mockSetDoc(...args),
+  updateDoc: (...args: any[]) => mockUpdateDoc(...args),
   serverTimestamp: () => mockServerTimestamp(),
-  doc: (...args: unknown[]) => mockDoc(...args),
+  doc: (...args: any[]) => mockDoc(...args),
 }));
 
 vi.mock('@/lib/firebase', () => ({


### PR DESCRIPTION
## Summary

- `tsc --noEmit` で検出されていた6ファイルの型エラーを修正
- `OptimizeButton.test.tsx`: `vi.fn` ジェネリクスをVitest 4.x形式に更新
- `checker.test.ts` / `validation.test.ts`: `ServiceTypeDoc` の必須フィールド(`category`, `duration`, `care_level`, `units`)追加
- `customers/helpers/service-types.test.ts`: モック関数のスプレッド引数型を `any[]` に統一

## Test plan

- [x] `tsc --noEmit` エラー0件
- [x] 修正対象6ファイルの全105テストパス
- [x] テストの動作に変更なし（型修正のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)