### PR TITLE
test: カバレッジギャップを埋める14テストファイル追加（865→972テスト）

### DIFF
--- a/web/src/components/onboarding/__tests__/WelcomeDialog.test.tsx
+++ b/web/src/components/onboarding/__tests__/WelcomeDialog.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WelcomeDialog } from '../WelcomeDialog';
+import { welcomeSteps } from '../welcomeSteps';
+
+// ── モック ──────────────────────────────────────────────────────
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open, onOpenChange }: { children: React.ReactNode; open?: boolean; onOpenChange?: (open: boolean) => void }) => {
+    if (open === false) return null;
+    return <div data-testid="dialog" data-on-open-change={onOpenChange ? 'true' : undefined}>{children}</div>;
+  },
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, ...props }: { children: React.ReactNode; onClick?: () => void; variant?: string; size?: string; className?: string }) => (
+    <button onClick={onClick} {...props}>{children}</button>
+  ),
+}));
+
+// ── テスト ──────────────────────────────────────────────────────
+
+describe('WelcomeDialog', () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('open=falseの場合、ダイアログが表示されない', () => {
+    render(<WelcomeDialog open={false} onClose={mockOnClose} />);
+    expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
+  });
+
+  it('open=trueの場合、ダイアログが表示される', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    expect(screen.getByTestId('dialog')).toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    expect(screen.getByText('VisitCare シフト最適化の使い方')).toBeInTheDocument();
+  });
+
+  it('最初のステップでステップ番号が表示される', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    expect(screen.getByText(`ステップ 1 / ${welcomeSteps.length}`)).toBeInTheDocument();
+  });
+
+  it('最初のステップでは「スキップ」ボタンが表示される', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    expect(screen.getByText('スキップ')).toBeInTheDocument();
+  });
+
+  it('最初のステップでは「次へ」ボタンが表示される', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    expect(screen.getByText('次へ')).toBeInTheDocument();
+  });
+
+  it('「次へ」をクリックすると次のステップに進む', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    fireEvent.click(screen.getByText('次へ'));
+    expect(screen.getByText(`ステップ 2 / ${welcomeSteps.length}`)).toBeInTheDocument();
+  });
+
+  it('2番目のステップでは「前へ」ボタンが表示される', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    fireEvent.click(screen.getByText('次へ'));
+    expect(screen.getByText('前へ')).toBeInTheDocument();
+  });
+
+  it('「前へ」をクリックすると前のステップに戻る', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    fireEvent.click(screen.getByText('次へ'));
+    expect(screen.getByText(`ステップ 2 / ${welcomeSteps.length}`)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('前へ'));
+    expect(screen.getByText(`ステップ 1 / ${welcomeSteps.length}`)).toBeInTheDocument();
+  });
+
+  it('最後のステップで「始める」ボタンが表示される', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    // 最後のステップまで進む
+    for (let i = 0; i < welcomeSteps.length - 1; i++) {
+      fireEvent.click(screen.getByText('次へ'));
+    }
+    expect(screen.getByText('始める')).toBeInTheDocument();
+  });
+
+  it('最後のステップで「始める」をクリックするとonCloseが呼ばれる', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    for (let i = 0; i < welcomeSteps.length - 1; i++) {
+      fireEvent.click(screen.getByText('次へ'));
+    }
+    fireEvent.click(screen.getByText('始める'));
+    expect(mockOnClose).toHaveBeenCalledOnce();
+  });
+
+  it('「スキップ」をクリックするとonCloseが呼ばれる', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    fireEvent.click(screen.getByText('スキップ'));
+    expect(mockOnClose).toHaveBeenCalledOnce();
+  });
+
+  it('ドットインジケーターがステップ数分表示される', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    const dots = screen.getAllByRole('button', { name: /ステップ \d+/ });
+    expect(dots).toHaveLength(welcomeSteps.length);
+  });
+
+  it('ドットインジケーターをクリックすると対応するステップに移動する', () => {
+    render(<WelcomeDialog open={true} onClose={mockOnClose} />);
+    const dot3 = screen.getByRole('button', { name: 'ステップ 3' });
+    fireEvent.click(dot3);
+    expect(screen.getByText(`ステップ 3 / ${welcomeSteps.length}`)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/onboarding/__tests__/WelcomeStepContent.test.tsx
+++ b/web/src/components/onboarding/__tests__/WelcomeStepContent.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WelcomeStepContent } from '../WelcomeStepContent';
+import type { WelcomeStep } from '../welcomeSteps';
+
+const MockIcon = ({ className }: { className?: string }) => (
+  <svg data-testid="mock-icon" className={className} />
+);
+
+const createStep = (overrides?: Partial<WelcomeStep>): WelcomeStep => ({
+  icon: MockIcon as unknown as WelcomeStep['icon'],
+  iconBg: 'bg-primary/10',
+  iconColor: 'text-primary',
+  title: 'テストステップ',
+  description: 'テストの説明文です。',
+  details: ['詳細1', '詳細2', '詳細3'],
+  ...overrides,
+});
+
+describe('WelcomeStepContent', () => {
+  it('タイトルが表示される', () => {
+    render(<WelcomeStepContent step={createStep()} />);
+    expect(screen.getByText('テストステップ')).toBeInTheDocument();
+  });
+
+  it('説明文が表示される', () => {
+    render(<WelcomeStepContent step={createStep()} />);
+    expect(screen.getByText('テストの説明文です。')).toBeInTheDocument();
+  });
+
+  it('詳細リストが全て表示される', () => {
+    render(<WelcomeStepContent step={createStep()} />);
+    expect(screen.getByText('詳細1')).toBeInTheDocument();
+    expect(screen.getByText('詳細2')).toBeInTheDocument();
+    expect(screen.getByText('詳細3')).toBeInTheDocument();
+  });
+
+  it('アイコンが表示される', () => {
+    render(<WelcomeStepContent step={createStep()} />);
+    expect(screen.getByTestId('mock-icon')).toBeInTheDocument();
+  });
+
+  it('アイコンにiconColorクラスが適用される', () => {
+    render(<WelcomeStepContent step={createStep({ iconColor: 'text-sky-500' })} />);
+    const icon = screen.getByTestId('mock-icon');
+    expect(icon.getAttribute('class')).toContain('text-sky-500');
+  });
+
+  it('details が1件のみの場合でも正しく表示される', () => {
+    render(<WelcomeStepContent step={createStep({ details: ['唯一の詳細'] })} />);
+    expect(screen.getByText('唯一の詳細')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/onboarding/__tests__/useWelcomeDialog.test.ts
+++ b/web/src/components/onboarding/__tests__/useWelcomeDialog.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useWelcomeDialog } from '../useWelcomeDialog';
+
+const STORAGE_KEY = 'visitcare-welcome-shown';
+
+describe('useWelcomeDialog', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('初回訪問: welcomeOpen=trueになる', () => {
+    const { result } = renderHook(() => useWelcomeDialog());
+    expect(result.current.welcomeOpen).toBe(true);
+  });
+
+  it('既にshown済み: welcomeOpen=falseになる', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    const { result } = renderHook(() => useWelcomeDialog());
+    expect(result.current.welcomeOpen).toBe(false);
+  });
+
+  it('closeWelcome: welcomeOpenがfalseになりlocalStorageに保存される', () => {
+    const { result } = renderHook(() => useWelcomeDialog());
+    expect(result.current.welcomeOpen).toBe(true);
+
+    act(() => {
+      result.current.closeWelcome();
+    });
+
+    expect(result.current.welcomeOpen).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('reopenWelcome: welcomeOpenがtrueに戻る', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    const { result } = renderHook(() => useWelcomeDialog());
+    expect(result.current.welcomeOpen).toBe(false);
+
+    act(() => {
+      result.current.reopenWelcome();
+    });
+
+    expect(result.current.welcomeOpen).toBe(true);
+  });
+
+  it('closeWelcome後にreopenWelcome: 再度trueになる', () => {
+    const { result } = renderHook(() => useWelcomeDialog());
+
+    act(() => {
+      result.current.closeWelcome();
+    });
+    expect(result.current.welcomeOpen).toBe(false);
+
+    act(() => {
+      result.current.reopenWelcome();
+    });
+    expect(result.current.welcomeOpen).toBe(true);
+  });
+
+  it('closeWelcomeとreopenWelcomeは安定した参照を返す', () => {
+    const { result, rerender } = renderHook(() => useWelcomeDialog());
+    const firstClose = result.current.closeWelcome;
+    const firstReopen = result.current.reopenWelcome;
+
+    rerender();
+
+    expect(result.current.closeWelcome).toBe(firstClose);
+    expect(result.current.reopenWelcome).toBe(firstReopen);
+  });
+});

--- a/web/src/components/onboarding/__tests__/welcomeSteps.test.ts
+++ b/web/src/components/onboarding/__tests__/welcomeSteps.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { welcomeSteps } from '../welcomeSteps';
+import type { WelcomeStep } from '../welcomeSteps';
+
+describe('welcomeSteps', () => {
+  it('ステップが1つ以上定義されている', () => {
+    expect(welcomeSteps.length).toBeGreaterThan(0);
+  });
+
+  it('各ステップが必須フィールドを持つ', () => {
+    welcomeSteps.forEach((step: WelcomeStep) => {
+      expect(step.icon).toBeDefined();
+      expect(typeof step.iconBg).toBe('string');
+      expect(typeof step.iconColor).toBe('string');
+      expect(typeof step.title).toBe('string');
+      expect(typeof step.description).toBe('string');
+      expect(Array.isArray(step.details)).toBe(true);
+    });
+  });
+
+  it('各ステップのtitleが空でない', () => {
+    welcomeSteps.forEach((step) => {
+      expect(step.title.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('各ステップのdescriptionが空でない', () => {
+    welcomeSteps.forEach((step) => {
+      expect(step.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('各ステップのdetailsが1つ以上ある', () => {
+    welcomeSteps.forEach((step) => {
+      expect(step.details.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('各ステップのiconがReactコンポーネントとして利用可能である', () => {
+    welcomeSteps.forEach((step) => {
+      expect(step.icon).toBeDefined();
+      // LucideIcon is a ForwardRef object or function depending on the build
+      expect(['function', 'object']).toContain(typeof step.icon);
+    });
+  });
+
+  it('ステップのtitleが重複していない', () => {
+    const titles = welcomeSteps.map((s) => s.title);
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+
+  it('8つのステップが定義されている', () => {
+    expect(welcomeSteps).toHaveLength(8);
+  });
+});

--- a/web/src/components/report/__tests__/CustomerSummaryTable.test.tsx
+++ b/web/src/components/report/__tests__/CustomerSummaryTable.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CustomerSummaryTable } from '../CustomerSummaryTable';
+import type { CustomerSummaryRow } from '@/lib/report/aggregation';
+
+function makeRow(overrides: Partial<CustomerSummaryRow> & { customerId: string }): CustomerSummaryRow {
+  return {
+    name: '田中 太郎',
+    visitCount: 5,
+    totalMinutes: 120,
+    ...overrides,
+  };
+}
+
+describe('CustomerSummaryTable', () => {
+  it('セクションタイトルが表示される', () => {
+    render(<CustomerSummaryTable rows={[]} />);
+    expect(screen.getByText('利用者別サービス実績')).toBeInTheDocument();
+  });
+
+  it('空配列のとき「データなし」が表示される', () => {
+    render(<CustomerSummaryTable rows={[]} />);
+    expect(screen.getByText('データなし')).toBeInTheDocument();
+    expect(screen.getByText('0名')).toBeInTheDocument();
+  });
+
+  it('行データが正しく表示される', () => {
+    const rows: CustomerSummaryRow[] = [
+      makeRow({ customerId: 'c1', name: '佐藤 花子', visitCount: 3, totalMinutes: 90 }),
+      makeRow({ customerId: 'c2', name: '鈴木 一郎', visitCount: 7, totalMinutes: 180 }),
+    ];
+    render(<CustomerSummaryTable rows={rows} />);
+
+    expect(screen.getByText('2名')).toBeInTheDocument();
+    expect(screen.getByText('佐藤 花子')).toBeInTheDocument();
+    expect(screen.getByText('3件')).toBeInTheDocument();
+    expect(screen.getByText('1時間30分')).toBeInTheDocument();
+    expect(screen.getByText('鈴木 一郎')).toBeInTheDocument();
+    expect(screen.getByText('7件')).toBeInTheDocument();
+    expect(screen.getByText('3時間')).toBeInTheDocument();
+  });
+
+  it('テーブルヘッダーが表示される', () => {
+    const rows = [makeRow({ customerId: 'c1' })];
+    render(<CustomerSummaryTable rows={rows} />);
+
+    expect(screen.getByText('氏名')).toBeInTheDocument();
+    expect(screen.getByText('訪問件数')).toBeInTheDocument();
+    expect(screen.getByText('合計時間')).toBeInTheDocument();
+  });
+
+  it('ちょうど0分のとき「0時間」と表示される', () => {
+    const rows = [makeRow({ customerId: 'c1', totalMinutes: 0 })];
+    render(<CustomerSummaryTable rows={rows} />);
+    expect(screen.getByText('0時間')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/report/__tests__/ExportButton.test.tsx
+++ b/web/src/components/report/__tests__/ExportButton.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ExportButton } from '../ExportButton';
+
+// ── モック ─────────────────────────────────────────────────────
+
+const mockExportReport = vi.fn();
+vi.mock('@/lib/api/optimizer', () => ({
+  exportReport: (...args: unknown[]) => mockExportReport(...args),
+  OptimizeApiError: class OptimizeApiError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'OptimizeApiError';
+    }
+  },
+}));
+
+vi.mock('@/lib/firebase', () => ({
+  getFirebaseAuth: () => ({
+    currentUser: { email: 'test@example.com' },
+  }),
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockExportReport.mockReset();
+});
+
+describe('ExportButton', () => {
+  const month = new Date('2026-03-01');
+
+  it('初期状態で「Sheetsに出力」と表示される', () => {
+    render(<ExportButton month={month} />);
+    expect(screen.getByText('Sheetsに出力')).toBeInTheDocument();
+  });
+
+  it('aria-labelが設定されている', () => {
+    render(<ExportButton month={month} />);
+    expect(screen.getByLabelText('Google Sheetsにエクスポート')).toBeInTheDocument();
+  });
+
+  it('クリック時にexportReportが呼ばれる', async () => {
+    mockExportReport.mockResolvedValue({ spreadsheet_url: 'https://docs.google.com/spreadsheets/test' });
+    const windowOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<ExportButton month={month} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(mockExportReport).toHaveBeenCalledWith({
+        year_month: '2026-03',
+        user_email: 'test@example.com',
+      });
+    });
+
+    await waitFor(() => {
+      expect(windowOpen).toHaveBeenCalledWith(
+        'https://docs.google.com/spreadsheets/test',
+        '_blank',
+        'noopener,noreferrer',
+      );
+    });
+
+    windowOpen.mockRestore();
+  });
+
+  it('エクスポート失敗時にエラーメッセージが表示される', async () => {
+    mockExportReport.mockRejectedValue(new Error('network error'));
+
+    render(<ExportButton month={month} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('エクスポートに失敗しました');
+  });
+
+  it('ローディング中は「エクスポート中...」と表示されボタンが無効化される', async () => {
+    let resolveExport!: (value: unknown) => void;
+    mockExportReport.mockReturnValue(
+      new Promise((resolve) => {
+        resolveExport = resolve;
+      }),
+    );
+
+    render(<ExportButton month={month} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('エクスポート中...')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button')).toBeDisabled();
+
+    // cleanup
+    resolveExport({ spreadsheet_url: 'https://example.com' });
+  });
+});

--- a/web/src/components/report/__tests__/MonthSelector.test.tsx
+++ b/web/src/components/report/__tests__/MonthSelector.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MonthSelector } from '../MonthSelector';
+
+describe('MonthSelector', () => {
+  const month = new Date('2026-03-01');
+
+  it('現在の年月が表示される', () => {
+    render(<MonthSelector month={month} onChange={vi.fn()} />);
+    expect(screen.getByText('2026年3月')).toBeInTheDocument();
+  });
+
+  it('前月ボタンをクリックすると1ヶ月前の日付でonChangeが呼ばれる', () => {
+    const onChange = vi.fn();
+    render(<MonthSelector month={month} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('前月'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const called = onChange.mock.calls[0][0] as Date;
+    expect(called.getFullYear()).toBe(2026);
+    expect(called.getMonth()).toBe(1); // February = 1
+  });
+
+  it('次月ボタンをクリックすると1ヶ月後の日付でonChangeが呼ばれる', () => {
+    const onChange = vi.fn();
+    render(<MonthSelector month={month} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('次月'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const called = onChange.mock.calls[0][0] as Date;
+    expect(called.getFullYear()).toBe(2026);
+    expect(called.getMonth()).toBe(3); // April = 3
+  });
+
+  it('年末の場合に正しく年をまたぐ', () => {
+    const december = new Date('2026-12-01');
+    const onChange = vi.fn();
+    render(<MonthSelector month={december} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('次月'));
+
+    const called = onChange.mock.calls[0][0] as Date;
+    expect(called.getFullYear()).toBe(2027);
+    expect(called.getMonth()).toBe(0); // January = 0
+  });
+});

--- a/web/src/components/report/__tests__/ServiceTypeSummaryCard.test.tsx
+++ b/web/src/components/report/__tests__/ServiceTypeSummaryCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ServiceTypeSummaryCard } from '../ServiceTypeSummaryCard';
+import type { ServiceTypeSummaryItem } from '@/lib/report/aggregation';
+
+function makeItem(overrides: Partial<ServiceTypeSummaryItem> = {}): ServiceTypeSummaryItem {
+  return {
+    serviceType: 'physical_care',
+    label: '身体介護',
+    visitCount: 10,
+    totalMinutes: 300,
+    ...overrides,
+  };
+}
+
+describe('ServiceTypeSummaryCard', () => {
+  it('セクションタイトルが表示される', () => {
+    render(<ServiceTypeSummaryCard items={[]} totalMinutes={0} />);
+    expect(screen.getByText('サービス種別内訳')).toBeInTheDocument();
+  });
+
+  it('空配列のとき「データなし」が表示される', () => {
+    render(<ServiceTypeSummaryCard items={[]} totalMinutes={0} />);
+    expect(screen.getByText('データなし')).toBeInTheDocument();
+  });
+
+  it('各サービス種別のラベル・件数・時間・パーセントが表示される', () => {
+    const items: ServiceTypeSummaryItem[] = [
+      makeItem({ serviceType: 'physical_care', label: '身体介護', visitCount: 6, totalMinutes: 180 }),
+      makeItem({ serviceType: 'daily_living', label: '生活援助', visitCount: 4, totalMinutes: 120 }),
+    ];
+    render(<ServiceTypeSummaryCard items={items} totalMinutes={300} />);
+
+    expect(screen.getByText('身体介護')).toBeInTheDocument();
+    expect(screen.getByText('6件')).toBeInTheDocument();
+    expect(screen.getByText('3時間')).toBeInTheDocument();
+    expect(screen.getByText('60%')).toBeInTheDocument();
+
+    expect(screen.getByText('生活援助')).toBeInTheDocument();
+    expect(screen.getByText('4件')).toBeInTheDocument();
+    expect(screen.getByText('2時間')).toBeInTheDocument();
+    expect(screen.getByText('40%')).toBeInTheDocument();
+  });
+
+  it('totalMinutesが0のときパーセントが0%になる', () => {
+    const items = [makeItem({ totalMinutes: 60 })];
+    render(<ServiceTypeSummaryCard items={items} totalMinutes={0} />);
+    expect(screen.getByText('0%')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/report/__tests__/StaffSummaryTable.test.tsx
+++ b/web/src/components/report/__tests__/StaffSummaryTable.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StaffSummaryTable } from '../StaffSummaryTable';
+import type { StaffSummaryRow } from '@/lib/report/aggregation';
+
+function makeRow(overrides: Partial<StaffSummaryRow> & { helperId: string }): StaffSummaryRow {
+  return {
+    name: '佐藤 太郎',
+    visitCount: 5,
+    totalMinutes: 120,
+    ...overrides,
+  };
+}
+
+describe('StaffSummaryTable', () => {
+  it('セクションタイトルが表示される', () => {
+    render(<StaffSummaryTable rows={[]} />);
+    expect(screen.getByText('スタッフ別稼働時間')).toBeInTheDocument();
+  });
+
+  it('空配列のとき「データなし」が表示される', () => {
+    render(<StaffSummaryTable rows={[]} />);
+    expect(screen.getByText('データなし')).toBeInTheDocument();
+    expect(screen.getByText('0名')).toBeInTheDocument();
+  });
+
+  it('行データが正しく表示される', () => {
+    const rows: StaffSummaryRow[] = [
+      makeRow({ helperId: 'h1', name: '山田 太郎', visitCount: 10, totalMinutes: 300 }),
+      makeRow({ helperId: 'h2', name: '田中 花子', visitCount: 4, totalMinutes: 75 }),
+    ];
+    render(<StaffSummaryTable rows={rows} />);
+
+    expect(screen.getByText('2名')).toBeInTheDocument();
+    expect(screen.getByText('山田 太郎')).toBeInTheDocument();
+    expect(screen.getByText('10件')).toBeInTheDocument();
+    expect(screen.getByText('5時間')).toBeInTheDocument();
+    expect(screen.getByText('田中 花子')).toBeInTheDocument();
+    expect(screen.getByText('4件')).toBeInTheDocument();
+    expect(screen.getByText('1時間15分')).toBeInTheDocument();
+  });
+
+  it('テーブルヘッダーが表示される', () => {
+    const rows = [makeRow({ helperId: 'h1' })];
+    render(<StaffSummaryTable rows={rows} />);
+
+    expect(screen.getByText('氏名')).toBeInTheDocument();
+    expect(screen.getByText('訪問件数')).toBeInTheDocument();
+    expect(screen.getByText('稼働時間')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/report/__tests__/StatusSummaryCard.test.tsx
+++ b/web/src/components/report/__tests__/StatusSummaryCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusSummaryCard } from '../StatusSummaryCard';
+import type { StatusSummary } from '@/lib/report/aggregation';
+
+function makeSummary(overrides: Partial<StatusSummary> = {}): StatusSummary {
+  return {
+    pending: 0,
+    assigned: 0,
+    completed: 0,
+    cancelled: 0,
+    total: 0,
+    completionRate: 0,
+    ...overrides,
+  };
+}
+
+describe('StatusSummaryCard', () => {
+  it('セクションタイトルが表示される', () => {
+    render(<StatusSummaryCard summary={makeSummary()} />);
+    expect(screen.getByText('実績確認ステータス')).toBeInTheDocument();
+  });
+
+  it('合計件数が表示される', () => {
+    render(<StatusSummaryCard summary={makeSummary({ total: 42 })} />);
+    expect(screen.getByText('合計 42件')).toBeInTheDocument();
+  });
+
+  it('完了率が表示される', () => {
+    render(<StatusSummaryCard summary={makeSummary({ completionRate: 75 })} />);
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+
+  it('各ステータスの件数が表示される', () => {
+    const summary = makeSummary({
+      completed: 10,
+      assigned: 5,
+      pending: 3,
+      cancelled: 2,
+      total: 20,
+      completionRate: 56,
+    });
+    render(<StatusSummaryCard summary={summary} />);
+
+    expect(screen.getByText('実績確認済')).toBeInTheDocument();
+    expect(screen.getByText('10件')).toBeInTheDocument();
+    expect(screen.getByText('割当済')).toBeInTheDocument();
+    expect(screen.getByText('5件')).toBeInTheDocument();
+    expect(screen.getByText('未割当')).toBeInTheDocument();
+    expect(screen.getByText('3件')).toBeInTheDocument();
+    expect(screen.getByText('キャンセル')).toBeInTheDocument();
+    expect(screen.getByText('2件')).toBeInTheDocument();
+  });
+
+  it('完了率ラベルが表示される', () => {
+    render(<StatusSummaryCard summary={makeSummary()} />);
+    expect(screen.getByText('実績確認率（キャンセル除く）')).toBeInTheDocument();
+  });
+
+  it('全て0件の場合でも正しく表示される', () => {
+    const summary = makeSummary({ total: 0, completionRate: 0 });
+    render(<StatusSummaryCard summary={summary} />);
+    expect(screen.getByText('合計 0件')).toBeInTheDocument();
+    expect(screen.getByText('0%')).toBeInTheDocument();
+  });
+});

--- a/web/src/contexts/__tests__/ScheduleContext.test.tsx
+++ b/web/src/contexts/__tests__/ScheduleContext.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+// date-fnsのstartOfWeek/addWeeks/subWeeksは実物を使う（純粋関数）
+// localStorageモックはjsdom標準で利用可能
+
+import { ScheduleProvider, useScheduleContext } from '../ScheduleContext';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ScheduleProvider>{children}</ScheduleProvider>;
+}
+
+describe('ScheduleContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // 2025-01-06 (Monday) に固定
+    vi.setSystemTime(new Date(2025, 0, 6, 10, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- Provider ---
+
+  it('Provider なしで useScheduleContext を呼ぶとエラーになる', () => {
+    expect(() => {
+      renderHook(() => useScheduleContext());
+    }).toThrow('useScheduleContext must be used within ScheduleProvider');
+  });
+
+  it('Provider 内で useScheduleContext がコンテキスト値を返す', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+
+    expect(result.current.weekStart).toBeInstanceOf(Date);
+    expect(result.current.selectedDay).toBeDefined();
+    expect(result.current.viewMode).toBe('day');
+    expect(result.current.ganttAxis).toBe('staff');
+  });
+
+  // --- weekStart 初期値 ---
+
+  it('weekStart が現在の週の月曜日に初期化される', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+
+    // 2025-01-06 は月曜日
+    expect(result.current.weekStart.getFullYear()).toBe(2025);
+    expect(result.current.weekStart.getMonth()).toBe(0);
+    expect(result.current.weekStart.getDate()).toBe(6);
+    expect(result.current.weekStart.getDay()).toBe(1); // Monday
+  });
+
+  // --- selectedDay 初期値 ---
+
+  it('selectedDay が現在の曜日に初期化される（月曜日の場合 monday）', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+    expect(result.current.selectedDay).toBe('monday');
+  });
+
+  // --- goToNextWeek / goToPrevWeek ---
+
+  it('goToNextWeek で weekStart が1週間進む', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+
+    act(() => {
+      result.current.goToNextWeek();
+    });
+
+    expect(result.current.weekStart.getDate()).toBe(13);
+  });
+
+  it('goToPrevWeek で weekStart が1週間戻る', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+
+    act(() => {
+      result.current.goToPrevWeek();
+    });
+
+    // 2024-12-30 (前週の月曜日)
+    expect(result.current.weekStart.getFullYear()).toBe(2024);
+    expect(result.current.weekStart.getMonth()).toBe(11);
+    expect(result.current.weekStart.getDate()).toBe(30);
+  });
+
+  // --- goToWeek ---
+
+  it('goToWeek で指定日の週の月曜日に移動する', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+
+    act(() => {
+      // 2025-02-19 (水曜日) → 2025-02-17 (月曜日)
+      result.current.goToWeek(new Date(2025, 1, 19));
+    });
+
+    expect(result.current.weekStart.getMonth()).toBe(1);
+    expect(result.current.weekStart.getDate()).toBe(17);
+    expect(result.current.weekStart.getDay()).toBe(1);
+  });
+
+  // --- setSelectedDay ---
+
+  it('setSelectedDay で曜日を変更できる', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+
+    act(() => {
+      result.current.setSelectedDay('friday');
+    });
+
+    expect(result.current.selectedDay).toBe('friday');
+  });
+
+  // --- viewMode ---
+
+  it('setViewMode で day/week を切り替えられる', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+    expect(result.current.viewMode).toBe('day');
+
+    act(() => {
+      result.current.setViewMode('week');
+    });
+
+    expect(result.current.viewMode).toBe('week');
+  });
+
+  // --- ganttAxis + localStorage ---
+
+  it('ganttAxis のデフォルトは staff', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+    expect(result.current.ganttAxis).toBe('staff');
+  });
+
+  it('setGanttAxis で customer に変更すると localStorage にも保存される', () => {
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+
+    act(() => {
+      result.current.setGanttAxis('customer');
+    });
+
+    expect(result.current.ganttAxis).toBe('customer');
+    expect(localStorage.getItem('ganttAxis')).toBe('customer');
+  });
+
+  it('localStorage に保存済みの ganttAxis が初期値として読み込まれる', () => {
+    localStorage.setItem('ganttAxis', 'customer');
+
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+    expect(result.current.ganttAxis).toBe('customer');
+  });
+
+  it('localStorage に無効な値がある場合はデフォルト staff になる', () => {
+    localStorage.setItem('ganttAxis', 'invalid');
+
+    const { result } = renderHook(() => useScheduleContext(), { wrapper });
+    expect(result.current.ganttAxis).toBe('staff');
+  });
+});

--- a/web/src/hooks/__tests__/useServiceTypes.test.ts
+++ b/web/src/hooks/__tests__/useServiceTypes.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Firestore モック ---
+
+let snapshotCallback: ((snapshot: unknown) => void) | null = null;
+let errorCallback: ((err: Error) => void) | null = null;
+const mockUnsubscribe = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  onSnapshot: vi.fn((_q: unknown, onNext: (snapshot: unknown) => void, onError: (err: Error) => void) => {
+    snapshotCallback = onNext;
+    errorCallback = onError;
+    return mockUnsubscribe;
+  }),
+}));
+
+vi.mock('@/lib/firebase', () => ({
+  getDb: vi.fn(),
+}));
+
+vi.mock('@/lib/firestore-converter', () => ({
+  convertTimestamps: vi.fn(<T>(data: T): T => data),
+}));
+
+import { useServiceTypes } from '../useServiceTypes';
+
+function makeSnapshot(docs: Array<{ id: string; data: () => Record<string, unknown> }>) {
+  return { forEach: (cb: (doc: { id: string; data: () => Record<string, unknown> }) => void) => docs.forEach(cb) };
+}
+
+describe('useServiceTypes', () => {
+  beforeEach(() => {
+    snapshotCallback = null;
+    errorCallback = null;
+    mockUnsubscribe.mockClear();
+  });
+
+  it('初期状態: loading=true, serviceTypes=空Map, sortedList=空配列', () => {
+    const { result } = renderHook(() => useServiceTypes());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.serviceTypes.size).toBe(0);
+    expect(result.current.sortedList).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('onSnapshot成功後: loading=false, serviceTypesにデータが入る', () => {
+    const { result } = renderHook(() => useServiceTypes());
+
+    act(() => {
+      snapshotCallback?.(makeSnapshot([
+        { id: 'ST001', data: () => ({ code: 'ST001', label: 'Physical Care', sort_order: 2 }) },
+        { id: 'ST002', data: () => ({ code: 'ST002', label: 'Daily Living', sort_order: 1 }) },
+      ]));
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.serviceTypes.size).toBe(2);
+    expect(result.current.serviceTypes.get('ST001')).toBeDefined();
+    expect(result.current.serviceTypes.get('ST002')).toBeDefined();
+  });
+
+  it('sortedList が sort_order 昇順でソートされる', () => {
+    const { result } = renderHook(() => useServiceTypes());
+
+    act(() => {
+      snapshotCallback?.(makeSnapshot([
+        { id: 'ST001', data: () => ({ code: 'ST001', label: 'Physical Care', sort_order: 3 }) },
+        { id: 'ST002', data: () => ({ code: 'ST002', label: 'Daily Living', sort_order: 1 }) },
+        { id: 'ST003', data: () => ({ code: 'ST003', label: 'Prevention', sort_order: 2 }) },
+      ]));
+    });
+
+    expect(result.current.sortedList).toHaveLength(3);
+    expect(result.current.sortedList[0].id).toBe('ST002');
+    expect(result.current.sortedList[1].id).toBe('ST003');
+    expect(result.current.sortedList[2].id).toBe('ST001');
+  });
+
+  it('エラー時: error が設定され loading=false になる', () => {
+    const { result } = renderHook(() => useServiceTypes());
+
+    act(() => {
+      errorCallback?.(new Error('Firestore error'));
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('Firestore error');
+  });
+
+  it('アンマウント時: unsubscribeが呼ばれる', () => {
+    const { unmount } = renderHook(() => useServiceTypes());
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('スナップショット更新時: データが置き換わる', () => {
+    const { result } = renderHook(() => useServiceTypes());
+
+    act(() => {
+      snapshotCallback?.(makeSnapshot([
+        { id: 'ST001', data: () => ({ code: 'ST001', label: 'Type A', sort_order: 1 }) },
+      ]));
+    });
+
+    expect(result.current.serviceTypes.size).toBe(1);
+
+    act(() => {
+      snapshotCallback?.(makeSnapshot([
+        { id: 'ST001', data: () => ({ code: 'ST001', label: 'Type A', sort_order: 1 }) },
+        { id: 'ST002', data: () => ({ code: 'ST002', label: 'Type B', sort_order: 2 }) },
+      ]));
+    });
+
+    expect(result.current.serviceTypes.size).toBe(2);
+    expect(result.current.sortedList).toHaveLength(2);
+  });
+});

--- a/web/src/lib/firestore/__tests__/settings.test.ts
+++ b/web/src/lib/firestore/__tests__/settings.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Firestoreモック
+const mockSetDoc = vi.fn();
+const mockServerTimestamp = vi.fn(() => 'MOCK_TIMESTAMP');
+const mockDoc = vi.fn((..._args: any[]) => 'MOCK_DOC_REF');
+
+vi.mock('firebase/firestore', () => ({
+  setDoc: (...args: any[]) => mockSetDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+  doc: (...args: any[]) => mockDoc(...args),
+}));
+
+vi.mock('@/lib/firebase', () => ({
+  getDb: () => 'MOCK_DB',
+}));
+
+import { updateNotificationSettings } from '../settings';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('updateNotificationSettings', () => {
+  it('正常系: setDocが呼ばれる', async () => {
+    mockSetDoc.mockResolvedValueOnce(undefined);
+
+    await updateNotificationSettings({ sender_email: 'test@example.com' });
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('settings/notificationドキュメントに対して書き込む', async () => {
+    mockSetDoc.mockResolvedValueOnce(undefined);
+
+    await updateNotificationSettings({ sender_email: 'test@example.com' });
+    expect(mockDoc).toHaveBeenCalledWith('MOCK_DB', 'settings', 'notification');
+  });
+
+  it('sender_emailが書き込みデータに含まれる', async () => {
+    mockSetDoc.mockResolvedValueOnce(undefined);
+
+    await updateNotificationSettings({ sender_email: 'admin@visitcare.jp' });
+    const writtenData = mockSetDoc.mock.calls[0][1];
+    expect(writtenData.sender_email).toBe('admin@visitcare.jp');
+  });
+
+  it('updated_atにserverTimestampが設定される', async () => {
+    mockSetDoc.mockResolvedValueOnce(undefined);
+
+    await updateNotificationSettings({ sender_email: 'test@example.com' });
+    const writtenData = mockSetDoc.mock.calls[0][1];
+    expect(writtenData.updated_at).toBe('MOCK_TIMESTAMP');
+  });
+
+  it('merge: trueオプションで呼ばれる', async () => {
+    mockSetDoc.mockResolvedValueOnce(undefined);
+
+    await updateNotificationSettings({ sender_email: 'test@example.com' });
+    const options = mockSetDoc.mock.calls[0][2];
+    expect(options).toEqual({ merge: true });
+  });
+
+  it('エラー時: Firestoreエラーがそのまま伝播する', async () => {
+    mockSetDoc.mockRejectedValueOnce(new Error('PERMISSION_DENIED'));
+
+    await expect(
+      updateNotificationSettings({ sender_email: 'test@example.com' })
+    ).rejects.toThrow('PERMISSION_DENIED');
+  });
+});

--- a/web/src/lib/firestore/__tests__/staff-unavailability.test.ts
+++ b/web/src/lib/firestore/__tests__/staff-unavailability.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Firestoreモック
+const mockAddDoc = vi.fn();
+const mockUpdateDoc = vi.fn();
+const mockDeleteDoc = vi.fn();
+const mockServerTimestamp = vi.fn(() => 'MOCK_TIMESTAMP');
+const mockCollection = vi.fn((..._args: any[]) => 'MOCK_COLLECTION_REF');
+const mockDoc = vi.fn((..._args: any[]) => 'MOCK_DOC_REF');
+const mockTimestampFromDate = vi.fn((date: Date) => ({ toDate: () => date, _type: 'Timestamp', _date: date }));
+
+vi.mock('firebase/firestore', () => ({
+  addDoc: (...args: any[]) => mockAddDoc(...args),
+  updateDoc: (...args: any[]) => mockUpdateDoc(...args),
+  deleteDoc: (...args: any[]) => mockDeleteDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+  collection: (...args: any[]) => mockCollection(...args),
+  doc: (...args: any[]) => mockDoc(...args),
+  Timestamp: {
+    fromDate: (date: Date) => mockTimestampFromDate(date),
+  },
+}));
+
+vi.mock('@/lib/firebase', () => ({
+  getDb: () => 'MOCK_DB',
+}));
+
+import {
+  createStaffUnavailability,
+  updateStaffUnavailability,
+  deleteStaffUnavailability,
+} from '../staff-unavailability';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function validInput() {
+  return {
+    staff_id: 'helper-001',
+    week_start_date: new Date('2026-03-09'),
+    unavailable_slots: [
+      { date: new Date('2026-03-10'), all_day: true },
+    ],
+    notes: '通院のため',
+  };
+}
+
+describe('createStaffUnavailability', () => {
+  it('正常系: addDocが呼ばれIDが返る', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'unavail-001' });
+
+    const id = await createStaffUnavailability(validInput());
+    expect(id).toBe('unavail-001');
+  });
+
+  it('staff_unavailabilityコレクションに対して書き込む', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'u1' });
+
+    await createStaffUnavailability(validInput());
+    expect(mockCollection).toHaveBeenCalledWith('MOCK_DB', 'staff_unavailability');
+  });
+
+  it('staff_idが書き込みデータに含まれる', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'u2' });
+
+    await createStaffUnavailability(validInput());
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    expect(writtenData.staff_id).toBe('helper-001');
+  });
+
+  it('week_start_dateがTimestamp.fromDateで変換される', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'u3' });
+
+    const input = validInput();
+    await createStaffUnavailability(input);
+    expect(mockTimestampFromDate).toHaveBeenCalledWith(input.week_start_date);
+  });
+
+  it('unavailable_slotsのdateがTimestamp.fromDateで変換される', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'u4' });
+
+    const input = validInput();
+    await createStaffUnavailability(input);
+    expect(mockTimestampFromDate).toHaveBeenCalledWith(input.unavailable_slots[0].date);
+  });
+
+  it('all_dayスロットにstart_time/end_timeが含まれない', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'u5' });
+
+    await createStaffUnavailability(validInput());
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    const slot = writtenData.unavailable_slots[0];
+    expect(slot.all_day).toBe(true);
+    expect(slot.start_time).toBeUndefined();
+    expect(slot.end_time).toBeUndefined();
+  });
+
+  it('時間指定スロットにstart_time/end_timeが含まれる', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'u6' });
+
+    const input = {
+      ...validInput(),
+      unavailable_slots: [
+        { date: new Date('2026-03-10'), all_day: false, start_time: '09:00', end_time: '12:00' },
+      ],
+    };
+    await createStaffUnavailability(input);
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    const slot = writtenData.unavailable_slots[0];
+    expect(slot.start_time).toBe('09:00');
+    expect(slot.end_time).toBe('12:00');
+  });
+
+  it('notesが未指定の場合nullが設定される', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'u7' });
+
+    const input = { ...validInput(), notes: undefined };
+    await createStaffUnavailability(input);
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    expect(writtenData.notes).toBeNull();
+  });
+
+  it('submitted_atにserverTimestampが設定される', async () => {
+    mockAddDoc.mockResolvedValueOnce({ id: 'u8' });
+
+    await createStaffUnavailability(validInput());
+    const writtenData = mockAddDoc.mock.calls[0][1];
+    expect(writtenData.submitted_at).toBe('MOCK_TIMESTAMP');
+  });
+
+  it('エラー時: Firestoreエラーがそのまま伝播する', async () => {
+    mockAddDoc.mockRejectedValueOnce(new Error('PERMISSION_DENIED'));
+
+    await expect(createStaffUnavailability(validInput())).rejects.toThrow('PERMISSION_DENIED');
+  });
+});
+
+describe('updateStaffUnavailability', () => {
+  it('正常系: updateDocが呼ばれる', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateStaffUnavailability('unavail-001', validInput());
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('正しいドキュメント参照で更新する', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateStaffUnavailability('unavail-123', validInput());
+    expect(mockDoc).toHaveBeenCalledWith('MOCK_DB', 'staff_unavailability', 'unavail-123');
+  });
+
+  it('staff_idが更新データに含まれる', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateStaffUnavailability('u1', validInput());
+    const writtenData = mockUpdateDoc.mock.calls[0][1];
+    expect(writtenData.staff_id).toBe('helper-001');
+  });
+
+  it('week_start_dateがTimestamp.fromDateで変換される', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    const input = validInput();
+    await updateStaffUnavailability('u2', input);
+    expect(mockTimestampFromDate).toHaveBeenCalledWith(input.week_start_date);
+  });
+
+  it('unavailable_slotsが正しく変換される', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    const input = {
+      ...validInput(),
+      unavailable_slots: [
+        { date: new Date('2026-03-11'), all_day: false, start_time: '14:00', end_time: '17:00' },
+      ],
+    };
+    await updateStaffUnavailability('u3', input);
+    const writtenData = mockUpdateDoc.mock.calls[0][1];
+    const slot = writtenData.unavailable_slots[0];
+    expect(slot.all_day).toBe(false);
+    expect(slot.start_time).toBe('14:00');
+    expect(slot.end_time).toBe('17:00');
+  });
+
+  it('submitted_atにserverTimestampが設定される', async () => {
+    mockUpdateDoc.mockResolvedValueOnce(undefined);
+
+    await updateStaffUnavailability('u4', validInput());
+    const writtenData = mockUpdateDoc.mock.calls[0][1];
+    expect(writtenData.submitted_at).toBe('MOCK_TIMESTAMP');
+  });
+
+  it('エラー時: Firestoreエラーがそのまま伝播する', async () => {
+    mockUpdateDoc.mockRejectedValueOnce(new Error('NOT_FOUND'));
+
+    await expect(
+      updateStaffUnavailability('nonexistent', validInput())
+    ).rejects.toThrow('NOT_FOUND');
+  });
+});
+
+describe('deleteStaffUnavailability', () => {
+  it('正常系: deleteDocが呼ばれる', async () => {
+    mockDeleteDoc.mockResolvedValueOnce(undefined);
+
+    await deleteStaffUnavailability('unavail-001');
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('正しいドキュメント参照で削除する', async () => {
+    mockDeleteDoc.mockResolvedValueOnce(undefined);
+
+    await deleteStaffUnavailability('unavail-456');
+    expect(mockDoc).toHaveBeenCalledWith('MOCK_DB', 'staff_unavailability', 'unavail-456');
+  });
+
+  it('エラー時: Firestoreエラーがそのまま伝播する', async () => {
+    mockDeleteDoc.mockRejectedValueOnce(new Error('PERMISSION_DENIED'));
+
+    await expect(deleteStaffUnavailability('unavail-001')).rejects.toThrow('PERMISSION_DENIED');
+  });
+});


### PR DESCRIPTION
## Summary

- Firestore設定・希望休ヘルパーのテスト追加（HIGH優先）
- レポートコンポーネント6ファイルのテスト追加
- オンボーディング4ファイルのテスト追加
- ScheduleContext + useServiceTypes のテスト追加

| グループ | ファイル数 | テスト数 |
|----------|-----------|---------|
| Firestoreヘルパー (HIGH) | 2 | 26 |
| レポートコンポーネント | 6 | 28 |
| オンボーディング | 4 | 34 |
| Context + Hook | 2 | 19 |
| **合計** | **14** | **107** |

## Test plan

- [x] 全972テストがパス（865→972）
- [x] tsc --noEmit: 新規エラーなし
- [x] 97テストファイル全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)