### PR TITLE
fix: 最適化・リセットダイアログに対象範囲を明記

### DIFF
--- a/web/src/components/schedule/OptimizeButton.tsx
+++ b/web/src/components/schedule/OptimizeButton.tsx
@@ -150,7 +150,7 @@ export function OptimizeButton({ onHistoryClear, onComplete }: OptimizeButtonPro
         <DialogHeader>
           <DialogTitle>シフト最適化の実行</DialogTitle>
           <DialogDescription>
-            {format(weekStart, 'yyyy/M/d')}週のシフトを最適化します。
+            {format(weekStart, 'yyyy/M/d')}週のシフトを最適化します（月〜日の全曜日が対象）。
           </DialogDescription>
         </DialogHeader>
         <ConstraintWeightsForm weights={weights} onChange={setWeights} />

--- a/web/src/components/schedule/ResetButton.tsx
+++ b/web/src/components/schedule/ResetButton.tsx
@@ -65,7 +65,7 @@ export function ResetButton({ onHistoryClear }: ResetButtonProps = {}) {
         <DialogHeader>
           <DialogTitle>割当をリセット</DialogTitle>
           <DialogDescription>
-            {format(weekStart, 'yyyy/M/d')}週のすべてのオーダー割当を解除します。
+            {format(weekStart, 'yyyy/M/d')}週のすべてのオーダー割当を解除します（月〜日の全曜日が対象）。
             この操作は元に戻せません。
           </DialogDescription>
         </DialogHeader>


### PR DESCRIPTION
## Summary

- 最適化・リセット実行前ダイアログに「月〜日の全曜日が対象」と明記
- 特定の曜日タブを見ている状態でも週全体に影響することをユーザーに伝達

## Test plan
- [x] tsc --noEmit: エラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)