### PR TITLE
fix: 利用者マスタテーブルにallowed_staff_ids表示を追加

### DIFF
--- a/web/src/app/masters/customers/__tests__/page.test.tsx
+++ b/web/src/app/masters/customers/__tests__/page.test.tsx
@@ -1,11 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import CustomersPage from '../page';
 
 // ── モック ──────────────────────────────────────────────────────
 
+const mockCustomers = new Map();
+
 vi.mock('@/hooks/useCustomers', () => ({
-  useCustomers: () => ({ customers: new Map(), loading: false }),
+  useCustomers: () => ({ customers: mockCustomers, loading: false }),
 }));
 
 vi.mock('@/hooks/useHelpers', () => ({
@@ -67,6 +69,10 @@ vi.mock('lucide-react', () => ({
 // ── テスト ──────────────────────────────────────────────────────
 
 describe('利用者マスタページ', () => {
+  beforeEach(() => {
+    mockCustomers.clear();
+  });
+
   it('エラーなくレンダリングされる', () => {
     render(<CustomersPage />);
     expect(screen.getByText('利用者マスタ')).toBeInTheDocument();
@@ -92,5 +98,24 @@ describe('利用者マスタページ', () => {
     expect(screen.getByText('氏名')).toBeInTheDocument();
     expect(screen.getByText('住所')).toBeInTheDocument();
     expect(screen.getByText('サ責')).toBeInTheDocument();
+    expect(screen.getByText('NG/推奨/入れる')).toBeInTheDocument();
+  });
+
+  it('allowed_staff_idsを持つ利用者に「入れる」バッジが表示される', () => {
+    mockCustomers.set('C010', {
+      id: 'C010',
+      name: { family: '吉田', given: '勝', family_kana: 'よしだ', given_kana: 'かつ' },
+      address: '鹿児島市天文館町15-7',
+      service_manager: '鈴木裕子',
+      weekly_services: {},
+      ng_staff_ids: [],
+      preferred_staff_ids: ['H001', 'H009'],
+      allowed_staff_ids: ['H001', 'H009'],
+      same_household_customer_ids: [],
+      same_facility_customer_ids: [],
+    });
+    render(<CustomersPage />);
+    expect(screen.getByText('推奨 2')).toBeInTheDocument();
+    expect(screen.getByText('入れる 2')).toBeInTheDocument();
   });
 });

--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -221,7 +221,7 @@ export default function CustomersPage() {
               <TableHead className="w-36">相談支援事業所</TableHead>
               <TableHead className="w-28">担当相談員</TableHead>
               <TableHead className="w-20 text-center">サービス日数</TableHead>
-              <TableHead className="w-28 text-center">NG/推奨</TableHead>
+              <TableHead className="w-36 text-center">NG/推奨/入れる</TableHead>
               <TableHead className="w-24 text-center">世帯/施設</TableHead>
               {canEditCustomers && <TableHead className="w-10" />}
             </TableRow>
@@ -285,7 +285,7 @@ export default function CustomersPage() {
                     </span>
                   </TableCell>
                   <TableCell className="text-center">
-                    <div className="flex items-center justify-center gap-1">
+                    <div className="flex items-center justify-center gap-1 flex-wrap">
                       {(customer.ng_staff_ids?.length ?? 0) > 0 ? (
                         <Badge variant="destructive" className="text-[10px] px-1.5 h-5">
                           NG {customer.ng_staff_ids.length}
@@ -296,7 +296,12 @@ export default function CustomersPage() {
                           推奨 {customer.preferred_staff_ids.length}
                         </Badge>
                       ) : null}
-                      {(customer.ng_staff_ids?.length ?? 0) === 0 && (customer.preferred_staff_ids?.length ?? 0) === 0 && '-'}
+                      {(customer.allowed_staff_ids?.length ?? 0) > 0 ? (
+                        <Badge variant="outline" className="text-[10px] px-1.5 h-5 border-green-300 text-green-600">
+                          入れる {customer.allowed_staff_ids.length}
+                        </Badge>
+                      ) : null}
+                      {(customer.ng_staff_ids?.length ?? 0) === 0 && (customer.preferred_staff_ids?.length ?? 0) === 0 && (customer.allowed_staff_ids?.length ?? 0) === 0 && '-'}
                     </div>
                   </TableCell>
                   <TableCell className="text-center">


### PR DESCRIPTION
## Summary

- 利用者マスタテーブルの「NG/推奨」列に `allowed_staff_ids`（入れるスタッフ）のカウントが表示されていなかった問題を修正
- 列ヘッダーを「NG/推奨/入れる」に変更
- 緑色の「入れる X」バッジを追加（NG=赤、推奨=グレー、入れる=緑で視覚的に区別）
- テストに `allowed_staff_ids` バッジ表示の確認を追加

## Test plan

- [x] Vitest: 利用者マスタページテスト 6件通過
- [x] tsc --noEmit: 型エラーなし
- [ ] CI全テスト通過確認

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)