### PR TITLE
fix: gunicorn workers 1→2でAPIブロック防止 (Closes #246)

### DIFF
--- a/optimizer/Dockerfile
+++ b/optimizer/Dockerfile
@@ -15,4 +15,4 @@ USER optimizer
 
 # gunicorn + uvicorn で起動
 # PORT環境変数はCloud Runが自動設定（デフォルト8080）
-CMD ["sh", "-c", "exec gunicorn optimizer.api.main:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT:-8080} --workers 1 --timeout 300"]
+CMD ["sh", "-c", "exec gunicorn optimizer.api.main:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT:-8080} --workers 2 --timeout 300"]


### PR DESCRIPTION
## Summary

- gunicorn `--workers` を1→2に変更
- 1ワーカーがFirestore接続ハングでブロックされても、もう1ワーカーが他リクエストを処理可能に
- メモリ1Gi内で2ワーカー動作可能（最適化の同時実行は実運用上ほぼ発生しない）

## 背景

2026-03-11にリセットAPIがハングし、CORSプリフライト含む全リクエストが504タイムアウト。
Cloud Runインスタンス再起動で即時復旧済み。

## Test plan
- [x] Dockerfile変更のみ（ロジック変更なし）
- [ ] CI: Optimizer Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)