### PR TITLE
fix: キャンセル済みオーダーの復元機能を追加

### DIFF
--- a/docs/schema/firestore-schema.md
+++ b/docs/schema/firestore-schema.md
@@ -139,6 +139,7 @@ pending → assigned（最適化エンジンによる割当）
 assigned → completed（サービス完了）
 assigned → cancelled（キャンセル）
 pending → cancelled（キャンセル）
+cancelled → pending（キャンセル取消・復元）
 ```
 
 ---

--- a/firebase/__tests__/firestore.rules.test.ts
+++ b/firebase/__tests__/firestore.rules.test.ts
@@ -756,7 +756,18 @@ describe('認証済みユーザー - orders status 遷移', () => {
     );
   });
 
-  it('cancelled → assigned の遷移は拒否される（最終状態）', async () => {
+  it('cancelled → pending の遷移が許可される（キャンセル取消）', async () => {
+    await setupOrderWithStatus('cancelled');
+    const authed = testEnv.authenticatedContext('user-1');
+    await assertSucceeds(
+      updateDoc(doc(authed.firestore(), 'orders', 'order-status'), {
+        status: 'pending',
+        updated_at: serverTimestamp(),
+      })
+    );
+  });
+
+  it('cancelled → assigned の遷移は拒否される', async () => {
     await setupOrderWithStatus('cancelled');
     const authed = testEnv.authenticatedContext('user-1');
     await assertFails(

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -58,6 +58,7 @@ service cloud.firestore {
         && (
           (oldStatus == 'assigned' && (newStatus == 'completed' || newStatus == 'cancelled'))
           || (oldStatus == 'pending' && newStatus == 'cancelled')
+          || (oldStatus == 'cancelled' && newStatus == 'pending')
         );
     }
 

--- a/web/src/components/schedule/OrderDetailPanel.tsx
+++ b/web/src/components/schedule/OrderDetailPanel.tsx
@@ -46,7 +46,7 @@ const NEXT_STATUSES: Record<OrderStatus, { value: OrderStatus; label: string }[]
     { value: 'cancelled', label: 'キャンセル' },
   ],
   completed: [],
-  cancelled: [],
+  cancelled: [{ value: 'pending', label: 'キャンセル取消（未割当に戻す）' }],
 };
 
 /** @deprecated フォールバック用。useServiceTypes() の label を優先 */
@@ -108,7 +108,7 @@ export function OrderDetailPanel({
     : order.customer_id;
 
   const nextStatuses = NEXT_STATUSES[order.status] ?? [];
-  const isFinalized = order.status === 'completed' || order.status === 'cancelled';
+  const isFinalized = order.status === 'completed';
 
   const handleStatusChange = async (newStatus: string) => {
     if (!isOrderStatus(newStatus)) return;

--- a/web/src/components/schedule/__tests__/OrderDetailPanel.test.tsx
+++ b/web/src/components/schedule/__tests__/OrderDetailPanel.test.tsx
@@ -198,10 +198,10 @@ describe('OrderDetailPanel - ステータス変更セレクト', () => {
     expect(screen.queryByTestId('status-change-select')).not.toBeInTheDocument();
   });
 
-  it('cancelledのとき → ステータス変更セレクトが表示されない', () => {
+  it('cancelledのとき → キャンセル取消セレクトが表示される', () => {
     const order = makeOrder({ status: 'cancelled' });
     render(<OrderDetailPanel order={order} {...defaultProps} />);
-    expect(screen.queryByTestId('status-change-select')).not.toBeInTheDocument();
+    expect(screen.getByTestId('status-change-select')).toBeInTheDocument();
   });
 });
 

--- a/web/src/lib/firestore/__tests__/updateOrder.test.ts
+++ b/web/src/lib/firestore/__tests__/updateOrder.test.ts
@@ -43,7 +43,11 @@ describe('updateOrderStatus - 状態遷移バリデーション', () => {
     );
   });
 
-  it('cancelled → assigned はエラーになる（最終状態）', async () => {
+  it('cancelled → pending は許可される（キャンセル取消）', async () => {
+    await expect(updateOrderStatus('o1', 'cancelled', 'pending')).resolves.not.toThrow();
+  });
+
+  it('cancelled → assigned はエラーになる', async () => {
     await expect(updateOrderStatus('o1', 'cancelled', 'assigned')).rejects.toThrow(
       'Invalid status transition'
     );
@@ -81,6 +85,14 @@ describe('isValidTransition - 純粋関数テスト', () => {
 
   it('pending → completed は false', () => {
     expect(isValidTransition('pending', 'completed')).toBe(false);
+  });
+
+  it('cancelled → pending は true（キャンセル取消）', () => {
+    expect(isValidTransition('cancelled', 'pending')).toBe(true);
+  });
+
+  it('cancelled → assigned は false', () => {
+    expect(isValidTransition('cancelled', 'assigned')).toBe(false);
   });
 });
 

--- a/web/src/lib/firestore/updateOrder.ts
+++ b/web/src/lib/firestore/updateOrder.ts
@@ -23,7 +23,7 @@ const VALID_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   pending: ['cancelled'],
   assigned: ['completed', 'cancelled'],
   completed: [],
-  cancelled: [],
+  cancelled: ['pending'],
 };
 
 const ORDER_STATUSES: readonly string[] = ['pending', 'assigned', 'completed', 'cancelled'];


### PR DESCRIPTION
## Summary
- キャンセル済み（cancelled）オーダーを未割当（pending）に戻せるようにする
- 誤操作でキャンセルした場合に取り消せない問題を修正
- UI・ビジネスロジック・Firestoreルール・テスト・ドキュメントを一貫して更新

## Test plan
- [x] updateOrder テスト 23件パス（遷移テスト2件追加）
- [x] OrderDetailPanel テスト 24件パス
- [x] Firestoreルールテスト 114件パス（cancelled→pending許可テスト追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)