### PR TITLE
test: StatsBar multi-staffテストの数値検証を強化

### DIFF
--- a/web/src/components/schedule/__tests__/StatsBar.test.tsx
+++ b/web/src/components/schedule/__tests__/StatsBar.test.tsx
@@ -205,5 +205,9 @@ describe('StatsBar', () => {
     // completed=1件（重複排除）、cancelled=1件
     // 完了率 = 1 / (2 - 1) = 100%
     expect(screen.getByText(/取消1/)).toBeInTheDocument();
+    // 実績確認セクションの数値検証: completed=1, 完了率=100%
+    const completionSection = screen.getByText('実績確認').closest('div')!.parentElement!;
+    expect(completionSection.textContent).toContain('1');
+    expect(completionSection.textContent).toContain('100%');
   });
 });


### PR DESCRIPTION
## Summary

- PR #236 で追加した2つ目のテスト（completed/cancelled重複排除）に、completed=1・完了率100%の数値検証を追加
- 取消バッジ存在確認だけでは重複排除の効果を検証できていなかった

## Test plan
- [x] Vitest: 12件 pass（StatsBar.test.tsx）

🤖 Generated with [Claude Code](https://claude.com/claude-code)