### PR TITLE
feat: 最適化完了後に違反パネルを自動表示

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { addDays } from 'date-fns';
 import { DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { ScheduleProvider, useScheduleContext } from '@/contexts/ScheduleContext';
@@ -93,6 +93,19 @@ function SchedulePage() {
       }),
     [schedule, helpers, customers, unavailability, selectedDay, serviceTypes, travelTimeLookup]
   );
+
+  // 最適化完了後に違反があれば自動でViolationPanelを表示
+  const pendingViolationCheckRef = useRef(false);
+  const handleOptimizeComplete = useCallback(() => {
+    pendingViolationCheckRef.current = true;
+  }, []);
+  useEffect(() => {
+    if (pendingViolationCheckRef.current && violations.size > 0) {
+      pendingViolationCheckRef.current = false;
+      setViolationPanelFilter('all');
+      setViolationPanelOpen(true);
+    }
+  }, [violations]);
 
   // 週変更時に履歴をクリア
   useEffect(() => {
@@ -219,7 +232,7 @@ function SchedulePage() {
             orders={allOrders}
           />
           <ResetButton onHistoryClear={clearHistory} />
-          <OptimizeButton onHistoryClear={clearHistory} />
+          <OptimizeButton onHistoryClear={clearHistory} onComplete={handleOptimizeComplete} />
         </div>
       </div>
       <StatsBar

--- a/web/src/components/schedule/OptimizeButton.tsx
+++ b/web/src/components/schedule/OptimizeButton.tsx
@@ -28,9 +28,10 @@ import { DAY_OF_WEEK_LABELS } from '@/types';
 
 interface OptimizeButtonProps {
   onHistoryClear?: () => void;
+  onComplete?: () => void;
 }
 
-export function OptimizeButton({ onHistoryClear }: OptimizeButtonProps = {}) {
+export function OptimizeButton({ onHistoryClear, onComplete }: OptimizeButtonProps = {}) {
   const { weekStart } = useScheduleContext();
   const { customers, helpers, orders, unavailability } = useScheduleData(weekStart);
 
@@ -69,6 +70,7 @@ export function OptimizeButton({ onHistoryClear }: OptimizeButtonProps = {}) {
       setLastResult({ assignedCount: result.assigned_count, totalOrders: result.total_orders });
       setNotifyOpen(true);
       onHistoryClear?.();
+      onComplete?.();
     } catch (err) {
       if (err instanceof OptimizeApiError) {
         const messages: Record<number, string> = {


### PR DESCRIPTION
## Summary

- 最適化実行完了後、違反・警告が検知されていればViolationPanelを自動オープン
- 違反0件の場合は何も表示しない
- OptimizeButtonに `onComplete` コールバックを追加、Firestoreデータ更新後のタイミングで発火

## Test plan
- [x] tsc --noEmit: エラー0件
- [x] Vitest OptimizeButton: 7件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)