### PR TITLE
fix: checkerの時間重複チェックでlinked_orderペアを除外

### DIFF
--- a/web/src/lib/constraints/__tests__/checker.test.ts
+++ b/web/src/lib/constraints/__tests__/checker.test.ts
@@ -650,4 +650,93 @@ describe('checkConstraints', () => {
       expect(violations.some((v) => v.type === 'outside_hours')).toBe(false);
     });
   });
+
+  describe('linked_order_id（同一世帯リンクオーダー）', () => {
+    it('リンクオーダーのペアは時間重複として検出しない', () => {
+      const helpers = new Map([['H001', makeHelper()]]);
+      const customers = new Map([['C001', makeCustomer()]]);
+      const order1 = makeOrder({
+        id: 'O001',
+        start_time: '09:00',
+        end_time: '10:00',
+        linked_order_id: 'O002',
+      });
+      const order2 = makeOrder({
+        id: 'O002',
+        start_time: '09:00',
+        end_time: '10:00',
+        linked_order_id: 'O001',
+      });
+      const result = checkConstraints({
+        orders: [order1, order2],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      const v1 = result.get('O001') ?? [];
+      const v2 = result.get('O002') ?? [];
+      expect(v1.some((v) => v.type === 'overlap')).toBe(false);
+      expect(v2.some((v) => v.type === 'overlap')).toBe(false);
+    });
+
+    it('リンクオーダーでない重複は引き続き検出する', () => {
+      const helpers = new Map([['H001', makeHelper()]]);
+      const customers = new Map([['C001', makeCustomer()]]);
+      const order1 = makeOrder({
+        id: 'O001',
+        start_time: '09:00',
+        end_time: '10:00',
+      });
+      const order2 = makeOrder({
+        id: 'O002',
+        start_time: '09:30',
+        end_time: '10:30',
+      });
+      const result = checkConstraints({
+        orders: [order1, order2],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      const v1 = result.get('O001') ?? [];
+      expect(v1.some((v) => v.type === 'overlap')).toBe(true);
+    });
+
+    it('リンクオーダーでも別の非リンクオーダーとの重複は検出する', () => {
+      const helpers = new Map([['H001', makeHelper()]]);
+      const customers = new Map([['C001', makeCustomer()]]);
+      const linked1 = makeOrder({
+        id: 'O001',
+        start_time: '09:00',
+        end_time: '10:00',
+        linked_order_id: 'O002',
+      });
+      const linked2 = makeOrder({
+        id: 'O002',
+        start_time: '09:00',
+        end_time: '10:00',
+        linked_order_id: 'O001',
+      });
+      const unrelated = makeOrder({
+        id: 'O003',
+        start_time: '09:30',
+        end_time: '10:30',
+      });
+      const result = checkConstraints({
+        orders: [linked1, linked2, unrelated],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      // O001 と O003 は重複（リンクではない）
+      const v1 = result.get('O001') ?? [];
+      expect(v1.filter((v) => v.type === 'overlap').length).toBe(1);
+      // O003 は O001, O002 両方と重複
+      const v3 = result.get('O003') ?? [];
+      expect(v3.filter((v) => v.type === 'overlap').length).toBe(2);
+    });
+  });
 });

--- a/web/src/lib/constraints/checker.ts
+++ b/web/src/lib/constraints/checker.ts
@@ -236,6 +236,8 @@ export function checkConstraints(input: CheckInput): ViolationMap {
       for (let j = i + 1; j < sorted.length; j++) {
         // sorted[j]の開始がsorted[i]の終了以降なら、それ以降も重複しない
         if (sorted[j].start_time >= sorted[i].end_time) break;
+        // 同一世帯リンクオーダーのペアは意図的な重複のためスキップ
+        if (sorted[i].linked_order_id === sorted[j].id || sorted[j].linked_order_id === sorted[i].id) continue;
         const name = helper?.name.family ?? staffId;
         addViolation({
           orderId: sorted[i].id,


### PR DESCRIPTION
## Summary

- 同一世帯のリンクオーダー（`linked_order_id`）ペアが時間重複として誤検出されていた問題を修正
- optimizerは世帯制約により意図的に同時刻・同スタッフに割り当てるが、checkerがこれを考慮していなかった
- 最適化実行後に「時間重複 8件」が表示される原因を解消

## 変更内容

- `checker.ts`: 重複チェックのループ内で `linked_order_id` ペアを `continue` でスキップ（1行追加）
- `checker.test.ts`: テスト3件追加
  - リンクオーダーペアは重複として検出しない
  - リンクでない重複は引き続き検出する
  - リンクオーダーでも別の非リンクオーダーとの重複は検出する

## Test plan

- [x] tsc --noEmit: 0エラー
- [x] Vitest: 1018テスト全PASS（100ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)