### PR TITLE
fix: 同一住所インジケーターを隣接オーダー限定に変更

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -24,7 +24,7 @@ import { useOrderEdit } from '@/hooks/useOrderEdit';
 import { useUndoRedo } from '@/hooks/useUndoRedo';
 import { useUndoRedoKeyboard } from '@/hooks/useUndoRedoKeyboard';
 import { useAssignmentDiff } from '@/hooks/useAssignmentDiff';
-import { useAddressGroups } from '@/hooks/useAddressGroups';
+import { useAdjacentAddressGroups } from '@/hooks/useAddressGroups';
 import { checkConstraints } from '@/lib/constraints/checker';
 import { createConfirmEditCommand } from '@/lib/undo/commands';
 import { useServiceTypes } from '@/hooks/useServiceTypes';
@@ -82,20 +82,8 @@ function SchedulePage() {
     [getDaySchedule, selectedDay, dayDate]
   );
 
-  // 当日オーダーがある顧客IDのSet（同一住所グループフィルタ用）
-  const activeCustomerIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const row of schedule.helperRows) {
-      for (const order of row.orders) {
-        ids.add(order.customer_id);
-      }
-    }
-    for (const order of schedule.unassignedOrders) {
-      ids.add(order.customer_id);
-    }
-    return ids;
-  }, [schedule]);
-  const addressGroupMap = useAddressGroups(customers, activeCustomerIds);
+  // 同じヘルパー行で隣接する同一住所ペアのみインジケーター表示
+  const addressGroupMap = useAdjacentAddressGroups(customers, schedule.helperRows);
 
   const violations = useMemo(
     () =>

--- a/web/src/components/gantt/GanttChart.tsx
+++ b/web/src/components/gantt/GanttChart.tsx
@@ -117,7 +117,6 @@ export function GanttChart({ schedule, customers, violations, onOrderClick, drop
           customers={customers}
           onOrderClick={onOrderClick}
           dropZoneStatus={dropZoneStatuses?.get('unassigned-section')}
-          addressGroupMap={addressGroupMap}
         />
       </div>
     </GanttScaleProvider>

--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -155,7 +155,7 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
               sourceHelperId={row.helper.id}
               staffCount={sc}
               onConfirmManualEdit={onConfirmManualEdit}
-              addressGroupInfo={addressGroupMap?.get(order.customer_id)}
+              addressGroupInfo={addressGroupMap?.get(order.id)}
             />
           );
         })}

--- a/web/src/components/gantt/UnassignedSection.tsx
+++ b/web/src/components/gantt/UnassignedSection.tsx
@@ -8,8 +8,6 @@ import type { Order, Customer } from '@/types';
 import type { DragData, DropZoneStatus } from '@/lib/dnd/types';
 import { cn } from '@/lib/utils';
 import { useServiceTypes } from '@/hooks/useServiceTypes';
-import { getAddressGroupColor } from '@/hooks/useAddressGroups';
-import type { AddressGroupInfo } from '@/hooks/useAddressGroups';
 
 const DROP_ZONE_STYLES: Record<DropZoneStatus, string> = {
   idle: '',
@@ -23,7 +21,6 @@ interface UnassignedSectionProps {
   customers: Map<string, Customer>;
   onOrderClick?: (order: Order) => void;
   dropZoneStatus?: DropZoneStatus;
-  addressGroupMap?: Map<string, AddressGroupInfo>;
 }
 
 /** @deprecated フォールバック用。useServiceTypes() の short_label を優先 */
@@ -54,13 +51,11 @@ function UnassignedOrderItem({
   customers,
   onOrderClick,
   serviceLabel,
-  addressGroupInfo,
 }: {
   order: Order;
   customers: Map<string, Customer>;
   onOrderClick?: (order: Order) => void;
   serviceLabel: string;
-  addressGroupInfo?: AddressGroupInfo;
 }) {
   const customer = customers.get(order.customer_id);
   const name = customer
@@ -92,18 +87,6 @@ function UnassignedOrderItem({
       {...attributes}
       {...listeners}
     >
-      {addressGroupInfo && (
-        <span className="shrink-0 flex items-center gap-0.5" title={customer?.address ? `📍 ${customer.address}` : undefined}>
-          <span
-            className="w-2.5 h-2.5 rounded-full ring-1 ring-white"
-            style={{ background: getAddressGroupColor(addressGroupInfo.index) }}
-            aria-hidden="true"
-          />
-          <span className="text-[10px] leading-none">
-            {addressGroupInfo.type === 'facility' ? '🏢' : '🏠'}
-          </span>
-        </span>
-      )}
       <Badge variant="outline" className={cn('text-[10px] border', badgeColor)}>
         {serviceLabel}
       </Badge>
@@ -115,7 +98,7 @@ function UnassignedOrderItem({
   );
 }
 
-export function UnassignedSection({ orders, customers, onOrderClick, dropZoneStatus = 'idle', addressGroupMap }: UnassignedSectionProps) {
+export function UnassignedSection({ orders, customers, onOrderClick, dropZoneStatus = 'idle' }: UnassignedSectionProps) {
   const { serviceTypes } = useServiceTypes();
   const { setNodeRef, isOver } = useDroppable({
     id: 'unassigned-section',
@@ -147,7 +130,6 @@ export function UnassignedSection({ orders, customers, onOrderClick, dropZoneSta
             customers={customers}
             onOrderClick={onOrderClick}
             serviceLabel={serviceTypes.get(order.service_type)?.short_label ?? SERVICE_LABELS_FALLBACK[order.service_type] ?? order.service_type}
-            addressGroupInfo={addressGroupMap?.get(order.customer_id)}
           />
         ))}
         {orders.length === 0 && (

--- a/web/src/hooks/__tests__/useAddressGroups.test.ts
+++ b/web/src/hooks/__tests__/useAddressGroups.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { buildAddressGroupMap, getAddressGroupColor, ADDRESS_GROUP_COLORS } from '../useAddressGroups';
-import type { Customer } from '@/types';
+import { buildAddressGroupMap, buildAdjacentAddressOrderMap, getAddressGroupColor, ADDRESS_GROUP_COLORS } from '../useAddressGroups';
+import type { Customer, Order } from '@/types';
 
 function makeCustomer(id: string, overrides: Partial<Customer> = {}): Customer {
   return {
@@ -21,6 +21,24 @@ function makeCustomer(id: string, overrides: Partial<Customer> = {}): Customer {
   } as Customer;
 }
 
+function makeOrder(id: string, customerId: string, startTime: string, endTime: string): Order {
+  return {
+    id,
+    customer_id: customerId,
+    start_time: startTime,
+    end_time: endTime,
+    assigned_staff_ids: [],
+    service_type: 'physical_care',
+    status: 'pending',
+    day_of_week: 'monday',
+    week_start_date: new Date('2026-03-09'),
+    date: new Date('2026-03-09'),
+    manually_edited: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+  } as Order;
+}
+
 describe('buildAddressGroupMap', () => {
   it('空のMapでは空を返す', () => {
     const result = buildAddressGroupMap(new Map());
@@ -38,7 +56,7 @@ describe('buildAddressGroupMap', () => {
     expect(result.has('C002')).toBe(true);
     expect(result.get('C001')!.index).toBe(result.get('C002')!.index);
     expect(result.get('C001')!.type).toBe('household');
-    expect(result.has('C003')).toBe(false); // 単独 → 含まない
+    expect(result.has('C003')).toBe(false);
   });
 
   it('同一施設メンバーが同じグループになる', () => {
@@ -49,19 +67,6 @@ describe('buildAddressGroupMap', () => {
     const result = buildAddressGroupMap(customers);
     expect(result.get('C001')!.index).toBe(result.get('C002')!.index);
     expect(result.get('C001')!.type).toBe('facility');
-  });
-
-  it('世帯と施設が混在するグループを統合する', () => {
-    const customers = new Map<string, Customer>([
-      ['C001', makeCustomer('C001', { same_household_customer_ids: ['C002'] })],
-      ['C002', makeCustomer('C002', { same_household_customer_ids: ['C001'], same_facility_customer_ids: ['C003'] })],
-      ['C003', makeCustomer('C003', { same_facility_customer_ids: ['C002'] })],
-    ]);
-    const result = buildAddressGroupMap(customers);
-    // C001, C002, C003 が全て同一グループ
-    expect(result.get('C001')!.index).toBe(result.get('C002')!.index);
-    expect(result.get('C002')!.index).toBe(result.get('C003')!.index);
-    expect(result.get('C001')!.type).toBe('mixed');
   });
 
   it('複数の独立グループに異なるインデックスを割り当てる', () => {
@@ -80,45 +85,83 @@ describe('buildAddressGroupMap', () => {
       ['C001', makeCustomer('C001', { same_household_customer_ids: ['C999'] })],
     ]);
     const result = buildAddressGroupMap(customers);
-    expect(result.has('C001')).toBe(false); // 相方が存在しないので単独扱い
+    expect(result.has('C001')).toBe(false);
+  });
+});
+
+describe('buildAdjacentAddressOrderMap', () => {
+  const customers = new Map<string, Customer>([
+    ['C001', makeCustomer('C001', { same_household_customer_ids: ['C002'] })],
+    ['C002', makeCustomer('C002', { same_household_customer_ids: ['C001'] })],
+    ['C003', makeCustomer('C003')],
+  ]);
+
+  it('隣接する同一住所ペアにインジケーターを付与する', () => {
+    const helperRows = [{
+      helper: { id: 'H1' },
+      orders: [
+        makeOrder('O1', 'C001', '09:00', '10:00'),
+        makeOrder('O2', 'C002', '10:00', '11:00'),
+      ],
+    }];
+    const result = buildAdjacentAddressOrderMap(helperRows, customers);
+    expect(result.has('O1')).toBe(true);
+    expect(result.has('O2')).toBe(true);
+    expect(result.get('O1')!.index).toBe(result.get('O2')!.index);
   });
 
-  it('全員が単独 → 空Mapを返す', () => {
-    const customers = new Map<string, Customer>([
-      ['C001', makeCustomer('C001')],
-      ['C002', makeCustomer('C002')],
-    ]);
-    const result = buildAddressGroupMap(customers);
+  it('隣接していない同一住所ペアにはインジケーターなし', () => {
+    const helperRows = [{
+      helper: { id: 'H1' },
+      orders: [
+        makeOrder('O1', 'C001', '09:00', '10:00'),
+        makeOrder('O3', 'C003', '10:00', '11:00'),
+        makeOrder('O2', 'C002', '11:00', '12:00'),
+      ],
+    }];
+    const result = buildAdjacentAddressOrderMap(helperRows, customers);
     expect(result.size).toBe(0);
   });
 
-  describe('activeCustomerIds フィルタ', () => {
-    const customers = new Map<string, Customer>([
-      ['C001', makeCustomer('C001', { same_household_customer_ids: ['C002'] })],
-      ['C002', makeCustomer('C002', { same_household_customer_ids: ['C001'] })],
-      ['C003', makeCustomer('C003', { same_household_customer_ids: ['C004'] })],
-      ['C004', makeCustomer('C004', { same_household_customer_ids: ['C003'] })],
-    ]);
+  it('異なるヘルパー行の隣接はカウントしない', () => {
+    const helperRows = [
+      { helper: { id: 'H1' }, orders: [makeOrder('O1', 'C001', '09:00', '10:00')] },
+      { helper: { id: 'H2' }, orders: [makeOrder('O2', 'C002', '10:00', '11:00')] },
+    ];
+    const result = buildAdjacentAddressOrderMap(helperRows, customers);
+    expect(result.size).toBe(0);
+  });
 
-    it('両メンバーに当日オーダーがある場合のみ表示', () => {
-      const active = new Set(['C001', 'C002']); // C001+C002はペア、C003/C004は当日なし
-      const result = buildAddressGroupMap(customers, active);
-      expect(result.has('C001')).toBe(true);
-      expect(result.has('C002')).toBe(true);
-      expect(result.has('C003')).toBe(false);
-      expect(result.has('C004')).toBe(false);
-    });
+  it('同一住所でないペアは隣接でもインジケーターなし', () => {
+    const helperRows = [{
+      helper: { id: 'H1' },
+      orders: [
+        makeOrder('O1', 'C001', '09:00', '10:00'),
+        makeOrder('O3', 'C003', '10:00', '11:00'),
+      ],
+    }];
+    const result = buildAdjacentAddressOrderMap(helperRows, customers);
+    expect(result.size).toBe(0);
+  });
 
-    it('ペアの片方のみ当日オーダー → グループ不成立', () => {
-      const active = new Set(['C001', 'C003']); // C001のみ(C002なし), C003のみ(C004なし)
-      const result = buildAddressGroupMap(customers, active);
-      expect(result.size).toBe(0);
-    });
+  it('空のヘルパー行では空を返す', () => {
+    const result = buildAdjacentAddressOrderMap([], customers);
+    expect(result.size).toBe(0);
+  });
 
-    it('activeCustomerIds 省略時は全グループ表示（後方互換）', () => {
-      const result = buildAddressGroupMap(customers);
-      expect(result.size).toBe(4);
-    });
+  it('3連続の同一住所オーダー（A→B→A）でも隣接ペアごとに判定', () => {
+    const helperRows = [{
+      helper: { id: 'H1' },
+      orders: [
+        makeOrder('O1', 'C001', '09:00', '10:00'),
+        makeOrder('O2', 'C002', '10:00', '11:00'),
+        makeOrder('O3', 'C001', '11:00', '12:00'),
+      ],
+    }];
+    const result = buildAdjacentAddressOrderMap(helperRows, customers);
+    expect(result.has('O1')).toBe(true);
+    expect(result.has('O2')).toBe(true);
+    expect(result.has('O3')).toBe(true);
   });
 });
 

--- a/web/src/hooks/useAddressGroups.ts
+++ b/web/src/hooks/useAddressGroups.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { Customer } from '@/types';
+import type { Customer, Order } from '@/types';
 
 /** グループ種別: 世帯 / 施設 / 混在 */
 export type AddressGroupType = 'household' | 'facility' | 'mixed';
@@ -13,24 +13,19 @@ export interface AddressGroupInfo {
 }
 
 /**
- * 同一住所グループの情報マップを計算するフック。
- *
- * same_household_customer_ids / same_facility_customer_ids を Union-Find で
- * 統合し、2名以上のグループに情報を割り当てる。
+ * 同じヘルパー行で隣接する同一住所ペアのオーダーにのみインジケーターを付与するフック。
  *
  * @param customers 全顧客マップ
- * @param activeCustomerIds 当日オーダーがある顧客IDのSet（省略時はフィルタなし）。
- *   指定した場合、グループメンバーのうち当日オーダーがある顧客が2名以上の
- *   グループのみインジケーターを表示する。
- * @returns addressGroupMap — Map<customerId, AddressGroupInfo>（単独顧客は含まない）
+ * @param helperRows ヘルパー行（各行にorders配列）
+ * @returns Map<orderId, AddressGroupInfo>（隣接ペアに該当するオーダーのみ）
  */
-export function useAddressGroups(
+export function useAdjacentAddressGroups(
   customers: Map<string, Customer>,
-  activeCustomerIds?: Set<string>,
+  helperRows: { helper: { id: string }; orders: Order[] }[],
 ): Map<string, AddressGroupInfo> {
   return useMemo(
-    () => buildAddressGroupMap(customers, activeCustomerIds),
-    [customers, activeCustomerIds],
+    () => buildAdjacentAddressOrderMap(helperRows, customers),
+    [customers, helperRows],
   );
 }
 
@@ -76,10 +71,9 @@ class UnionFind {
   }
 }
 
-/** テスト用にエクスポート */
+/** テスト用にエクスポート: 顧客マスタから同一住所グループを構築 */
 export function buildAddressGroupMap(
   customers: Map<string, Customer>,
-  activeCustomerIds?: Set<string>,
 ): Map<string, AddressGroupInfo> {
   const uf = new UnionFind();
   const customerIds = new Set(customers.keys());
@@ -112,7 +106,6 @@ export function buildAddressGroupMap(
     if (members.length < 2) continue;
     let hasHousehold = false;
     let hasFacility = false;
-    // メンバーペアがhousehold/facilityのどちらに属するか確認
     for (const id of members) {
       const customer = customers.get(id)!;
       for (const relatedId of customer.same_household_customer_ids) {
@@ -126,20 +119,54 @@ export function buildAddressGroupMap(
   }
 
   // 2名以上のグループに情報を割り当て
-  // activeCustomerIds 指定時は、当日オーダーがあるメンバーが2名以上のグループのみ対象
   const result = new Map<string, AddressGroupInfo>();
   let groupIndex = 0;
   for (const [root, members] of groups) {
     if (members.length < 2) continue;
-    const activeMembers = activeCustomerIds
-      ? members.filter((id) => activeCustomerIds.has(id))
-      : members;
-    if (activeMembers.length < 2) continue;
     const type = groupTypes.get(root)!;
-    for (const id of activeMembers) {
+    for (const id of members) {
       result.set(id, { index: groupIndex, type });
     }
     groupIndex++;
+  }
+
+  return result;
+}
+
+/**
+ * テスト用にエクスポート: ヘルパー行の隣接オーダーペアから表示対象を計算。
+ *
+ * 同じヘルパー行で時間的に隣接（前のend_time === 次のstart_time）し、
+ * かつ同一住所グループに属するオーダーのみインジケーターを付与する。
+ *
+ * @returns Map<orderId, AddressGroupInfo>
+ */
+export function buildAdjacentAddressOrderMap(
+  helperRows: { helper: { id: string }; orders: Order[] }[],
+  customers: Map<string, Customer>,
+): Map<string, AddressGroupInfo> {
+  const customerGroupMap = buildAddressGroupMap(customers);
+  const result = new Map<string, AddressGroupInfo>();
+
+  for (const row of helperRows) {
+    const sorted = [...row.orders].sort((a, b) => a.start_time.localeCompare(b.start_time));
+
+    for (let i = 0; i < sorted.length - 1; i++) {
+      const current = sorted[i];
+      const next = sorted[i + 1];
+
+      // 隣接チェック: 前のend_time === 次のstart_time
+      if (current.end_time !== next.start_time) continue;
+
+      // 同一住所グループチェック
+      const currentGroup = customerGroupMap.get(current.customer_id);
+      const nextGroup = customerGroupMap.get(next.customer_id);
+
+      if (currentGroup && nextGroup && currentGroup.index === nextGroup.index) {
+        result.set(current.id, currentGroup);
+        result.set(next.id, nextGroup);
+      }
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary
- 同じヘルパー行で時間的に隣接（end_time === start_time）し、かつ同一住所グループのオーダーのみインジケーター表示
- 未割当セクションからはインジケーターを削除（隣接判定不可のため）
- `useAddressGroups` → `useAdjacentAddressGroups` にリネーム、マップのキーを customerId → orderId に変更

Closes #264

## Test plan
- [x] useAddressGroups テスト 13件パス（隣接判定テスト6件追加）
- [x] 型チェックパス
- [x] 全テスト 1022件パス（96ファイル）
- [ ] ブラウザで隣接ペアのみにインジケーター表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)