### PR TITLE
fix: Customer配列フィールド欠落による全クラッシュ箇所を網羅修正

### DIFF
--- a/web/e2e/schedule-allowed-staff.spec.ts
+++ b/web/e2e/schedule-allowed-staff.spec.ts
@@ -102,10 +102,10 @@ test.describe('allowed_staff_ids 事前チェックダイアログ', () => {
     await expect(dialog.getByText('最適化前の注意')).toBeVisible();
     // C010（吉田勝）の利用者名が表示される
     await expect(dialog.getByText('吉田').first()).toBeVisible();
-    // 月曜の表示
-    await expect(dialog.getByText(/月曜/)).toBeVisible();
+    // 月曜の表示（C010は月曜に2オーダーあるため複数マッチ → first()）
+    await expect(dialog.getByText(/月曜/).first()).toBeVisible();
     // allowed ヘルパー名の表示（設定中: ... → 全員対応不可）
-    await expect(dialog.getByText(/全員対応不可/)).toBeVisible();
+    await expect(dialog.getByText(/全員対応不可/).first()).toBeVisible();
   });
 
   test('「戻って修正する」で警告ダイアログが閉じる', async ({ page }) => {

--- a/web/src/components/masters/customerDetailViewModel.ts
+++ b/web/src/components/masters/customerDetailViewModel.ts
@@ -98,9 +98,9 @@ export function buildCustomerDetailViewModel(
       ? `${customer.name.family_kana ?? ''} ${customer.name.given_kana ?? ''}`.trim()
       : null;
 
-  const preferredSet = new Set(customer.preferred_staff_ids);
+  const preferredSet = new Set(customer.preferred_staff_ids ?? []);
 
-  const ngStaff: ResolvedStaff[] = customer.ng_staff_ids
+  const ngStaff: ResolvedStaff[] = (customer.ng_staff_ids ?? [])
     .filter((id) => helpers.has(id))
     .map((id) => ({
       id,

--- a/web/src/lib/constraints/__tests__/checker.test.ts
+++ b/web/src/lib/constraints/__tests__/checker.test.ts
@@ -537,4 +537,25 @@ describe('checkConstraints', () => {
       expect(violations.some((v) => v.type === 'preferred_staff')).toBe(false);
     });
   });
+
+  describe('Firestore配列フィールド欠落への耐性', () => {
+    it('ng_staff_ids/preferred_staff_ids が undefined でもクラッシュしない', () => {
+      const legacyCustomer = {
+        ...makeCustomer(),
+        ng_staff_ids: undefined,
+        preferred_staff_ids: undefined,
+      } as unknown as Customer;
+      const helpers = new Map([['H001', makeHelper()]]);
+      const customers = new Map([['C001', legacyCustomer]]);
+      expect(() => {
+        checkConstraints({
+          orders: [makeOrder()],
+          helpers,
+          customers,
+          unavailability: [],
+          day: 'monday',
+        });
+      }).not.toThrow();
+    });
+  });
 });

--- a/web/src/lib/constraints/checker.ts
+++ b/web/src/lib/constraints/checker.ts
@@ -78,7 +78,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
       if (!helper) continue;
 
       // NGスタッフ
-      if (customer?.ng_staff_ids.includes(staffId)) {
+      if (customer?.ng_staff_ids?.includes(staffId)) {
         addViolation({
           orderId: order.id,
           staffId,
@@ -133,7 +133,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
       }
 
       // 推奨スタッフ外
-      if (customer && customer.preferred_staff_ids.length > 0 && !customer.preferred_staff_ids.includes(staffId)) {
+      if (customer && (customer.preferred_staff_ids?.length ?? 0) > 0 && !customer.preferred_staff_ids.includes(staffId)) {
         addViolation({
           orderId: order.id,
           staffId,

--- a/web/src/lib/dnd/__tests__/validation.test.ts
+++ b/web/src/lib/dnd/__tests__/validation.test.ts
@@ -567,4 +567,17 @@ describe('validateDrop', () => {
       expect(result.allowed).toBe(false);
     });
   });
+
+  describe('Firestore配列フィールド欠落への耐性', () => {
+    it('ng_staff_ids/preferred_staff_ids が undefined でもクラッシュしない', () => {
+      const input = baseInput();
+      const legacyCustomer = {
+        ...makeCustomer(),
+        ng_staff_ids: undefined,
+        preferred_staff_ids: undefined,
+      } as unknown as Customer;
+      input.customers = new Map([['cust-1', legacyCustomer]]);
+      expect(() => validateDrop(input)).not.toThrow();
+    });
+  });
 });

--- a/web/src/lib/dnd/validation.ts
+++ b/web/src/lib/dnd/validation.ts
@@ -56,7 +56,7 @@ export function validateDrop(input: ValidateDropInput): DropValidationResult {
   }
 
   // NGスタッフ
-  if (customer?.ng_staff_ids.includes(targetHelperId)) {
+  if (customer?.ng_staff_ids?.includes(targetHelperId)) {
     return { allowed: false, reason: `${helper.name.family} はNGスタッフです` };
   }
 
@@ -135,7 +135,7 @@ export function validateDrop(input: ValidateDropInput): DropValidationResult {
   }
 
   // 推奨スタッフ外 → 警告
-  if (customer && customer.preferred_staff_ids.length > 0 && !customer.preferred_staff_ids.includes(targetHelperId)) {
+  if (customer && (customer.preferred_staff_ids?.length ?? 0) > 0 && !customer.preferred_staff_ids.includes(targetHelperId)) {
     warnings.push(`${helper.name.family} は推奨スタッフ外です`);
   }
 

--- a/web/src/lib/validation/allowed-staff-check.test.ts
+++ b/web/src/lib/validation/allowed-staff-check.test.ts
@@ -303,4 +303,21 @@ describe('checkAllowedStaff', () => {
       expect(result[0].customer_id).toBe('C002');
     });
   });
+
+  describe('Firestore配列フィールド欠落への耐性', () => {
+    it('allowed_staff_ids が undefined でもクラッシュしない', () => {
+      const legacyCustomer = {
+        ...makeCustomer({ id: 'C001' }),
+        allowed_staff_ids: undefined,
+      } as unknown as Customer;
+      expect(() => {
+        checkAllowedStaff({
+          customers: new Map([['C001', legacyCustomer]]),
+          helpers: new Map([['H001', makeHelper({ id: 'H001' })]]),
+          orders: [makeOrder({ id: 'O001', customer_id: 'C001' })],
+          unavailability: [],
+        });
+      }).not.toThrow();
+    });
+  });
 });

--- a/web/src/lib/validation/allowed-staff-check.ts
+++ b/web/src/lib/validation/allowed-staff-check.ts
@@ -90,7 +90,7 @@ export function checkAllowedStaff(input: CheckAllowedStaffInput): AllowedStaffWa
 
   for (const order of input.orders) {
     const customer = input.customers.get(order.customer_id);
-    if (!customer || customer.allowed_staff_ids.length === 0) continue;
+    if (!customer || (customer.allowed_staff_ids?.length ?? 0) === 0) continue;
 
     const dayOfWeek = getDayOfWeek(order.date);
 


### PR DESCRIPTION
## Summary

PR #201 で `useCustomers` データ層 + `page.tsx` ビュー層のみ修正したが、
ライブラリ層にも同様の未ガード箇所が残っていた。全箇所を網羅的に調査・修正。

### 修正対象（8箇所）

| ファイル | 箇所 | 問題 |
|---------|------|------|
| `checker.ts:81` | `customer?.ng_staff_ids.includes()` | `?.` で customer のみ null check、`ng_staff_ids` は未ガード |
| `checker.ts:136` | `customer.preferred_staff_ids.length` | 同上 |
| `validation.ts:59` | `customer?.ng_staff_ids.includes()` | 同上 |
| `validation.ts:138` | `customer.preferred_staff_ids.length` | 同上 |
| `allowed-staff-check.ts:93` | `customer.allowed_staff_ids.length` | undefined でクラッシュ |
| `customerDetailViewModel.ts:101` | `new Set(customer.preferred_staff_ids)` | undefined でクラッシュ |
| `customerDetailViewModel.ts:103` | `customer.ng_staff_ids.filter()` | undefined でクラッシュ |
| `schedule-allowed-staff.spec.ts:106,108` | `getByText(/月曜/)`, `getByText(/全員対応不可/)` | strict mode違反（E2E CI失敗） |

### 対応内容
- TDD: 再現テスト3件追加（RED確認済み）→ 修正 → GREEN
- 全565テスト通過、tsc --noEmit 通過

## Test plan

- [x] 再現テスト3件追加（checker / validation / allowed-staff-check）
- [x] Vitest 565テスト全通過
- [x] `tsc --noEmit` 通過
- [ ] CI全ジョブGREEN（E2E含む）
- [ ] 本番デプロイ後、`/masters/customers/` 正常表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)