### PR TITLE
test: 利用者テーブルの世帯/施設バッジ表示テストを追加

### DIFF
--- a/web/src/app/masters/customers/__tests__/page.test.tsx
+++ b/web/src/app/masters/customers/__tests__/page.test.tsx
@@ -139,4 +139,79 @@ describe('利用者マスタページ', () => {
     expect(screen.getByText('推奨 2')).toBeInTheDocument();
     expect(screen.getByText('入れる 1')).toBeInTheDocument();
   });
+
+  it('同一世帯メンバーがいる利用者に「世帯」バッジが表示される', () => {
+    mockCustomers.set('C001', {
+      id: 'C001',
+      name: { family: '山田', given: '太郎', family_kana: 'やまだ', given_kana: 'たろう' },
+      address: '鹿児島市天文館町10-1',
+      service_manager: '田中美咲',
+      weekly_services: {},
+      ng_staff_ids: [],
+      preferred_staff_ids: [],
+      allowed_staff_ids: [],
+      same_household_customer_ids: ['C002'],
+      same_facility_customer_ids: [],
+    });
+    render(<CustomersPage />);
+    expect(screen.getByText('世帯 1')).toBeInTheDocument();
+    // 施設バッジ（"施設 N"形式）は表示されない（ヘッダーの「世帯/施設」は除く）
+    expect(screen.queryByText(/^施設 \d+$/)).not.toBeInTheDocument();
+  });
+
+  it('同一施設メンバーがいる利用者に「施設」バッジが表示される', () => {
+    mockCustomers.set('C018', {
+      id: 'C018',
+      name: { family: '池田', given: '政夫', family_kana: 'いけだ', given_kana: 'まさお' },
+      address: '鹿児島市谷山中央一丁目6-12',
+      service_manager: '佐藤健一',
+      weekly_services: {},
+      ng_staff_ids: [],
+      preferred_staff_ids: [],
+      allowed_staff_ids: [],
+      same_household_customer_ids: [],
+      same_facility_customer_ids: ['C043'],
+    });
+    render(<CustomersPage />);
+    expect(screen.getByText('施設 1')).toBeInTheDocument();
+    // 世帯バッジ（"世帯 N"形式）は表示されない
+    expect(screen.queryByText(/^世帯 \d+$/)).not.toBeInTheDocument();
+  });
+
+  it('世帯+施設の両方がある利用者に両バッジが表示される', () => {
+    mockCustomers.set('C008', {
+      id: 'C008',
+      name: { family: '渡辺', given: 'トメ', family_kana: 'わたなべ', given_kana: 'とめ' },
+      address: '鹿児島市鴨池一丁目18-3',
+      service_manager: '田中美咲',
+      weekly_services: {},
+      ng_staff_ids: [],
+      preferred_staff_ids: [],
+      allowed_staff_ids: [],
+      same_household_customer_ids: ['C017'],
+      same_facility_customer_ids: ['C042'],
+    });
+    render(<CustomersPage />);
+    expect(screen.getByText('世帯 1')).toBeInTheDocument();
+    expect(screen.getByText('施設 1')).toBeInTheDocument();
+  });
+
+  it('世帯も施設もない利用者は「-」が表示される', () => {
+    mockCustomers.set('C003', {
+      id: 'C003',
+      name: { family: '中村', given: '正雄', family_kana: 'なかむら', given_kana: 'まさお' },
+      address: '鹿児島市中央町5-3',
+      service_manager: '佐藤健一',
+      weekly_services: {},
+      ng_staff_ids: [],
+      preferred_staff_ids: [],
+      allowed_staff_ids: [],
+      same_household_customer_ids: [],
+      same_facility_customer_ids: [],
+    });
+    render(<CustomersPage />);
+    // NG/推奨/入れるの「-」と世帯/施設の「-」の2つがある
+    const dashes = screen.getAllByText('-');
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
+++ b/web/src/components/masters/__tests__/customerDetailViewModel.test.ts
@@ -254,6 +254,37 @@ describe('buildCustomerDetailViewModel', () => {
     ]);
   });
 
+  it('世帯+施設の両方がある場合に両方のメンバーが解決される', () => {
+    const c017 = makeCustomer({ id: 'C017', name: { family: '森', given: 'ハル' } });
+    const c042 = makeCustomer({ id: 'C042', name: { family: '中川', given: 'ウメ' } });
+    const customersMap = new Map([['C017', c017], ['C042', c042]]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({
+        id: 'C008',
+        same_household_customer_ids: ['C017'],
+        same_facility_customer_ids: ['C042'],
+      }),
+      emptyHelpers, customersMap, emptyServiceTypes,
+    );
+    expect(vm.householdMembers).toEqual([{ id: 'C017', name: '森 ハル' }]);
+    expect(vm.facilityMembers).toEqual([{ id: 'C042', name: '中川 ウメ' }]);
+  });
+
+  it('施設のみ（世帯なし）の場合 householdMembers が空', () => {
+    const c043 = makeCustomer({ id: 'C043', name: { family: '中島', given: '喜一' } });
+    const customersMap = new Map([['C043', c043]]);
+    const vm = buildCustomerDetailViewModel(
+      makeCustomer({
+        id: 'C018',
+        same_household_customer_ids: [],
+        same_facility_customer_ids: ['C043'],
+      }),
+      emptyHelpers, customersMap, emptyServiceTypes,
+    );
+    expect(vm.householdMembers).toEqual([]);
+    expect(vm.facilityMembers).toEqual([{ id: 'C043', name: '中島 喜一' }]);
+  });
+
   it('性別要件ラベルが正しく変換される', () => {
     const vm = buildCustomerDetailViewModel(
       makeCustomer({ gender_requirement: 'female' }),


### PR DESCRIPTION
## Summary

- 利用者マスタテーブルの世帯/施設バッジ表示を6パターンでテスト追加
- PR #219 で追加した seed データとUI表示の整合性を保証

### 追加テスト

**page.test.tsx (+4件)**
- 同一世帯メンバーがいる → 「世帯 1」バッジ表示、施設バッジなし
- 同一施設メンバーがいる → 「施設 1」バッジ表示、世帯バッジなし
- 世帯+施設の両方 → 両バッジ表示
- どちらもなし → 「-」表示

**customerDetailViewModel.test.ts (+2件)**
- 世帯+施設の両方がある場合に両方のメンバー名が解決される
- 施設のみ（世帯なし）の場合 householdMembers が空

## Test plan

- [x] vitest 97ファイル 985テスト全パス（+6件増加）
- [x] 回帰なし

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)