### PR TITLE
test: allowed_staff_ids 事前チェックダイアログE2Eテスト追加

### DIFF
--- a/web/e2e/schedule-allowed-staff.spec.ts
+++ b/web/e2e/schedule-allowed-staff.spec.ts
@@ -101,7 +101,7 @@ test.describe('allowed_staff_ids 事前チェックダイアログ', () => {
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText('最適化前の注意')).toBeVisible();
     // C010（吉田勝）の利用者名が表示される
-    await expect(dialog.getByText('吉田')).toBeVisible();
+    await expect(dialog.getByText('吉田').first()).toBeVisible();
     // 月曜の表示
     await expect(dialog.getByText(/月曜/)).toBeVisible();
     // allowed ヘルパー名の表示（設定中: ... → 全員対応不可）


### PR DESCRIPTION
## Summary

- Firestore emulator REST API（Bearer owner認証）でH001/H009に月曜全日希望休を動的追加
- C010（allowed_staff_ids=[H001,H009]）の月曜オーダーで全員対応不可→警告ダイアログ発生
- 3テストケース：警告表示確認、「戻って修正する」、「警告を無視して実行」→ウェイト設定遷移

## Test plan

- [ ] CI E2Eテスト（Playwright）がパスする
- [ ] 既存E2Eテストに影響がない（afterAllでクリーンアップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)