### PR TITLE
fix: テーブル一覧の「推奨」バッジ件数をDetailSheetと一致させる

### DIFF
--- a/web/src/app/masters/customers/__tests__/page.test.tsx
+++ b/web/src/app/masters/customers/__tests__/page.test.tsx
@@ -115,7 +115,28 @@ describe('利用者マスタページ', () => {
       same_facility_customer_ids: [],
     });
     render(<CustomersPage />);
-    expect(screen.getByText('推奨 2')).toBeInTheDocument();
+    // preferred が全て allowed に含まれるため「推奨」バッジは表示されない
+    expect(screen.queryByText('推奨 2')).not.toBeInTheDocument();
     expect(screen.getByText('入れる 2')).toBeInTheDocument();
+  });
+
+  it('preferred が allowed と重複しない場合のみ「推奨」バッジが表示される', () => {
+    mockCustomers.set('C020', {
+      id: 'C020',
+      name: { family: '山田', given: '太郎', family_kana: 'やまだ', given_kana: 'たろう' },
+      address: '鹿児島市中央町1-1',
+      service_manager: '鈴木裕子',
+      weekly_services: {},
+      ng_staff_ids: ['H003'],
+      preferred_staff_ids: ['H001', 'H002', 'H009'],
+      allowed_staff_ids: ['H009'],
+      same_household_customer_ids: [],
+      same_facility_customer_ids: [],
+    });
+    render(<CustomersPage />);
+    expect(screen.getByText('NG 1')).toBeInTheDocument();
+    // H001, H002 は allowed に含まれないので推奨バッジに表示
+    expect(screen.getByText('推奨 2')).toBeInTheDocument();
+    expect(screen.getByText('入れる 1')).toBeInTheDocument();
   });
 });

--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -291,11 +291,15 @@ export default function CustomersPage() {
                           NG {customer.ng_staff_ids.length}
                         </Badge>
                       ) : null}
-                      {(customer.preferred_staff_ids?.length ?? 0) > 0 ? (
-                        <Badge variant="secondary" className="text-[10px] px-1.5 h-5">
-                          推奨 {customer.preferred_staff_ids.length}
-                        </Badge>
-                      ) : null}
+                      {(() => {
+                        const allowedSet = new Set(customer.allowed_staff_ids ?? []);
+                        const preferredOnly = (customer.preferred_staff_ids ?? []).filter((id) => !allowedSet.has(id));
+                        return preferredOnly.length > 0 ? (
+                          <Badge variant="secondary" className="text-[10px] px-1.5 h-5">
+                            推奨 {preferredOnly.length}
+                          </Badge>
+                        ) : null;
+                      })()}
                       {(customer.allowed_staff_ids?.length ?? 0) > 0 ? (
                         <Badge variant="outline" className="text-[10px] px-1.5 h-5 border-green-300 text-green-600">
                           入れる {customer.allowed_staff_ids.length}

--- a/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
+++ b/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
@@ -188,7 +188,6 @@ describe('buildCustomerDetailViewModel', () => {
     expect(vm.weeklyServices[0].dayLabel).toBe('月');
     expect(vm.weeklyServices[0].slots[0].serviceLabel).toBe('身体介護');
     expect(vm.weeklyServices[0].slots[0].time).toBe('09:00 - 10:00');
-    expect(vm.weeklyServices.length).toBeGreaterThan(0);
   });
 
   it('未知のservice_typeはコードがそのまま使われる', () => {
@@ -226,6 +225,33 @@ describe('buildCustomerDetailViewModel', () => {
       emptyHelpers, emptyCustomers, emptyServiceTypes,
     );
     expect(vmYes.hasContact).toBe(true);
+  });
+
+  it('NG + preferred + allowed の3種が同時に正しく分類される（C010相当）', () => {
+    const helpers = new Map([
+      ['h-1', makeHelper('h-1', '鈴木', '一郎')],
+      ['h-2', makeHelper('h-2', '高橋', '二郎')],
+      ['h-3', makeHelper('h-3', '山本', 'さくら')],
+      ['h-4', makeHelper('h-4', '佐藤', '太郎')],
+    ]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({
+        ng_staff_ids: ['h-1'],
+        preferred_staff_ids: ['h-2', 'h-3'],
+        allowed_staff_ids: ['h-3', 'h-4'],
+      }),
+      helpers, emptyCustomers, emptyServiceTypes,
+    );
+    // h-1: NGのみ
+    expect(vm.ngStaff).toEqual([{ id: 'h-1', name: '鈴木 一郎', isPreferred: false }]);
+    // h-2: preferred かつ allowed に含まれない → preferredStaff
+    expect(vm.preferredStaff).toEqual([{ id: 'h-2', name: '高橋 二郎', isPreferred: true }]);
+    // h-3: preferred かつ allowed → allowedStaff に isPreferred=true で入る
+    // h-4: allowed のみ → allowedStaff に isPreferred=false で入る
+    expect(vm.allowedStaff).toEqual([
+      { id: 'h-3', name: '山本 さくら', isPreferred: true },
+      { id: 'h-4', name: '佐藤 太郎', isPreferred: false },
+    ]);
   });
 
   it('性別要件ラベルが正しく変換される', () => {


### PR DESCRIPTION
## Summary

- テーブル一覧の推奨バッジが `preferred_staff_ids.length` をそのまま表示しており、DetailSheet側（allowed重複除外）と件数が不一致だった問題を修正
- NG+推奨+入れるの3種同時テストケースを追加（C010相当のデータパターン）
- 冗長アサーション削除

## 具体例（修正前→修正後）

C010: `preferred=['H001','H009']`, `allowed=['H001','H009']`
- **修正前**: テーブル「推奨 2」/ DetailSheet 推奨0件（全員allowedに移動）→ 不一致
- **修正後**: テーブル推奨バッジ非表示 / DetailSheet 推奨0件 → 一致

## Test plan

- [x] Vitest 50テスト全パス（ViewModel 17 + DetailSheet 26 + Page 7）
- [x] tsc --noEmit エラーなし
- [x] 推奨+入れる重複時のバッジ非表示テスト追加
- [x] NG+推奨+入れる3種同時分類テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)