### PR TITLE
fix: StatsBar割当済カウントのstaff_count二重カウントを修正

### DIFF
--- a/web/src/components/schedule/StatsBar.tsx
+++ b/web/src/components/schedule/StatsBar.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import type { DaySchedule } from '@/hooks/useScheduleData';
 import type { ViolationMap, ViolationSeverity } from '@/lib/constraints/checker';
 import type { AssignmentDiff } from '@/hooks/useAssignmentDiff';
+import type { Order } from '@/types';
 import { ViolationPopover } from './ViolationPopover';
 
 interface StatsBarProps {
@@ -15,10 +16,15 @@ interface StatsBarProps {
 }
 
 export function StatsBar({ schedule, violations, diffMap, onViolationClick }: StatsBarProps) {
-  const allOrders = schedule.helperRows.flatMap((r) => r.orders).concat(schedule.unassignedOrders);
-  const assignedCount = schedule.helperRows.reduce(
-    (sum, row) => sum + row.orders.length, 0
-  );
+  // staff_count>=2 のオーダーは複数ヘルパー行に重複するため、IDで重複排除
+  const uniqueAssigned = new Map<string, Order>();
+  for (const row of schedule.helperRows) {
+    for (const order of row.orders) {
+      uniqueAssigned.set(order.id, order);
+    }
+  }
+  const allOrders = [...uniqueAssigned.values(), ...schedule.unassignedOrders];
+  const assignedCount = uniqueAssigned.size;
   const completedCount = allOrders.filter((o) => o.status === 'completed').length;
   const cancelledCount = allOrders.filter((o) => o.status === 'cancelled').length;
   const errorCount = Array.from(violations.values())

--- a/web/src/components/schedule/__tests__/StatsBar.test.tsx
+++ b/web/src/components/schedule/__tests__/StatsBar.test.tsx
@@ -149,4 +149,61 @@ describe('StatsBar', () => {
     render(<StatsBar schedule={schedule} violations={emptyViolations} />);
     expect(screen.getByText(/取消1/)).toBeInTheDocument();
   });
+
+  it('staff_count=2 のオーダーが複数ヘルパー行にあっても割当済は1件としてカウントされる', () => {
+    // staff_count=2 のオーダーは2人のヘルパーに割り当てられ、各行に同じオーダーが入る
+    const multiStaffOrder: Order = {
+      ...makeOrder('o-multi', 'assigned'),
+      staff_count: 2,
+      assigned_staff_ids: ['h1', 'h2'],
+    };
+    const singleOrder = makeOrder('o-single', 'assigned');
+
+    const schedule: DaySchedule = {
+      day: 'tuesday',
+      date: new Date('2026-03-10'),
+      helperRows: [
+        { helper: makeHelper('h1'), orders: [multiStaffOrder, singleOrder] },
+        { helper: makeHelper('h2'), orders: [multiStaffOrder] },
+      ],
+      unassignedOrders: [],
+      totalOrders: 2, // 実際のオーダーは2件（multi + single）
+    };
+
+    render(<StatsBar schedule={schedule} violations={emptyViolations} />);
+
+    // 割当済は2件であるべき（multiStaffOrderは1回のみカウント）
+    // totalOrders=2 なので割当率は100%
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    // 割当済の数値 "2" が表示される
+    const assignedSection = screen.getByText('割当済').closest('div')!.parentElement!;
+    expect(assignedSection.textContent).toContain('2');
+    expect(assignedSection.textContent).toContain('100%');
+  });
+
+  it('staff_count=2 のcompleted/cancelledオーダーも重複カウントされない', () => {
+    const completedMulti: Order = {
+      ...makeOrder('o-comp', 'completed'),
+      staff_count: 2,
+      assigned_staff_ids: ['h1', 'h2'],
+    };
+    const cancelledSingle = makeOrder('o-cancel', 'cancelled');
+
+    const schedule: DaySchedule = {
+      day: 'tuesday',
+      date: new Date('2026-03-10'),
+      helperRows: [
+        { helper: makeHelper('h1'), orders: [completedMulti] },
+        { helper: makeHelper('h2'), orders: [completedMulti] },
+      ],
+      unassignedOrders: [cancelledSingle],
+      totalOrders: 2,
+    };
+
+    render(<StatsBar schedule={schedule} violations={emptyViolations} />);
+
+    // completed=1件（重複排除）、cancelled=1件
+    // 完了率 = 1 / (2 - 1) = 100%
+    expect(screen.getByText(/取消1/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- `staff_count>=2`のオーダーが複数ヘルパー行に重複登録されるため、`assignedCount`・`completedCount`・`cancelledCount`が二重カウントされ割当率108%等の不正値になっていた
- オーダーIDベースの`Map`で重複排除することで正しいユニークカウントに修正
- テスト2件追加（multi-staff割当カウント、multi-staff completed/cancelled）

## Test plan
- [x] tsc --noEmit: エラー0件
- [x] Vitest: 1004件 pass（99ファイル全pass）
- [x] 新規テスト: staff_count=2のオーダーが100%（108%でない）と表示されること

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)