### PR TITLE
feat: StatsBarの違反/警告バッジにPopover詳細表示を追加

### DIFF
--- a/web/src/components/schedule/StatsBar.tsx
+++ b/web/src/components/schedule/StatsBar.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import type { DaySchedule } from '@/hooks/useScheduleData';
 import type { ViolationMap } from '@/lib/constraints/checker';
 import type { AssignmentDiff } from '@/hooks/useAssignmentDiff';
+import { ViolationPopover } from './ViolationPopover';
 
 interface StatsBarProps {
   schedule: DaySchedule;
@@ -25,7 +26,6 @@ export function StatsBar({ schedule, violations, diffMap }: StatsBarProps) {
   const warningCount = Array.from(violations.values())
     .flat()
     .filter((v) => v.severity === 'warning').length;
-  const totalViolations = errorCount + warningCount;
   const assignRate = schedule.totalOrders > 0
     ? Math.round((assignedCount / schedule.totalOrders) * 100)
     : 0;
@@ -116,16 +116,8 @@ export function StatsBar({ schedule, violations, diffMap }: StatsBarProps) {
           <p className="text-[11px] text-muted-foreground leading-none">ヘルパー</p>
           <div className="flex items-center gap-1.5">
             <p className="text-lg font-bold leading-tight">{schedule.helperRows.length}<span className="text-xs font-normal text-muted-foreground ml-0.5">名</span></p>
-            {errorCount > 0 && (
-              <Badge variant="destructive" className="h-5 px-1.5 text-[10px]">
-                違反{errorCount}
-              </Badge>
-            )}
-            {warningCount > 0 && (
-              <Badge variant="outline" className="h-5 px-1.5 text-[10px] border-yellow-500 text-yellow-600">
-                警告{warningCount}
-              </Badge>
-            )}
+            <ViolationPopover violations={violations} severity="error" count={errorCount} />
+            <ViolationPopover violations={violations} severity="warning" count={warningCount} />
           </div>
         </div>
       </div>

--- a/web/src/components/schedule/ViolationPopover.tsx
+++ b/web/src/components/schedule/ViolationPopover.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useMemo } from 'react';
+import { AlertTriangle, XCircle } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover';
+import type { Violation, ViolationMap, ViolationSeverity } from '@/lib/constraints/checker';
+
+const VIOLATION_TYPE_LABELS: Record<Violation['type'], string> = {
+  ng_staff: 'NGスタッフ',
+  qualification: '資格不適合',
+  overlap: '時間重複',
+  unavailability: '希望休',
+  gender: '性別要件',
+  training: '研修状態',
+  preferred_staff: '推奨スタッフ外',
+  staff_count_under: '人員不足',
+  staff_count_over: '人員超過',
+  outside_hours: '勤務時間外',
+  travel_time: '移動時間不足',
+};
+
+interface ViolationPopoverProps {
+  violations: ViolationMap;
+  severity: ViolationSeverity;
+  count: number;
+}
+
+interface GroupedViolation {
+  type: Violation['type'];
+  label: string;
+  items: Violation[];
+}
+
+export function ViolationPopover({ violations, severity, count }: ViolationPopoverProps) {
+  const grouped = useMemo(() => {
+    const all = Array.from(violations.values())
+      .flat()
+      .filter((v) => v.severity === severity);
+
+    const map = new Map<Violation['type'], Violation[]>();
+    for (const v of all) {
+      const list = map.get(v.type) ?? [];
+      list.push(v);
+      map.set(v.type, list);
+    }
+
+    const result: GroupedViolation[] = [];
+    for (const [type, items] of map) {
+      result.push({ type, label: VIOLATION_TYPE_LABELS[type], items });
+    }
+    return result.sort((a, b) => b.items.length - a.items.length);
+  }, [violations, severity]);
+
+  if (count === 0) return null;
+
+  const isError = severity === 'error';
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        {isError ? (
+          <Badge
+            variant="destructive"
+            className="h-5 px-1.5 text-[10px] cursor-pointer hover:opacity-80 transition-opacity"
+            role="button"
+            aria-label={`違反${count}件の詳細を表示`}
+          >
+            違反{count}
+          </Badge>
+        ) : (
+          <Badge
+            variant="outline"
+            className="h-5 px-1.5 text-[10px] border-yellow-500 text-yellow-600 cursor-pointer hover:bg-yellow-50 transition-colors"
+            role="button"
+            aria-label={`警告${count}件の詳細を表示`}
+          >
+            警告{count}
+          </Badge>
+        )}
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-80 max-h-72 overflow-y-auto p-0"
+        align="start"
+      >
+        <div className="sticky top-0 flex items-center gap-1.5 border-b bg-popover px-3 py-2">
+          {isError ? (
+            <XCircle className="h-4 w-4 text-destructive shrink-0" />
+          ) : (
+            <AlertTriangle className="h-4 w-4 text-yellow-600 shrink-0" />
+          )}
+          <span className="text-sm font-medium">
+            {isError ? '違反' : '警告'}一覧（{count}件）
+          </span>
+        </div>
+        <div className="divide-y">
+          {grouped.map((group) => (
+            <div key={group.type} className="px-3 py-2">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs font-medium text-muted-foreground">
+                  {group.label}
+                </span>
+                <span className="text-[10px] text-muted-foreground">
+                  {group.items.length}件
+                </span>
+              </div>
+              <ul className="space-y-0.5">
+                {group.items.map((item, i) => (
+                  <li key={`${item.orderId}-${item.staffId ?? ''}-${i}`} className="text-xs leading-relaxed">
+                    {item.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/components/schedule/__tests__/ViolationPopover.test.tsx
+++ b/web/src/components/schedule/__tests__/ViolationPopover.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ViolationPopover } from '../ViolationPopover';
+import type { ViolationMap } from '@/lib/constraints/checker';
+
+describe('ViolationPopover', () => {
+  it('count=0のとき何も表示しない', () => {
+    const violations: ViolationMap = new Map();
+    const { container } = render(
+      <ViolationPopover violations={violations} severity="error" count={0} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('error severity で「違反N」バッジが表示される', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        { orderId: 'o1', staffId: 'h1', type: 'overlap', severity: 'error', message: '時間重複テスト' },
+        { orderId: 'o1', staffId: 'h1', type: 'ng_staff', severity: 'error', message: 'NGスタッフテスト' },
+      ]],
+    ]);
+    render(<ViolationPopover violations={violations} severity="error" count={2} />);
+    expect(screen.getByText('違反2')).toBeInTheDocument();
+  });
+
+  it('warning severity で「警告N」バッジが表示される', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        { orderId: 'o1', type: 'outside_hours', severity: 'warning', message: '勤務時間外テスト' },
+      ]],
+    ]);
+    render(<ViolationPopover violations={violations} severity="warning" count={1} />);
+    expect(screen.getByText('警告1')).toBeInTheDocument();
+  });
+
+  it('バッジクリックでPopoverが開き、種別ごとにグループ表示される', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        { orderId: 'o1', staffId: 'h1', type: 'overlap', severity: 'error', message: '佐藤 の時間重複: 10:00-11:00' },
+        { orderId: 'o1', staffId: 'h2', type: 'overlap', severity: 'error', message: '鈴木 の時間重複: 09:00-10:00' },
+        { orderId: 'o1', staffId: 'h1', type: 'ng_staff', severity: 'error', message: 'NGスタッフ 佐藤 が割当済み' },
+      ]],
+    ]);
+    render(<ViolationPopover violations={violations} severity="error" count={3} />);
+
+    fireEvent.click(screen.getByText('違反3'));
+
+    // ヘッダー
+    expect(screen.getByText('違反一覧（3件）')).toBeInTheDocument();
+
+    // 種別グループラベル
+    expect(screen.getByText('時間重複')).toBeInTheDocument();
+    expect(screen.getByText('NGスタッフ')).toBeInTheDocument();
+
+    // 個別メッセージ
+    expect(screen.getByText('佐藤 の時間重複: 10:00-11:00')).toBeInTheDocument();
+    expect(screen.getByText('鈴木 の時間重複: 09:00-10:00')).toBeInTheDocument();
+    expect(screen.getByText('NGスタッフ 佐藤 が割当済み')).toBeInTheDocument();
+  });
+
+  it('warning Popover内に件数が表示される', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        { orderId: 'o1', type: 'travel_time', severity: 'warning', message: '移動時間不足（必要: 15分、余裕: 5分）' },
+        { orderId: 'o2', type: 'outside_hours', severity: 'warning', message: '佐藤 の勤務時間外' },
+      ]],
+    ]);
+    render(<ViolationPopover violations={violations} severity="warning" count={2} />);
+
+    fireEvent.click(screen.getByText('警告2'));
+
+    expect(screen.getByText('警告一覧（2件）')).toBeInTheDocument();
+    expect(screen.getByText('移動時間不足')).toBeInTheDocument();
+    expect(screen.getByText('勤務時間外')).toBeInTheDocument();
+  });
+
+  it('他のseverityの項目はフィルタされる', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        { orderId: 'o1', type: 'overlap', severity: 'error', message: 'エラーメッセージ' },
+        { orderId: 'o1', type: 'outside_hours', severity: 'warning', message: '警告メッセージ' },
+      ]],
+    ]);
+    render(<ViolationPopover violations={violations} severity="error" count={1} />);
+
+    fireEvent.click(screen.getByText('違反1'));
+
+    expect(screen.getByText('エラーメッセージ')).toBeInTheDocument();
+    expect(screen.queryByText('警告メッセージ')).not.toBeInTheDocument();
+  });
+
+  it('aria-labelがバッジに設定されている', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [{ orderId: 'o1', type: 'overlap', severity: 'error', message: 'test' }]],
+    ]);
+    render(<ViolationPopover violations={violations} severity="error" count={1} />);
+    expect(screen.getByLabelText('違反1件の詳細を表示')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- 「違反N」「警告N」バッジをクリックするとPopoverで内訳を表示
- 種別（NGスタッフ、資格不適合、時間重複等）ごとにグループ化
- 各項目にメッセージを一覧表示
- ViolationPopover新規コンポーネント + テスト7件追加

Closes #229

## 変更ファイル
- `ViolationPopover.tsx` — 新規: Popover付きバッジコンポーネント
- `StatsBar.tsx` — Badge → ViolationPopoverに置き換え、未使用変数削除
- `ViolationPopover.test.tsx` — 新規: 7テスト

## Test plan
- [x] tsc --noEmit: エラー0件
- [x] ESLint: エラー0件
- [x] Vitest: 992件 pass（98ファイル全pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)