### PR TITLE
fix: 利用者一覧ページのundefinedクラッシュを修正

### DIFF
--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -286,32 +286,32 @@ export default function CustomersPage() {
                   </TableCell>
                   <TableCell className="text-center">
                     <div className="flex items-center justify-center gap-1">
-                      {customer.ng_staff_ids.length > 0 ? (
+                      {(customer.ng_staff_ids?.length ?? 0) > 0 ? (
                         <Badge variant="destructive" className="text-[10px] px-1.5 h-5">
                           NG {customer.ng_staff_ids.length}
                         </Badge>
                       ) : null}
-                      {customer.preferred_staff_ids.length > 0 ? (
+                      {(customer.preferred_staff_ids?.length ?? 0) > 0 ? (
                         <Badge variant="secondary" className="text-[10px] px-1.5 h-5">
                           推奨 {customer.preferred_staff_ids.length}
                         </Badge>
                       ) : null}
-                      {customer.ng_staff_ids.length === 0 && customer.preferred_staff_ids.length === 0 && '-'}
+                      {(customer.ng_staff_ids?.length ?? 0) === 0 && (customer.preferred_staff_ids?.length ?? 0) === 0 && '-'}
                     </div>
                   </TableCell>
                   <TableCell className="text-center">
                     <div className="flex items-center justify-center gap-1">
-                      {customer.same_household_customer_ids.length > 0 ? (
+                      {(customer.same_household_customer_ids?.length ?? 0) > 0 ? (
                         <Badge variant="outline" className="text-[10px] px-1.5 h-5">
                           世帯 {customer.same_household_customer_ids.length}
                         </Badge>
                       ) : null}
-                      {customer.same_facility_customer_ids.length > 0 ? (
+                      {(customer.same_facility_customer_ids?.length ?? 0) > 0 ? (
                         <Badge variant="outline" className="text-[10px] px-1.5 h-5 border-blue-300 text-blue-600">
                           施設 {customer.same_facility_customer_ids.length}
                         </Badge>
                       ) : null}
-                      {customer.same_household_customer_ids.length === 0 && customer.same_facility_customer_ids.length === 0 && '-'}
+                      {(customer.same_household_customer_ids?.length ?? 0) === 0 && (customer.same_facility_customer_ids?.length ?? 0) === 0 && '-'}
                     </div>
                   </TableCell>
                   {canEditCustomers && (

--- a/web/src/hooks/useCustomers.ts
+++ b/web/src/hooks/useCustomers.ts
@@ -18,6 +18,12 @@ export function useCustomers() {
         const map = new Map<string, Customer>();
         snapshot.forEach((doc) => {
           const data = convertTimestamps<Customer>({ id: doc.id, ...doc.data() });
+          // 既存ドキュメントに欠落している可能性がある配列フィールドを補完
+          data.ng_staff_ids ??= [];
+          data.preferred_staff_ids ??= [];
+          data.allowed_staff_ids ??= [];
+          data.same_household_customer_ids ??= [];
+          data.same_facility_customer_ids ??= [];
           map.set(doc.id, data);
         });
         setCustomers(map);


### PR DESCRIPTION
## Summary

- 本番環境 `/masters/customers/` で "Application error: a client-side exception has occurred" が発生
- **根本原因**: PR #198 で追加した `same_household_customer_ids` / `same_facility_customer_ids` の `.length` アクセスに、既存Firestoreドキュメント（フィールド未保持）に対する防御がなかった
- **修正**:
  - データ層（`useCustomers.ts`）: 配列フィールド5種にデフォルト値補完（`??= []`）
  - ビュー層（`page.tsx`）: オプショナルチェーン追加（多層防御）

## Test plan

- [x] `tsc --noEmit` 通過
- [x] Vitest 562テスト全通過
- [ ] CI全ジョブGREEN
- [ ] 本番デプロイ後、`/masters/customers/` が正常表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)