### PR TITLE
refactor: 世帯/施設グループ構築ロジックをDRY化

### DIFF
--- a/seed/scripts/import-customers.ts
+++ b/seed/scripts/import-customers.ts
@@ -2,7 +2,7 @@ import { resolve } from 'path';
 import { Timestamp } from 'firebase-admin/firestore';
 import { parseCSV } from './utils/csv-parser.js';
 import { batchWrite, getDB } from './utils/firestore-client.js';
-import { normalizeAddress } from './utils/normalize-address.js';
+import { buildHouseholdFacilityGroups } from './utils/household-groups.js';
 
 const DATA_DIR = resolve(import.meta.dirname, '../data');
 
@@ -59,32 +59,11 @@ export async function importCustomers(): Promise<number> {
 
   const now = Timestamp.now();
 
-  // household_id → same_household_customer_ids 変換
-  const hhGroups: Record<string, string[]> = {};
-  for (const c of customers) {
-    if (c.household_id) {
-      if (!hhGroups[c.household_id]) hhGroups[c.household_id] = [];
-      hhGroups[c.household_id].push(c.id);
-    }
-  }
-
-  // 住所ベースの同一施設グループ構築
-  const addrGroups: Record<string, string[]> = {};
-  for (const c of customers) {
-    const norm = normalizeAddress(c.address);
-    if (!addrGroups[norm]) addrGroups[norm] = [];
-    addrGroups[norm].push(c.id);
-  }
+  // 世帯/施設グループを構築
+  const groups = buildHouseholdFacilityGroups(customers);
 
   const docs = customers.map((c) => {
-    // 同一世帯: 同じhousehold_idの他メンバー
-    const sameHousehold = c.household_id
-      ? (hhGroups[c.household_id] || []).filter((id) => id !== c.id)
-      : [];
-    // 同一施設: 同じ住所の他メンバー（世帯メンバーは除外）
-    const normAddr = normalizeAddress(c.address);
-    const hhSet = new Set(sameHousehold);
-    const sameFacility = (addrGroups[normAddr] || []).filter((id) => id !== c.id && !hhSet.has(id));
+    const { sameHousehold, sameFacility } = groups.get(c.id)!;
     // 曜日別サービス枠を構築
     const customerServices = services.filter((s) => s.customer_id === c.id);
     const weeklyServices: Record<string, Array<{

--- a/seed/scripts/patch-customers-household.ts
+++ b/seed/scripts/patch-customers-household.ts
@@ -16,7 +16,7 @@ import { resolve } from 'path';
 import { Timestamp } from 'firebase-admin/firestore';
 import { parseCSV } from './utils/csv-parser.js';
 import { getDB } from './utils/firestore-client.js';
-import { normalizeAddress } from './utils/normalize-address.js';
+import { buildHouseholdFacilityGroups } from './utils/household-groups.js';
 
 const DATA_DIR = resolve(import.meta.dirname, '../data');
 
@@ -30,50 +30,23 @@ async function main() {
   const dryRun = process.argv.includes('--dry-run');
   const customers = parseCSV<CustomerRow>(resolve(DATA_DIR, 'customers.csv'));
 
-  // household_id → グループ構築
-  const hhGroups: Record<string, string[]> = {};
-  for (const c of customers) {
-    if (c.household_id) {
-      if (!hhGroups[c.household_id]) hhGroups[c.household_id] = [];
-      hhGroups[c.household_id].push(c.id);
-    }
-  }
-
-  // 住所ベースの同一施設グループ構築
-  const addrGroups: Record<string, string[]> = {};
-  for (const c of customers) {
-    const norm = normalizeAddress(c.address);
-    if (!addrGroups[norm]) addrGroups[norm] = [];
-    addrGroups[norm].push(c.id);
-  }
-
-  // 各利用者の新フィールドを計算
-  const updates: { id: string; sameHousehold: string[]; sameFacility: string[] }[] = [];
-  for (const c of customers) {
-    const sameHousehold = c.household_id
-      ? (hhGroups[c.household_id] || []).filter((id) => id !== c.id)
-      : [];
-    const normAddr = normalizeAddress(c.address);
-    const hhSet = new Set(sameHousehold);
-    const sameFacility = (addrGroups[normAddr] || []).filter(
-      (id) => id !== c.id && !hhSet.has(id),
-    );
-    updates.push({ id: c.id, sameHousehold, sameFacility });
-  }
+  const groups = buildHouseholdFacilityGroups(customers);
 
   if (dryRun) {
     console.log('🔍 Dry run — 以下のフィールドが更新されます:\n');
-    for (const u of updates) {
-      if (u.sameHousehold.length > 0 || u.sameFacility.length > 0) {
-        console.log(`  ${u.id}:`);
-        if (u.sameHousehold.length > 0)
-          console.log(`    same_household_customer_ids: [${u.sameHousehold.join(', ')}]`);
-        if (u.sameFacility.length > 0)
-          console.log(`    same_facility_customer_ids: [${u.sameFacility.join(', ')}]`);
+    for (const [id, { sameHousehold, sameFacility }] of groups) {
+      if (sameHousehold.length > 0 || sameFacility.length > 0) {
+        console.log(`  ${id}:`);
+        if (sameHousehold.length > 0)
+          console.log(`    same_household_customer_ids: [${sameHousehold.join(', ')}]`);
+        if (sameFacility.length > 0)
+          console.log(`    same_facility_customer_ids: [${sameFacility.join(', ')}]`);
       }
     }
-    const withData = updates.filter((u) => u.sameHousehold.length > 0 || u.sameFacility.length > 0);
-    console.log(`\n合計: ${withData.length}/${updates.length} 件に世帯/施設データあり`);
+    const withData = [...groups.values()].filter(
+      (g) => g.sameHousehold.length > 0 || g.sameFacility.length > 0,
+    );
+    console.log(`\n合計: ${withData.length}/${groups.size} 件に世帯/施設データあり`);
     process.exit(0);
   }
 
@@ -82,18 +55,19 @@ async function main() {
   const BATCH_LIMIT = 500;
   const now = Timestamp.now();
   let written = 0;
+  const entries = [...groups.entries()];
 
-  for (let i = 0; i < updates.length; i += BATCH_LIMIT) {
+  for (let i = 0; i < entries.length; i += BATCH_LIMIT) {
     const batch = db.batch();
-    const chunk = updates.slice(i, i + BATCH_LIMIT);
+    const chunk = entries.slice(i, i + BATCH_LIMIT);
 
-    for (const u of chunk) {
-      const ref = db.collection('customers').doc(u.id);
+    for (const [id, { sameHousehold, sameFacility }] of chunk) {
+      const ref = db.collection('customers').doc(id);
       batch.set(
         ref,
         {
-          same_household_customer_ids: u.sameHousehold,
-          same_facility_customer_ids: u.sameFacility,
+          same_household_customer_ids: sameHousehold,
+          same_facility_customer_ids: sameFacility,
           updated_at: now,
         },
         { merge: true },

--- a/seed/scripts/utils/household-groups.ts
+++ b/seed/scripts/utils/household-groups.ts
@@ -1,0 +1,55 @@
+import { normalizeAddress } from './normalize-address.js';
+
+interface CustomerForGrouping {
+  id: string;
+  address: string;
+  household_id: string;
+}
+
+export interface HouseholdFacilityResult {
+  sameHousehold: string[];
+  sameFacility: string[];
+}
+
+/**
+ * 利用者リストから世帯/施設グループを構築し、各利用者のメンバーIDを返す
+ *
+ * - 同一 household_id → same_household_customer_ids
+ * - 同一住所（正規化済み）で世帯メンバーでない → same_facility_customer_ids
+ */
+export function buildHouseholdFacilityGroups(
+  customers: CustomerForGrouping[],
+): Map<string, HouseholdFacilityResult> {
+  // household_id → グループ構築
+  const hhGroups: Record<string, string[]> = {};
+  for (const c of customers) {
+    if (c.household_id) {
+      if (!hhGroups[c.household_id]) hhGroups[c.household_id] = [];
+      hhGroups[c.household_id].push(c.id);
+    }
+  }
+
+  // 住所ベースの同一施設グループ構築
+  const addrGroups: Record<string, string[]> = {};
+  for (const c of customers) {
+    const norm = normalizeAddress(c.address);
+    if (!addrGroups[norm]) addrGroups[norm] = [];
+    addrGroups[norm].push(c.id);
+  }
+
+  const result = new Map<string, HouseholdFacilityResult>();
+
+  for (const c of customers) {
+    const sameHousehold = c.household_id
+      ? (hhGroups[c.household_id] || []).filter((id) => id !== c.id)
+      : [];
+    const normAddr = normalizeAddress(c.address);
+    const hhSet = new Set(sameHousehold);
+    const sameFacility = (addrGroups[normAddr] || []).filter(
+      (id) => id !== c.id && !hhSet.has(id),
+    );
+    result.set(c.id, { sameHousehold, sameFacility });
+  }
+
+  return result;
+}

--- a/seed/tests/household-groups.test.ts
+++ b/seed/tests/household-groups.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { buildHouseholdFacilityGroups } from '../scripts/utils/household-groups.js';
+
+describe('buildHouseholdFacilityGroups', () => {
+  it('should link household members by household_id', () => {
+    const customers = [
+      { id: 'C001', address: '東京都新宿区1-1', household_id: 'H001' },
+      { id: 'C002', address: '東京都新宿区1-1', household_id: 'H001' },
+      { id: 'C003', address: '東京都渋谷区2-2', household_id: '' },
+    ];
+
+    const groups = buildHouseholdFacilityGroups(customers);
+
+    expect(groups.get('C001')!.sameHousehold).toEqual(['C002']);
+    expect(groups.get('C002')!.sameHousehold).toEqual(['C001']);
+    expect(groups.get('C003')!.sameHousehold).toEqual([]);
+  });
+
+  it('should link facility members by normalized address', () => {
+    const customers = [
+      { id: 'C001', address: '東京都新宿区１ー１', household_id: '' },
+      { id: 'C002', address: '東京都新宿区1-1', household_id: '' },
+    ];
+
+    const groups = buildHouseholdFacilityGroups(customers);
+
+    // 正規化後に同一住所 → 施設グループ
+    expect(groups.get('C001')!.sameFacility).toEqual(['C002']);
+    expect(groups.get('C002')!.sameFacility).toEqual(['C001']);
+  });
+
+  it('should exclude household members from facility group', () => {
+    const customers = [
+      { id: 'C001', address: '東京都新宿区1-1', household_id: 'H001' },
+      { id: 'C002', address: '東京都新宿区1-1', household_id: 'H001' },
+    ];
+
+    const groups = buildHouseholdFacilityGroups(customers);
+
+    // 同一住所かつ同一世帯 → 世帯のみ、施設には含まれない
+    expect(groups.get('C001')!.sameHousehold).toEqual(['C002']);
+    expect(groups.get('C001')!.sameFacility).toEqual([]);
+    expect(groups.get('C002')!.sameHousehold).toEqual(['C001']);
+    expect(groups.get('C002')!.sameFacility).toEqual([]);
+  });
+
+  it('should handle mixed household and facility at same address', () => {
+    const customers = [
+      { id: 'C001', address: '鹿児島市中央1-1', household_id: 'H001' },
+      { id: 'C002', address: '鹿児島市中央1-1', household_id: 'H001' },
+      { id: 'C003', address: '鹿児島市中央1-1', household_id: '' },
+    ];
+
+    const groups = buildHouseholdFacilityGroups(customers);
+
+    // C001/C002: 世帯ペア、C003は施設のみ
+    expect(groups.get('C001')!.sameHousehold).toEqual(['C002']);
+    expect(groups.get('C001')!.sameFacility).toEqual(['C003']);
+    expect(groups.get('C003')!.sameHousehold).toEqual([]);
+    expect(groups.get('C003')!.sameFacility).toEqual(['C001', 'C002']);
+  });
+
+  it('should return empty arrays for solo customers', () => {
+    const customers = [
+      { id: 'C001', address: '東京都新宿区1-1', household_id: '' },
+      { id: 'C002', address: '東京都渋谷区2-2', household_id: '' },
+    ];
+
+    const groups = buildHouseholdFacilityGroups(customers);
+
+    expect(groups.get('C001')!.sameHousehold).toEqual([]);
+    expect(groups.get('C001')!.sameFacility).toEqual([]);
+    expect(groups.get('C002')!.sameHousehold).toEqual([]);
+    expect(groups.get('C002')!.sameFacility).toEqual([]);
+  });
+
+  it('should handle household with 3+ members', () => {
+    const customers = [
+      { id: 'C001', address: '東京都新宿区1-1', household_id: 'H001' },
+      { id: 'C002', address: '東京都新宿区1-1', household_id: 'H001' },
+      { id: 'C003', address: '東京都新宿区1-1', household_id: 'H001' },
+    ];
+
+    const groups = buildHouseholdFacilityGroups(customers);
+
+    expect(groups.get('C001')!.sameHousehold).toEqual(['C002', 'C003']);
+    expect(groups.get('C002')!.sameHousehold).toEqual(['C001', 'C003']);
+    expect(groups.get('C003')!.sameHousehold).toEqual(['C001', 'C002']);
+    // 全員世帯なので施設は空
+    expect(groups.get('C001')!.sameFacility).toEqual([]);
+  });
+
+  it('should return empty map for empty input', () => {
+    const groups = buildHouseholdFacilityGroups([]);
+    expect(groups.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `buildHouseholdFacilityGroups()` を `seed/scripts/utils/household-groups.ts` に抽出
- `import-customers.ts` と `patch-customers-household.ts` の重複ロジックを統一
- ユニットテスト7件追加

## 背景

PR #225 で `patch-customers-household.ts` を作成した際、`import-customers.ts` と同一の世帯/施設グループ構築ロジックが重複していた（DRY違反）。片方のバグ修正がもう片方に反映されないリスクを解消。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `seed/scripts/utils/household-groups.ts` | 新規: 共通モジュール |
| `seed/scripts/import-customers.ts` | 重複ロジック削除 → 共通モジュール使用 |
| `seed/scripts/patch-customers-household.ts` | 重複ロジック削除 → 共通モジュール使用 |
| `seed/tests/household-groups.test.ts` | 新規: ユニットテスト7件 |

## Test plan

- [x] 新規テスト7件パス（世帯ペア、施設ペア、世帯除外、混在、ソロ、3人以上、空入力）
- [x] 既存seed全テスト42件パス（回帰確認）
- [x] パッチスクリプト dry-run 出力が変更前と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)