### PR TITLE
feat: 違反/警告サマリーバーを常時表示 (Closes #234)

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -29,6 +29,7 @@ import { checkConstraints } from '@/lib/constraints/checker';
 import { createConfirmEditCommand } from '@/lib/undo/commands';
 import { useServiceTypes } from '@/hooks/useServiceTypes';
 import { ViolationPanel } from '@/components/schedule/ViolationPanel';
+import { ViolationSummaryBar } from '@/components/schedule/ViolationSummaryBar';
 import { SLOT_WIDTH_PX } from '@/components/gantt/constants';
 import { DAY_OF_WEEK_ORDER } from '@/types';
 import type { Order, DayOfWeek } from '@/types';
@@ -224,6 +225,12 @@ function SchedulePage() {
         diffMap={diffMap}
         onViolationClick={handleViolationClick}
       />
+      {viewMode === 'day' && (
+        <ViolationSummaryBar
+          violations={violations}
+          onOpenPanel={() => setViolationPanelOpen(true)}
+        />
+      )}
       <main className="flex-1 overflow-auto p-4">
         {viewMode === 'day' ? (
           ganttAxis === 'customer' ? (

--- a/web/src/components/schedule/ViolationPanel.tsx
+++ b/web/src/components/schedule/ViolationPanel.tsx
@@ -11,21 +11,8 @@ import {
   SheetDescription,
 } from '@/components/ui/sheet';
 import type { Violation, ViolationMap, ViolationSeverity } from '@/lib/constraints/checker';
+import { VIOLATION_TYPE_LABELS } from '@/lib/constraints/labels';
 import type { Customer, Helper } from '@/types';
-
-const VIOLATION_TYPE_LABELS: Record<Violation['type'], string> = {
-  ng_staff: 'NGスタッフ',
-  qualification: '資格不適合',
-  overlap: '時間重複',
-  unavailability: '希望休',
-  gender: '性別要件',
-  training: '研修状態',
-  preferred_staff: '推奨スタッフ外',
-  staff_count_under: '人員不足',
-  staff_count_over: '人員超過',
-  outside_hours: '勤務時間外',
-  travel_time: '移動時間不足',
-};
 
 type FilterMode = 'all' | ViolationSeverity;
 

--- a/web/src/components/schedule/ViolationPopover.tsx
+++ b/web/src/components/schedule/ViolationPopover.tsx
@@ -9,20 +9,7 @@ import {
   PopoverContent,
 } from '@/components/ui/popover';
 import type { Violation, ViolationMap, ViolationSeverity } from '@/lib/constraints/checker';
-
-const VIOLATION_TYPE_LABELS: Record<Violation['type'], string> = {
-  ng_staff: 'NGスタッフ',
-  qualification: '資格不適合',
-  overlap: '時間重複',
-  unavailability: '希望休',
-  gender: '性別要件',
-  training: '研修状態',
-  preferred_staff: '推奨スタッフ外',
-  staff_count_under: '人員不足',
-  staff_count_over: '人員超過',
-  outside_hours: '勤務時間外',
-  travel_time: '移動時間不足',
-};
+import { VIOLATION_TYPE_LABELS } from '@/lib/constraints/labels';
 
 interface ViolationPopoverProps {
   violations: ViolationMap;

--- a/web/src/components/schedule/ViolationSummaryBar.tsx
+++ b/web/src/components/schedule/ViolationSummaryBar.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useMemo } from 'react';
+import { AlertTriangle, XCircle, ChevronRight } from 'lucide-react';
+import type { Violation, ViolationMap } from '@/lib/constraints/checker';
+import { VIOLATION_TYPE_LABELS } from '@/lib/constraints/labels';
+
+interface ViolationSummaryBarProps {
+  violations: ViolationMap;
+  onOpenPanel: () => void;
+}
+
+interface TypeCount {
+  type: Violation['type'];
+  label: string;
+  count: number;
+}
+
+function groupByType(violations: Violation[]): TypeCount[] {
+  const map = new Map<Violation['type'], number>();
+  for (const v of violations) {
+    map.set(v.type, (map.get(v.type) ?? 0) + 1);
+  }
+  const result: TypeCount[] = [];
+  for (const [type, count] of map) {
+    result.push({ type, label: VIOLATION_TYPE_LABELS[type], count });
+  }
+  return result.sort((a, b) => b.count - a.count);
+}
+
+export function ViolationSummaryBar({ violations, onOpenPanel }: ViolationSummaryBarProps) {
+  const all = useMemo(
+    () => Array.from(violations.values()).flat(),
+    [violations],
+  );
+
+  const errors = useMemo(() => groupByType(all.filter((v) => v.severity === 'error')), [all]);
+  const warnings = useMemo(() => groupByType(all.filter((v) => v.severity === 'warning')), [all]);
+
+  if (errors.length === 0 && warnings.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-1.5 border-b bg-muted/30 text-xs">
+      {errors.length > 0 && (
+        <div className="flex items-center gap-2">
+          <XCircle className="h-3.5 w-3.5 text-destructive shrink-0" />
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {errors.map((g) => (
+              <span key={g.type} className="inline-flex items-center gap-0.5 text-destructive">
+                <span className="font-medium">{g.label}</span>
+                <span className="text-destructive/70">{g.count}件</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      {errors.length > 0 && warnings.length > 0 && (
+        <span className="text-muted-foreground/40">|</span>
+      )}
+      {warnings.length > 0 && (
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-3.5 w-3.5 text-yellow-600 shrink-0" />
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {warnings.map((g) => (
+              <span key={g.type} className="inline-flex items-center gap-0.5 text-yellow-600">
+                <span className="font-medium">{g.label}</span>
+                <span className="text-yellow-600/70">{g.count}件</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={onOpenPanel}
+        className="ml-auto flex items-center gap-0.5 text-muted-foreground hover:text-foreground transition-colors shrink-0"
+        aria-label="詳細を表示"
+      >
+        <span>詳細</span>
+        <ChevronRight className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/schedule/__tests__/ViolationSummaryBar.test.tsx
+++ b/web/src/components/schedule/__tests__/ViolationSummaryBar.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ViolationSummaryBar } from '../ViolationSummaryBar';
+import type { ViolationMap, Violation } from '@/lib/constraints/checker';
+
+function makeViolation(overrides: Partial<Violation> & Pick<Violation, 'orderId' | 'type' | 'severity' | 'message'>): Violation {
+  return overrides as Violation;
+}
+
+describe('ViolationSummaryBar', () => {
+  it('違反も警告もない場合は何も表示しない', () => {
+    const violations: ViolationMap = new Map();
+    const { container } = render(
+      <ViolationSummaryBar violations={violations} onOpenPanel={() => {}} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('エラー違反がタイプ別に件数表示される', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        makeViolation({ orderId: 'o1', type: 'overlap', severity: 'error', message: '重複1' }),
+        makeViolation({ orderId: 'o1', type: 'overlap', severity: 'error', message: '重複2' }),
+        makeViolation({ orderId: 'o1', type: 'ng_staff', severity: 'error', message: 'NG1' }),
+      ]],
+    ]);
+    render(
+      <ViolationSummaryBar violations={violations} onOpenPanel={() => {}} />
+    );
+    expect(screen.getByText('時間重複')).toBeInTheDocument();
+    expect(screen.getByText('2件')).toBeInTheDocument();
+    expect(screen.getByText('NGスタッフ')).toBeInTheDocument();
+    expect(screen.getByText('1件')).toBeInTheDocument();
+  });
+
+  it('警告がタイプ別に件数表示される', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        makeViolation({ orderId: 'o1', type: 'preferred_staff', severity: 'warning', message: '推奨外' }),
+        makeViolation({ orderId: 'o1', type: 'outside_hours', severity: 'warning', message: '時間外' }),
+      ]],
+    ]);
+    render(
+      <ViolationSummaryBar violations={violations} onOpenPanel={() => {}} />
+    );
+    expect(screen.getByText('推奨スタッフ外')).toBeInTheDocument();
+    expect(screen.getByText('勤務時間外')).toBeInTheDocument();
+  });
+
+  it('クリックでonOpenPanelが呼ばれる', () => {
+    const onOpenPanel = vi.fn();
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        makeViolation({ orderId: 'o1', type: 'overlap', severity: 'error', message: '重複' }),
+      ]],
+    ]);
+    render(
+      <ViolationSummaryBar violations={violations} onOpenPanel={onOpenPanel} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: '詳細を表示' }));
+    expect(onOpenPanel).toHaveBeenCalledTimes(1);
+  });
+
+  it('エラーと警告が両方ある場合にセクション分けされる', () => {
+    const violations: ViolationMap = new Map([
+      ['o1', [
+        makeViolation({ orderId: 'o1', type: 'overlap', severity: 'error', message: '重複' }),
+        makeViolation({ orderId: 'o1', type: 'preferred_staff', severity: 'warning', message: '推奨外' }),
+      ]],
+    ]);
+    render(
+      <ViolationSummaryBar violations={violations} onOpenPanel={() => {}} />
+    );
+    expect(screen.getByText('時間重複')).toBeInTheDocument();
+    expect(screen.getByText('推奨スタッフ外')).toBeInTheDocument();
+  });
+});

--- a/web/src/lib/constraints/labels.ts
+++ b/web/src/lib/constraints/labels.ts
@@ -1,0 +1,15 @@
+import type { Violation } from './checker';
+
+export const VIOLATION_TYPE_LABELS: Record<Violation['type'], string> = {
+  ng_staff: 'NGスタッフ',
+  qualification: '資格不適合',
+  overlap: '時間重複',
+  unavailability: '希望休',
+  gender: '性別要件',
+  training: '研修状態',
+  preferred_staff: '推奨スタッフ外',
+  staff_count_under: '人員不足',
+  staff_count_over: '人員超過',
+  outside_hours: '勤務時間外',
+  travel_time: '移動時間不足',
+};


### PR DESCRIPTION
## Summary

- StatsBarの下に`ViolationSummaryBar`を新規追加。違反タイプ別の件数（例: 時間重複 3件 | NGスタッフ 2件）をクリックなしで常時表示
- 「詳細」ボタンでViolationPanel（Sheetドロワー）を開く
- `VIOLATION_TYPE_LABELS`を`labels.ts`に共通化し、ViolationPopover/ViolationPanelのDRY違反を解消
- 週ビューでは非表示（日ビューのみ表示）

## Test plan
- [x] tsc --noEmit: エラー0件
- [x] Vitest: 1009件 pass（100ファイル全pass、+5件新規テスト）
- [x] 新規テスト: 空表示/エラー表示/警告表示/クリック動作/混在表示

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)