### PR TITLE
fix: Emulator project IDをdemo-visitcareに統一（安全性向上）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           NEXT_PUBLIC_USE_EMULATOR: 'true'
           NEXT_PUBLIC_AUTH_MODE: demo
-          NEXT_PUBLIC_FIREBASE_PROJECT_ID: visitcare-shift-optimizer
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: demo-visitcare
           NEXT_PUBLIC_OPTIMIZER_API_URL: 'http://localhost:8081'
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/seed/scripts/utils/firestore-client.ts
+++ b/seed/scripts/utils/firestore-client.ts
@@ -24,7 +24,7 @@ export function getDB(): Firestore {
       process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
     }
     if (getApps().length === 0) {
-      initializeApp({ projectId: 'visitcare-shift-optimizer' });
+      initializeApp({ projectId: 'demo-visitcare' });
     }
   }
 


### PR DESCRIPTION
## Summary

- seed/CI E2Eで使用するEmulator project IDを`demo-visitcare`に統一
- `demo-`プレフィックスにより、Emulator未接続時の本番Firestore書き込みを防止
- PR #223で`visitcare-shift-optimizer`に変更していたが、防御層が1つ減るリスクがあったため修正

## Changes (2 files, +2/-2)

- `seed/scripts/utils/firestore-client.ts`: `visitcare-shift-optimizer` → `demo-visitcare`
- `.github/workflows/ci.yml`: `NEXT_PUBLIC_FIREBASE_PROJECT_ID: demo-visitcare`
- `web/.env.local`: `demo-visitcare`（git管理外、ローカルのみ）

## Test plan

- [x] Web Tests: 985 passed
- [x] CI全チェック通過を確認（PR作成後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)