### PR TITLE
feat: キャンセル/復元をトグルボタン化

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -40,7 +40,7 @@ function SchedulePage() {
   const { customers, helpers, orderCounts, getDaySchedule, unavailability, loading, travelTimeLookup } =
     useScheduleData(weekStart);
 
-  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [violationPanelOpen, setViolationPanelOpen] = useState(false);
   const [violationPanelFilter, setViolationPanelFilter] = useState<ViolationSeverity | 'all'>('all');
@@ -66,6 +66,11 @@ function SchedulePage() {
     }
     return orders;
   }, [weekStart, getDaySchedule]);
+
+  const selectedOrder = useMemo(
+    () => (selectedOrderId ? allOrders.find((o) => o.id === selectedOrderId) ?? null : null),
+    [selectedOrderId, allOrders],
+  );
 
   const { diffMap } = useAssignmentDiff(weekStart, allOrders);
 
@@ -169,7 +174,7 @@ function SchedulePage() {
   }, [allOrders, helpers, selectedDay, dayDate]);
 
   const handleOrderClick = (order: Order) => {
-    setSelectedOrder(order);
+    setSelectedOrderId(order.id);
     setDetailOpen(true);
   };
 

--- a/web/src/components/schedule/OrderDetailPanel.tsx
+++ b/web/src/components/schedule/OrderDetailPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Clock, MapPin, User, AlertTriangle, Pencil, Undo2 } from 'lucide-react';
+import { Clock, MapPin, User, AlertTriangle, Pencil, Undo2, Ban, CheckCircle2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -11,17 +11,10 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { StaffMultiSelect } from '@/components/masters/StaffMultiSelect';
 import { AssignmentDiffBadge } from '@/components/schedule/AssignmentDiffBadge';
 import { updateOrderStatus, isOrderStatus } from '@/lib/firestore/updateOrder';
-import type { Order, Customer, Helper, OrderStatus } from '@/types';
+import type { Order, Customer, Helper } from '@/types';
 import type { Violation } from '@/lib/constraints/checker';
 import type { AssignmentDiff } from '@/hooks/useAssignmentDiff';
 import { useServiceTypes } from '@/hooks/useServiceTypes';
@@ -39,15 +32,6 @@ interface OrderDetailPanelProps {
   saving?: boolean;
 }
 
-const NEXT_STATUSES: Record<OrderStatus, { value: OrderStatus; label: string }[]> = {
-  pending: [{ value: 'cancelled', label: 'キャンセル' }],
-  assigned: [
-    { value: 'completed', label: '完了（実績確認済み）' },
-    { value: 'cancelled', label: 'キャンセル' },
-  ],
-  completed: [],
-  cancelled: [{ value: 'pending', label: 'キャンセル取消（未割当に戻す）' }],
-};
 
 /** @deprecated フォールバック用。useServiceTypes() の label を優先 */
 const SERVICE_LABELS_FALLBACK: Record<string, string> = {
@@ -107,7 +91,6 @@ export function OrderDetailPanel({
     ? `${customer.name.family} ${customer.name.given}`
     : order.customer_id;
 
-  const nextStatuses = NEXT_STATUSES[order.status] ?? [];
   const isFinalized = order.status === 'completed' || order.status === 'cancelled';
 
   const handleStatusChange = async (newStatus: string) => {
@@ -155,7 +138,7 @@ export function OrderDetailPanel({
                 <Badge variant="outline" className={STATUS_BADGE_STYLES[order.status] ?? ''}>
                   {STATUS_LABELS[order.status]}
                 </Badge>
-                {order.status === 'cancelled' ? (
+                {order.status === 'cancelled' && (
                   <Button
                     variant="outline"
                     size="sm"
@@ -167,25 +150,32 @@ export function OrderDetailPanel({
                     <Undo2 className="mr-1 h-3 w-3" />
                     復元
                   </Button>
-                ) : nextStatuses.length > 0 && (
-                  <Select
-                    onValueChange={handleStatusChange}
+                )}
+                {order.status === 'assigned' && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-xs"
                     disabled={statusSaving}
+                    onClick={() => handleStatusChange('completed')}
+                    data-testid="status-complete-button"
                   >
-                    <SelectTrigger
-                      className="h-7 w-auto min-w-[100px] text-xs"
-                      data-testid="status-change-select"
-                    >
-                      <SelectValue placeholder="変更..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {nextStatuses.map((s) => (
-                        <SelectItem key={s.value} value={s.value}>
-                          {s.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    <CheckCircle2 className="mr-1 h-3 w-3" />
+                    完了
+                  </Button>
+                )}
+                {(order.status === 'pending' || order.status === 'assigned') && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-xs text-destructive hover:text-destructive"
+                    disabled={statusSaving}
+                    onClick={() => handleStatusChange('cancelled')}
+                    data-testid="status-cancel-button"
+                  >
+                    <Ban className="mr-1 h-3 w-3" />
+                    キャンセル
+                  </Button>
                 )}
               </div>
             </div>

--- a/web/src/components/schedule/__tests__/OrderDetailPanel.test.tsx
+++ b/web/src/components/schedule/__tests__/OrderDetailPanel.test.tsx
@@ -33,16 +33,6 @@ vi.mock('@/components/ui/sheet', () => ({
   SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
 }));
 
-// Select をモック（Radix ポータル対策）
-vi.mock('@/components/ui/select', () => ({
-  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectTrigger: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
-    <button {...props}>{children}</button>,
-  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
-  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) =>
-    <option value={value}>{children}</option>,
-}));
 
 // StaffMultiSelect をモック
 vi.mock('@/components/masters/StaffMultiSelect', () => ({
@@ -185,17 +175,33 @@ describe('OrderDetailPanel - 基本情報', () => {
   });
 });
 
-describe('OrderDetailPanel - ステータス変更セレクト', () => {
-  it('pendingのとき → ステータス変更セレクトが表示される', () => {
+describe('OrderDetailPanel - ステータス変更ボタン', () => {
+  it('pendingのとき → キャンセルボタンが表示される', () => {
     const order = makeOrder({ status: 'pending' });
     render(<OrderDetailPanel order={order} {...defaultProps} />);
-    expect(screen.getByTestId('status-change-select')).toBeInTheDocument();
+    expect(screen.getByTestId('status-cancel-button')).toBeInTheDocument();
+    expect(screen.getByText('キャンセル')).toBeInTheDocument();
   });
 
-  it('completedのとき → ステータス変更セレクトが表示されない', () => {
+  it('pendingのとき → 完了ボタンは表示されない', () => {
+    const order = makeOrder({ status: 'pending' });
+    render(<OrderDetailPanel order={order} {...defaultProps} />);
+    expect(screen.queryByTestId('status-complete-button')).not.toBeInTheDocument();
+  });
+
+  it('assignedのとき → キャンセルボタンと完了ボタンが表示される', () => {
+    const order = makeOrder({ status: 'assigned' });
+    render(<OrderDetailPanel order={order} {...defaultProps} />);
+    expect(screen.getByTestId('status-cancel-button')).toBeInTheDocument();
+    expect(screen.getByTestId('status-complete-button')).toBeInTheDocument();
+  });
+
+  it('completedのとき → ステータス変更ボタンが表示されない', () => {
     const order = makeOrder({ status: 'completed' });
     render(<OrderDetailPanel order={order} {...defaultProps} />);
-    expect(screen.queryByTestId('status-change-select')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('status-cancel-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('status-complete-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('status-restore-button')).not.toBeInTheDocument();
   });
 
   it('cancelledのとき → 復元ボタンが表示される', () => {
@@ -203,6 +209,12 @@ describe('OrderDetailPanel - ステータス変更セレクト', () => {
     render(<OrderDetailPanel order={order} {...defaultProps} />);
     expect(screen.getByTestId('status-restore-button')).toBeInTheDocument();
     expect(screen.getByText('復元')).toBeInTheDocument();
+  });
+
+  it('cancelledのとき → キャンセルボタンは表示されない', () => {
+    const order = makeOrder({ status: 'cancelled' });
+    render(<OrderDetailPanel order={order} {...defaultProps} />);
+    expect(screen.queryByTestId('status-cancel-button')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- Selectドロップダウンを廃止し、キャンセル・復元・完了を個別ボタンに変更
- `selectedOrder` をIDベースで管理し、Firestoreリアルタイム更新がパネルに即反映
- パネルを閉じずにキャンセル⇔復元をワンクリックでトグル切替可能に

## Test plan
- [x] OrderDetailPanel テスト 27件パス
- [x] page.tsx テスト 3件パス
- [x] 型チェック・lintエラーなし
- [ ] 本番でpending/assigned→キャンセル→復元のトグル切替がパネル内で完結することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)