### PR TITLE
fix: CompanionDialogに「教える方」表示追加 & 制約違反に「（同行）」付与

### DIFF
--- a/web/src/components/schedule/CompanionDialog.tsx
+++ b/web/src/components/schedule/CompanionDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { Search, Users, X } from 'lucide-react';
+import { ClipboardList, Search, Users, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
@@ -54,6 +54,14 @@ export function CompanionDialog({
     ? helpers.get(order.companion_staff_id)
     : null;
 
+  // 「教える方」= 割当済みスタッフから同行者を除いたスタッフ
+  const teachingStaff = useMemo(() => {
+    return order.assigned_staff_ids
+      .filter((id) => id !== order.companion_staff_id)
+      .map((id) => helpers.get(id))
+      .filter((h): h is Helper => h != null);
+  }, [order.assigned_staff_ids, order.companion_staff_id, helpers]);
+
   const candidates = useMemo(
     () => getCompanionCandidates({ order, customer, helpers }),
     [order, customer, helpers],
@@ -101,6 +109,23 @@ export function CompanionDialog({
             研修目的で一時的に同行するスタッフを選択してください
           </DialogDescription>
         </DialogHeader>
+
+        {/* 教える方（担当スタッフ）表示 */}
+        {teachingStaff.length > 0 && (
+          <div className="rounded-md border p-2 bg-blue-50/50" data-testid="teaching-staff">
+            <div className="flex items-center gap-1.5 mb-1">
+              <ClipboardList className="h-4 w-4 text-blue-600" />
+              <span className="text-xs font-medium text-blue-700">教える方（担当スタッフ）</span>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {teachingStaff.map((h) => (
+                <Badge key={h.id} variant="secondary" className="text-xs">
+                  {h.name.family} {h.name.given}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* 現在の同行者表示 */}
         {currentCompanion && (

--- a/web/src/components/schedule/__tests__/CompanionDialog.test.tsx
+++ b/web/src/components/schedule/__tests__/CompanionDialog.test.tsx
@@ -143,6 +143,54 @@ describe('CompanionDialog', () => {
     expect(onRemoveCompanion).toHaveBeenCalled();
   });
 
+  it('「教える方」に担当スタッフ名が表示される', () => {
+    const order = makeOrder({ assigned_staff_ids: ['h1'] });
+    const customer = makeCustomer();
+
+    render(
+      <CompanionDialog
+        open={true}
+        onOpenChange={() => {}}
+        order={order}
+        customer={customer}
+        helpers={helpers}
+        onSetCompanion={() => {}}
+        onRemoveCompanion={() => {}}
+      />,
+    );
+
+    const section = screen.getByTestId('teaching-staff');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('教える方');
+    expect(section).toHaveTextContent('山田 太郎');
+  });
+
+  it('同行者は「教える方」に含まれない', () => {
+    const order = makeOrder({
+      assigned_staff_ids: ['h1', 'h2'],
+      companion_staff_id: 'h2',
+    });
+    const customer = makeCustomer();
+
+    render(
+      <CompanionDialog
+        open={true}
+        onOpenChange={() => {}}
+        order={order}
+        customer={customer}
+        helpers={helpers}
+        onSetCompanion={() => {}}
+        onRemoveCompanion={() => {}}
+      />,
+    );
+
+    const section = screen.getByTestId('teaching-staff');
+    // h1（山田）は教える方として表示される
+    expect(section).toHaveTextContent('山田 太郎');
+    // h2（鈴木）は同行者なので教える方には含まれない
+    expect(section).not.toHaveTextContent('鈴木 花子');
+  });
+
   it('openがfalseのとき描画されない', () => {
     render(
       <CompanionDialog

--- a/web/src/lib/constraints/__tests__/checker.test.ts
+++ b/web/src/lib/constraints/__tests__/checker.test.ts
@@ -764,4 +764,57 @@ describe('checkConstraints', () => {
       expect(v3.filter((v) => v.type === 'overlap').length).toBe(2);
     });
   });
+
+  describe('同行スタッフの違反メッセージ修飾', () => {
+    it('companion_staff_id のスタッフは違反メッセージに「（同行）」が付く', () => {
+      const helpers = new Map([
+        ['H001', makeHelper({ id: 'H001' })],
+        ['H002', makeHelper({ id: 'H002', name: { family: '加藤', given: '花子' } })],
+      ]);
+      const customers = new Map([['C001', makeCustomer({ preferred_staff_ids: ['H999'] })]]);
+      const result = checkConstraints({
+        orders: [makeOrder({
+          assigned_staff_ids: ['H001', 'H002'],
+          companion_staff_id: 'H002',
+          staff_count: 2,
+        })],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      const violations = result.get('O001') ?? [];
+      const companionViolation = violations.find(
+        (v) => v.type === 'preferred_staff' && v.staffId === 'H002'
+      );
+      expect(companionViolation).toBeDefined();
+      expect(companionViolation!.message).toContain('加藤（同行）');
+    });
+
+    it('通常スタッフの違反メッセージには「（同行）」が付かない', () => {
+      const helpers = new Map([
+        ['H001', makeHelper({ id: 'H001' })],
+        ['H002', makeHelper({ id: 'H002', name: { family: '加藤', given: '花子' } })],
+      ]);
+      const customers = new Map([['C001', makeCustomer({ preferred_staff_ids: ['H999'] })]]);
+      const result = checkConstraints({
+        orders: [makeOrder({
+          assigned_staff_ids: ['H001', 'H002'],
+          companion_staff_id: 'H002',
+          staff_count: 2,
+        })],
+        helpers,
+        customers,
+        unavailability: [],
+        day: 'monday',
+      });
+      const violations = result.get('O001') ?? [];
+      const normalViolation = violations.find(
+        (v) => v.type === 'preferred_staff' && v.staffId === 'H001'
+      );
+      expect(normalViolation).toBeDefined();
+      expect(normalViolation!.message).toContain('田中');
+      expect(normalViolation!.message).not.toContain('（同行）');
+    });
+  });
 });

--- a/web/src/lib/constraints/checker.ts
+++ b/web/src/lib/constraints/checker.ts
@@ -80,6 +80,11 @@ export function checkConstraints(input: CheckInput): ViolationMap {
       const helper = input.helpers.get(staffId);
       if (!helper) continue;
 
+      const isCompanion = staffId === order.companion_staff_id;
+      const staffLabel = isCompanion
+        ? `${helper.name.family}（同行）`
+        : helper.name.family;
+
       // NGスタッフ
       if (customer?.ng_staff_ids?.includes(staffId)) {
         addViolation({
@@ -87,7 +92,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
           staffId,
           type: 'ng_staff',
           severity: 'error',
-          message: `NGスタッフ ${helper.name.family} が割当済み`,
+          message: `NGスタッフ ${staffLabel} が割当済み`,
         });
       }
 
@@ -114,7 +119,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
             staffId,
             type: 'training',
             severity: 'warning',
-            message: `${helper.name.family} は未訪問（複数人体制のため同行可能）`,
+            message: `${staffLabel} は未訪問（複数人体制のため同行可能）`,
           });
         } else {
           addViolation({
@@ -122,7 +127,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
             staffId,
             type: 'training',
             severity: 'error',
-            message: `${helper.name.family} は未訪問（研修未開始）`,
+            message: `${staffLabel} は未訪問（研修未開始）`,
           });
         }
       } else if (trainingStatus === 'training') {
@@ -131,7 +136,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
           staffId,
           type: 'training',
           severity: 'warning',
-          message: `${helper.name.family} は研修中（同行必要）`,
+          message: `${staffLabel} は研修中（同行必要）`,
         });
       }
 
@@ -142,7 +147,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
           staffId,
           type: 'preferred_staff',
           severity: 'warning',
-          message: `${helper.name.family} は推奨スタッフ外`,
+          message: `${staffLabel} は推奨スタッフ外`,
         });
       }
 
@@ -155,7 +160,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
           staffId,
           type: 'qualification',
           severity: 'error',
-          message: `${helper.name.family} は身体介護の資格なし`,
+          message: `${staffLabel} は身体介護の資格なし`,
         });
       }
 
@@ -169,7 +174,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
             staffId,
             type: 'outside_hours',
             severity: 'warning',
-            message: `${helper.name.family} の勤務時間外`,
+            message: `${staffLabel} の勤務時間外`,
           });
         } else {
           const withinAny = availability.some(
@@ -181,7 +186,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
               staffId,
               type: 'outside_hours',
               severity: 'warning',
-              message: `${helper.name.family} の勤務時間外`,
+              message: `${staffLabel} の勤務時間外`,
             });
           }
         }
@@ -198,7 +203,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
               staffId,
               type: 'unavailability',
               severity: 'error',
-              message: `${helper.name.family} は希望休（終日）`,
+              message: `${staffLabel} は希望休（終日）`,
             });
           } else if (
             slot.start_time && slot.end_time &&
@@ -209,7 +214,7 @@ export function checkConstraints(input: CheckInput): ViolationMap {
               staffId,
               type: 'unavailability',
               severity: 'error',
-              message: `${helper.name.family} は希望休（${slot.start_time}-${slot.end_time}）`,
+              message: `${staffLabel} は希望休（${slot.start_time}-${slot.end_time}）`,
             });
           }
         }


### PR DESCRIPTION
## Summary
- CompanionDialogの上部に「教える方（担当スタッフ）」セクションを追加（Badge表示、変更不可）
- 制約違反メッセージで同行スタッフ名に「（同行）」ラベルを付与し、通常スタッフと区別可能に

Closes #268 の要件乖離2点を修正

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `CompanionDialog.tsx` | 「教える方」セクション追加 |
| `checker.ts` | `staffLabel` で同行者メッセージ修飾 |
| `CompanionDialog.test.tsx` | テスト2件追加 |
| `checker.test.ts` | テスト2件追加 |

## Test plan
- [x] CompanionDialogテスト: 教える方の名前表示（6件パス）
- [x] checkerテスト: 同行者メッセージに「（同行）」含有（43件パス）
- [x] 全テストスイート回帰確認（98ファイル / 1058件パス）
- [x] TypeScript型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)