### PR TITLE
fix: checker/optimizer不整合を修正 — status除外+outside_hours整合

### DIFF
--- a/web/src/lib/constraints/__tests__/checker.test.ts
+++ b/web/src/lib/constraints/__tests__/checker.test.ts
@@ -558,4 +558,96 @@ describe('checkConstraints', () => {
       }).not.toThrow();
     });
   });
+
+  describe('completed/cancelled オーダーの除外', () => {
+    it('status=completed のオーダーは違反チェック対象外', () => {
+      const helpers = new Map([['H001', makeHelper()]]);
+      const customers = new Map([['C001', makeCustomer({ ng_staff_ids: ['H001'] })]]);
+      const result = checkConstraints({
+        orders: [makeOrder({ status: 'completed' })],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      expect(result.size).toBe(0);
+    });
+
+    it('status=cancelled のオーダーは違反チェック対象外', () => {
+      const helpers = new Map([['H001', makeHelper()]]);
+      const customers = new Map([['C001', makeCustomer({ ng_staff_ids: ['H001'] })]]);
+      const result = checkConstraints({
+        orders: [makeOrder({ status: 'cancelled' })],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      expect(result.size).toBe(0);
+    });
+
+    it('status=assigned のオーダーは違反チェック対象', () => {
+      const helpers = new Map([['H001', makeHelper()]]);
+      const customers = new Map([['C001', makeCustomer({ ng_staff_ids: ['H001'] })]]);
+      const result = checkConstraints({
+        orders: [makeOrder({ status: 'assigned' })],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      expect(result.get('O001')?.some((v) => v.type === 'ng_staff')).toBe(true);
+    });
+  });
+
+  describe('outside_hours: 未定義曜日のハンドリング', () => {
+    it('weekly_availability に該当曜日がない場合は勤務時間外として警告', () => {
+      // monday のみ定義、tuesday は未定義
+      const helpers = new Map([['H001', makeHelper({
+        weekly_availability: { monday: [{ start_time: '08:00', end_time: '17:00' }] },
+      })]]);
+      const customers = new Map([['C001', makeCustomer()]]);
+      const result = checkConstraints({
+        orders: [makeOrder()],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'tuesday', // monday しか定義されていない
+      });
+      const violations = result.get('O001') ?? [];
+      expect(violations.some((v) => v.type === 'outside_hours' && v.severity === 'warning')).toBe(true);
+    });
+
+    it('weekly_availability が空オブジェクトの場合は全曜日で勤務時間外', () => {
+      const helpers = new Map([['H001', makeHelper({
+        weekly_availability: {},
+      })]]);
+      const customers = new Map([['C001', makeCustomer()]]);
+      const result = checkConstraints({
+        orders: [makeOrder()],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      const violations = result.get('O001') ?? [];
+      expect(violations.some((v) => v.type === 'outside_hours' && v.severity === 'warning')).toBe(true);
+    });
+
+    it('weekly_availability 未定義（undefined）の場合は制約なし（違反なし）', () => {
+      const helpers = new Map([['H001', makeHelper({
+        weekly_availability: undefined as unknown as Helper['weekly_availability'],
+      })]]);
+      const customers = new Map([['C001', makeCustomer()]]);
+      const result = checkConstraints({
+        orders: [makeOrder()],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      const violations = result.get('O001') ?? [];
+      expect(violations.some((v) => v.type === 'outside_hours')).toBe(false);
+    });
+  });
 });

--- a/web/src/lib/constraints/checker.ts
+++ b/web/src/lib/constraints/checker.ts
@@ -49,7 +49,10 @@ export function checkConstraints(input: CheckInput): ViolationMap {
     violations.set(v.orderId, list);
   };
 
-  const assignedOrders = input.orders.filter((o) => o.assigned_staff_ids.length > 0);
+  const activeOrders = input.orders.filter(
+    (o) => o.status !== 'completed' && o.status !== 'cancelled'
+  );
+  const assignedOrders = activeOrders.filter((o) => o.assigned_staff_ids.length > 0);
 
   for (const order of assignedOrders) {
     const customer = input.customers.get(order.customer_id);
@@ -156,13 +159,11 @@ export function checkConstraints(input: CheckInput): ViolationMap {
         });
       }
 
-      // 勤務時間外
-      const availability = helper.weekly_availability[input.day];
-      if (availability) {
-        const withinAny = availability.some(
-          (slot) => slot.start_time <= order.start_time && slot.end_time >= order.end_time
-        );
-        if (!withinAny) {
+      // 勤務時間外（optimizer と整合: 未定義曜日=勤務不可、weekly_availability 自体が未定義=制約なし）
+      if (helper.weekly_availability) {
+        const availability = helper.weekly_availability[input.day];
+        if (!availability || availability.length === 0) {
+          // 曜日エントリがないか空 → optimizer と同じく勤務不可扱い
           addViolation({
             orderId: order.id,
             staffId,
@@ -170,6 +171,19 @@ export function checkConstraints(input: CheckInput): ViolationMap {
             severity: 'warning',
             message: `${helper.name.family} の勤務時間外`,
           });
+        } else {
+          const withinAny = availability.some(
+            (slot) => slot.start_time <= order.start_time && slot.end_time >= order.end_time
+          );
+          if (!withinAny) {
+            addViolation({
+              orderId: order.id,
+              staffId,
+              type: 'outside_hours',
+              severity: 'warning',
+              message: `${helper.name.family} の勤務時間外`,
+            });
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- `completed`/`cancelled` ステータスのオーダーを違反チェック対象外にフィルタ追加
- `outside_hours` チェックのロジックをoptimizer側と整合
  - 未定義曜日 → 「勤務不可」として警告（optimizer: ハード制約で割当禁止）
  - 空配列 `[]` → 同上
  - `weekly_availability` 自体が未定義 → 「制約なし」（optimizer: 同様にスキップ）

## 背景 (#235)

本番データで最適化後に違反8件・警告3件が発生する問題を調査。
checker と optimizer の制約ロジック差異を網羅的に比較し、以下の不整合を特定・修正:

1. **statusフィルタ欠如**: checkerが全ステータスのオーダーを処理（optimizerは pending/assigned のみ）
2. **outside_hours 未定義曜日**: checkerがスキップ（permissive）、optimizerは割当禁止（restrictive）

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] Vitest: 1015件 pass（100ファイル全pass）
- [x] 新規テスト6件追加（status除外3件 + outside_hours整合3件）
- [ ] 本番環境で違反件数が減少することを確認

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)