### PR TITLE
fix: 同一住所インジケーターを1色に統一しアンダーラインを太く

### DIFF
--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -9,7 +9,7 @@ import { useSlotWidth } from './GanttScaleContext';
 import type { Order, Customer } from '@/types';
 import type { DragData } from '@/lib/dnd/types';
 import { cn } from '@/lib/utils';
-import { getAddressGroupColor } from '@/hooks/useAddressGroups';
+import { ADDRESS_GROUP_COLOR } from '@/hooks/useAddressGroups';
 import type { AddressGroupInfo } from '@/hooks/useAddressGroups';
 
 interface GanttBarProps {
@@ -51,14 +51,14 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
     ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
     : order.customer_id;
 
-  const addressColor = addressGroupInfo ? getAddressGroupColor(addressGroupInfo.index) : undefined;
+  const addressColor = addressGroupInfo ? ADDRESS_GROUP_COLOR : undefined;
   const addressIcon = addressGroupInfo?.type === 'facility' ? '🏢' : addressGroupInfo ? '🏠' : undefined;
 
   const style = {
     left,
     width: Math.max(width, slotWidth * 2),
     transform: CSS.Translate.toString(transform),
-    ...(addressColor ? { borderBottom: `3px solid ${addressColor}` } : {}),
+    ...(addressColor ? { borderBottom: `5px solid ${addressColor}` } : {}),
   };
 
   return (

--- a/web/src/hooks/__tests__/useAddressGroups.test.ts
+++ b/web/src/hooks/__tests__/useAddressGroups.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildAddressGroupMap, buildAdjacentAddressOrderMap, getAddressGroupColor, ADDRESS_GROUP_COLORS } from '../useAddressGroups';
+import { buildAddressGroupMap, buildAdjacentAddressOrderMap, ADDRESS_GROUP_COLOR } from '../useAddressGroups';
 import type { Customer, Order } from '@/types';
 
 function makeCustomer(id: string, overrides: Partial<Customer> = {}): Customer {
@@ -165,15 +165,9 @@ describe('buildAdjacentAddressOrderMap', () => {
   });
 });
 
-describe('getAddressGroupColor', () => {
-  it('インデックス0-4で異なる色を返す', () => {
-    const colors = [0, 1, 2, 3, 4].map(getAddressGroupColor);
-    const unique = new Set(colors);
-    expect(unique.size).toBe(5);
-  });
-
-  it('5以上のインデックスはローテーションする', () => {
-    expect(getAddressGroupColor(5)).toBe(ADDRESS_GROUP_COLORS[0]);
-    expect(getAddressGroupColor(6)).toBe(ADDRESS_GROUP_COLORS[1]);
+describe('ADDRESS_GROUP_COLOR', () => {
+  it('固定色が定義されている', () => {
+    expect(ADDRESS_GROUP_COLOR).toBeTruthy();
+    expect(typeof ADDRESS_GROUP_COLOR).toBe('string');
   });
 });

--- a/web/src/hooks/useAddressGroups.ts
+++ b/web/src/hooks/useAddressGroups.ts
@@ -172,16 +172,5 @@ export function buildAdjacentAddressOrderMap(
   return result;
 }
 
-/** アンダーライン色パレット（5色ローテーション） */
-export const ADDRESS_GROUP_COLORS = [
-  'oklch(0.65 0.22 330)',  // ローズ
-  'oklch(0.65 0.18 195)',  // シアン
-  'oklch(0.72 0.18 85)',   // イエロー
-  'oklch(0.58 0.18 145)',  // エメラルド
-  'oklch(0.60 0.18 275)',  // パープル
-] as const;
-
-/** groupIndex → インラインスタイル色を返す */
-export function getAddressGroupColor(groupIndex: number): string {
-  return ADDRESS_GROUP_COLORS[groupIndex % ADDRESS_GROUP_COLORS.length]!;
-}
+/** 同一住所インジケーターの固定色（1色のみ） */
+export const ADDRESS_GROUP_COLOR = 'oklch(0.65 0.22 330)'; // ローズ


### PR DESCRIPTION
## Summary
- 5色ローテーションを廃止し、ローズ1色に統一（紛らわしさ解消）
- アンダーライン太さを3px→5pxに変更（視認性向上）
- `getAddressGroupColor`関数と`ADDRESS_GROUP_COLORS`配列を削除、`ADDRESS_GROUP_COLOR`定数に簡素化

## Test plan
- [x] useAddressGroups テスト12件パス
- [x] 型チェックパス
- [ ] ブラウザで全ペアが同一色・太めアンダーラインで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)