### PR TITLE
fix: 同一住所インジケーターを当日オーダーがある顧客ペアのみに限定

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -74,7 +74,6 @@ function SchedulePage() {
   );
 
   const { diffMap } = useAssignmentDiff(weekStart, allOrders);
-  const addressGroupMap = useAddressGroups(customers);
 
   const dayIndex = DAY_OF_WEEK_ORDER.indexOf(selectedDay);
   const dayDate = useMemo(() => addDays(weekStart, dayIndex), [weekStart, dayIndex]);
@@ -82,6 +81,21 @@ function SchedulePage() {
     () => getDaySchedule(selectedDay, dayDate),
     [getDaySchedule, selectedDay, dayDate]
   );
+
+  // 当日オーダーがある顧客IDのSet（同一住所グループフィルタ用）
+  const activeCustomerIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const row of schedule.helperRows) {
+      for (const order of row.orders) {
+        ids.add(order.customer_id);
+      }
+    }
+    for (const order of schedule.unassignedOrders) {
+      ids.add(order.customer_id);
+    }
+    return ids;
+  }, [schedule]);
+  const addressGroupMap = useAddressGroups(customers, activeCustomerIds);
 
   const violations = useMemo(
     () =>

--- a/web/src/hooks/__tests__/useAddressGroups.test.ts
+++ b/web/src/hooks/__tests__/useAddressGroups.test.ts
@@ -91,6 +91,35 @@ describe('buildAddressGroupMap', () => {
     const result = buildAddressGroupMap(customers);
     expect(result.size).toBe(0);
   });
+
+  describe('activeCustomerIds フィルタ', () => {
+    const customers = new Map<string, Customer>([
+      ['C001', makeCustomer('C001', { same_household_customer_ids: ['C002'] })],
+      ['C002', makeCustomer('C002', { same_household_customer_ids: ['C001'] })],
+      ['C003', makeCustomer('C003', { same_household_customer_ids: ['C004'] })],
+      ['C004', makeCustomer('C004', { same_household_customer_ids: ['C003'] })],
+    ]);
+
+    it('両メンバーに当日オーダーがある場合のみ表示', () => {
+      const active = new Set(['C001', 'C002']); // C001+C002はペア、C003/C004は当日なし
+      const result = buildAddressGroupMap(customers, active);
+      expect(result.has('C001')).toBe(true);
+      expect(result.has('C002')).toBe(true);
+      expect(result.has('C003')).toBe(false);
+      expect(result.has('C004')).toBe(false);
+    });
+
+    it('ペアの片方のみ当日オーダー → グループ不成立', () => {
+      const active = new Set(['C001', 'C003']); // C001のみ(C002なし), C003のみ(C004なし)
+      const result = buildAddressGroupMap(customers, active);
+      expect(result.size).toBe(0);
+    });
+
+    it('activeCustomerIds 省略時は全グループ表示（後方互換）', () => {
+      const result = buildAddressGroupMap(customers);
+      expect(result.size).toBe(4);
+    });
+  });
 });
 
 describe('getAddressGroupColor', () => {

--- a/web/src/hooks/useAddressGroups.ts
+++ b/web/src/hooks/useAddressGroups.ts
@@ -18,10 +18,20 @@ export interface AddressGroupInfo {
  * same_household_customer_ids / same_facility_customer_ids を Union-Find で
  * 統合し、2名以上のグループに情報を割り当てる。
  *
+ * @param customers 全顧客マップ
+ * @param activeCustomerIds 当日オーダーがある顧客IDのSet（省略時はフィルタなし）。
+ *   指定した場合、グループメンバーのうち当日オーダーがある顧客が2名以上の
+ *   グループのみインジケーターを表示する。
  * @returns addressGroupMap — Map<customerId, AddressGroupInfo>（単独顧客は含まない）
  */
-export function useAddressGroups(customers: Map<string, Customer>): Map<string, AddressGroupInfo> {
-  return useMemo(() => buildAddressGroupMap(customers), [customers]);
+export function useAddressGroups(
+  customers: Map<string, Customer>,
+  activeCustomerIds?: Set<string>,
+): Map<string, AddressGroupInfo> {
+  return useMemo(
+    () => buildAddressGroupMap(customers, activeCustomerIds),
+    [customers, activeCustomerIds],
+  );
 }
 
 // ────────── Union-Find ──────────
@@ -67,7 +77,10 @@ class UnionFind {
 }
 
 /** テスト用にエクスポート */
-export function buildAddressGroupMap(customers: Map<string, Customer>): Map<string, AddressGroupInfo> {
+export function buildAddressGroupMap(
+  customers: Map<string, Customer>,
+  activeCustomerIds?: Set<string>,
+): Map<string, AddressGroupInfo> {
   const uf = new UnionFind();
   const customerIds = new Set(customers.keys());
 
@@ -113,12 +126,17 @@ export function buildAddressGroupMap(customers: Map<string, Customer>): Map<stri
   }
 
   // 2名以上のグループに情報を割り当て
+  // activeCustomerIds 指定時は、当日オーダーがあるメンバーが2名以上のグループのみ対象
   const result = new Map<string, AddressGroupInfo>();
   let groupIndex = 0;
   for (const [root, members] of groups) {
     if (members.length < 2) continue;
+    const activeMembers = activeCustomerIds
+      ? members.filter((id) => activeCustomerIds.has(id))
+      : members;
+    if (activeMembers.length < 2) continue;
     const type = groupTypes.get(root)!;
-    for (const id of members) {
+    for (const id of activeMembers) {
       result.set(id, { index: groupIndex, type });
     }
     groupIndex++;


### PR DESCRIPTION
## Summary
- 全顧客データからグループを計算していたため、当日にオーダーがないグループメンバーの相方にもインジケーターが誤表示されていた
- `useAddressGroups` に `activeCustomerIds` パラメータを追加し、当日スケジュールの顧客IDでフィルタ
- グループメンバーのうち当日オーダーがある顧客が2名以上の場合のみインジケーター表示

Closes #264

## Test plan
- [x] useAddressGroups テスト 12件パス（+3件追加: フィルタテスト）
- [x] 型チェックパス (`tsc --noEmit`)
- [x] 全テスト 96ファイル 1021件パス
- [ ] ブラウザで同一住所ペアの片方のみスケジュールされた日にインジケーターが出ないことを確認
- [ ] ブラウザで両方スケジュールされた日にインジケーターが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)