### PR TITLE
fix: キャンセル復元UIを復元ボタンに変更

### DIFF
--- a/web/src/components/schedule/OrderDetailPanel.tsx
+++ b/web/src/components/schedule/OrderDetailPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Clock, MapPin, User, AlertTriangle, Pencil } from 'lucide-react';
+import { Clock, MapPin, User, AlertTriangle, Pencil, Undo2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -152,7 +152,19 @@ export function OrderDetailPanel({
                 <Badge variant="outline" className={STATUS_BADGE_STYLES[order.status] ?? ''}>
                   {STATUS_LABELS[order.status]}
                 </Badge>
-                {nextStatuses.length > 0 && (
+                {order.status === 'cancelled' ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-xs"
+                    disabled={statusSaving}
+                    onClick={() => handleStatusChange('pending')}
+                    data-testid="status-restore-button"
+                  >
+                    <Undo2 className="mr-1 h-3 w-3" />
+                    復元
+                  </Button>
+                ) : nextStatuses.length > 0 && (
                   <Select
                     onValueChange={handleStatusChange}
                     disabled={statusSaving}

--- a/web/src/components/schedule/__tests__/OrderDetailPanel.test.tsx
+++ b/web/src/components/schedule/__tests__/OrderDetailPanel.test.tsx
@@ -198,10 +198,11 @@ describe('OrderDetailPanel - ステータス変更セレクト', () => {
     expect(screen.queryByTestId('status-change-select')).not.toBeInTheDocument();
   });
 
-  it('cancelledのとき → キャンセル取消セレクトが表示される', () => {
+  it('cancelledのとき → 復元ボタンが表示される', () => {
     const order = makeOrder({ status: 'cancelled' });
     render(<OrderDetailPanel order={order} {...defaultProps} />);
-    expect(screen.getByTestId('status-change-select')).toBeInTheDocument();
+    expect(screen.getByTestId('status-restore-button')).toBeInTheDocument();
+    expect(screen.getByText('復元')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- キャンセル済みオーダーの復元操作をセレクト→明示的な「復元」ボタンに変更
- Undo2アイコン付きで直感的に操作可能に

## Test plan
- [x] OrderDetailPanel テスト 24件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)