### PR TITLE
fix: 利用者詳細シートに推奨スタッフ表示を追加

### DIFF
--- a/web/src/components/masters/CustomerDetailSheet.tsx
+++ b/web/src/components/masters/CustomerDetailSheet.tsx
@@ -143,10 +143,10 @@ export function CustomerDetailSheet({
             </section>
           )}
 
-          {/* 3. NG/入れるスタッフ */}
-          {(vm.ngStaff.length > 0 || vm.allowedStaff.length > 0) && (
+          {/* 3. NG/推奨/入れるスタッフ */}
+          {(vm.ngStaff.length > 0 || vm.preferredStaff.length > 0 || vm.allowedStaff.length > 0) && (
             <section>
-              <SectionHeader>NG / 入れるスタッフ</SectionHeader>
+              <SectionHeader>NG / 推奨 / 入れるスタッフ</SectionHeader>
               <div className="space-y-2">
                 {vm.ngStaff.length > 0 && (
                   <div>
@@ -155,6 +155,18 @@ export function CustomerDetailSheet({
                       {vm.ngStaff.map((s) => (
                         <Badge key={s.id} variant="destructive">
                           {s.name}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {vm.preferredStaff.length > 0 && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">推奨スタッフ</p>
+                    <div className="flex flex-wrap gap-1.5" data-testid="preferred-staff-badges">
+                      {vm.preferredStaff.map((s) => (
+                        <Badge key={s.id} variant="secondary" className="border-amber-300 text-amber-700">
+                          {s.name} ★
                         </Badge>
                       ))}
                     </div>

--- a/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
+++ b/web/src/components/masters/__tests__/CustomerDetailSheet.test.tsx
@@ -22,6 +22,7 @@ function makeVm(overrides: Partial<CustomerDetailViewModel> = {}): CustomerDetai
     serviceManager: '山田太郎',
     genderRequirementLabel: '指定なし',
     ngStaff: [],
+    preferredStaff: [],
     allowedStaff: [],
     householdMembers: [],
     facilityMembers: [],
@@ -128,6 +129,21 @@ describe('CustomerDetailSheet', () => {
     render(<CustomerDetailSheet {...defaultProps} vm={makeVm()} />);
     expect(screen.queryByText('同一世帯')).not.toBeInTheDocument();
     expect(screen.queryByText('同一施設')).not.toBeInTheDocument();
+  });
+
+  it('推奨スタッフのバッジが表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      preferredStaff: [{ id: 'h-4', name: '山本 さくら', isPreferred: true }],
+    })} />);
+    expect(screen.getByTestId('preferred-staff-badges')).toBeInTheDocument();
+    expect(screen.getByText(/山本 さくら/)).toBeInTheDocument();
+  });
+
+  it('推奨スタッフのみの場合でもスタッフセクションが表示される', () => {
+    render(<CustomerDetailSheet {...defaultProps} vm={makeVm({
+      preferredStaff: [{ id: 'h-5', name: '渡辺 恵子', isPreferred: true }],
+    })} />);
+    expect(screen.getByText('NG / 推奨 / 入れるスタッフ')).toBeInTheDocument();
   });
 
   it('allowed_staff が空のとき「入れるスタッフ」セクションが表示されない', () => {

--- a/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
+++ b/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
@@ -96,6 +96,38 @@ describe('buildCustomerDetailViewModel', () => {
     expect(vm.ngStaff).toEqual([]);
   });
 
+  it('preferredStaff が正しく解決される（allowed に含まれないものだけ）', () => {
+    const helpers = new Map([
+      ['h-1', makeHelper('h-1', '鈴木', '一郎')],
+      ['h-2', makeHelper('h-2', '高橋', '二郎')],
+    ]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({
+        preferred_staff_ids: ['h-1', 'h-2'],
+        allowed_staff_ids: ['h-2'],
+      }),
+      helpers, emptyCustomers, emptyServiceTypes,
+    );
+    // h-1 は allowed に含まれないので preferredStaff に入る
+    expect(vm.preferredStaff).toEqual([{ id: 'h-1', name: '鈴木 一郎', isPreferred: true }]);
+    // h-2 は allowed に含まれるので preferredStaff には入らない
+    expect(vm.preferredStaff.find((s) => s.id === 'h-2')).toBeUndefined();
+    // h-2 は allowedStaff に入り isPreferred=true
+    expect(vm.allowedStaff[0].isPreferred).toBe(true);
+  });
+
+  it('preferred のみの利用者で preferredStaff が設定される', () => {
+    const helpers = new Map([
+      ['h-1', makeHelper('h-1', '山本', 'さくら')],
+    ]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({ preferred_staff_ids: ['h-1'] }),
+      helpers, emptyCustomers, emptyServiceTypes,
+    );
+    expect(vm.preferredStaff).toEqual([{ id: 'h-1', name: '山本 さくら', isPreferred: true }]);
+    expect(vm.allowedStaff).toEqual([]);
+  });
+
   it('allowedStaff に preferred フラグが正しく設定される', () => {
     const helpers = new Map([
       ['h-1', makeHelper('h-1', '鈴木', '一郎')],

--- a/web/src/components/masters/customerDetailViewModel.ts
+++ b/web/src/components/masters/customerDetailViewModel.ts
@@ -52,6 +52,7 @@ export interface CustomerDetailViewModel {
   genderRequirementLabel: string;
 
   ngStaff: ResolvedStaff[];
+  preferredStaff: ResolvedStaff[];
   allowedStaff: ResolvedStaff[];
   householdMembers: { id: string; name: string }[];
   facilityMembers: { id: string; name: string }[];
@@ -106,6 +107,16 @@ export function buildCustomerDetailViewModel(
       id,
       name: resolveStaffName(id, helpers),
       isPreferred: false,
+    }));
+
+  const allowedSet = new Set(customer.allowed_staff_ids ?? []);
+
+  const preferredStaff: ResolvedStaff[] = (customer.preferred_staff_ids ?? [])
+    .filter((id) => helpers.has(id) && !allowedSet.has(id))
+    .map((id) => ({
+      id,
+      name: resolveStaffName(id, helpers),
+      isPreferred: true,
     }));
 
   const allowedStaff: ResolvedStaff[] = (customer.allowed_staff_ids ?? [])
@@ -163,6 +174,7 @@ export function buildCustomerDetailViewModel(
       GENDER_REQUIREMENT_LABELS[customer.gender_requirement ?? 'any'] ?? '指定なし',
 
     ngStaff,
+    preferredStaff,
     allowedStaff,
     householdMembers,
     facilityMembers,


### PR DESCRIPTION
## Summary

- 利用者詳細シートに推奨スタッフ（`preferred_staff_ids`）の表示セクションを追加
- テーブルでは「推奨 X」バッジが表示されるのに、詳細シートには何も表示されなかった不整合を修正
- ViewModel に `preferredStaff` フィールドを追加（`allowed_staff_ids` に含まれないものだけ抽出）
- セクションタイトルを「NG / 推奨 / 入れるスタッフ」に更新
- 影響: C001, C003, C017, C025, C030, C038, C042, C048 の8利用者で推奨スタッフが表示されるようになる

## Test plan

- [x] Vitest: ViewModel テスト 16件通過（+2件追加）
- [x] Vitest: DetailSheet テスト 26件通過（+2件追加）
- [x] Vitest: 全テスト 977件通過
- [x] tsc --noEmit: 型エラーなし
- [ ] CI全テスト通過確認

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)