### PR TITLE
fix: SummaryBar詳細クリック時のフィルタリセット

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -228,7 +228,7 @@ function SchedulePage() {
       {viewMode === 'day' && (
         <ViolationSummaryBar
           violations={violations}
-          onOpenPanel={() => setViolationPanelOpen(true)}
+          onOpenPanel={() => { setViolationPanelFilter('all'); setViolationPanelOpen(true); }}
         />
       )}
       <main className="flex-1 overflow-auto p-4">


### PR DESCRIPTION
## Summary

- ViolationSummaryBar の「詳細」ボタンクリック時に `violationPanelFilter` を `'all'` にリセット
- Popover 経由で severity フィルタ適用後、SummaryBar から開くと前回フィルタが残る問題を修正

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] Vitest: 1015件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)