### PR TITLE
fix: 同行スタッフ候補から希望休・勤務時間外のスタッフを除外

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -314,6 +314,8 @@ function SchedulePage() {
         onCompanionChange={handleCompanionChange}
         diff={selectedOrder ? diffMap.get(selectedOrder.id) : undefined}
         saving={saving}
+        unavailability={unavailability}
+        day={selectedDay}
       />
     </div>
   );

--- a/web/src/components/schedule/CompanionDialog.tsx
+++ b/web/src/components/schedule/CompanionDialog.tsx
@@ -14,7 +14,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { getCompanionCandidates } from '@/lib/companion/filter';
-import type { Order, Customer, Helper, TrainingStatus } from '@/types';
+import type { Order, Customer, Helper, TrainingStatus, StaffUnavailability, DayOfWeek } from '@/types';
 
 const TRAINING_STATUS_LABELS: Record<TrainingStatus, string> = {
   not_visited: '未訪問',
@@ -36,6 +36,8 @@ interface CompanionDialogProps {
   helpers: Map<string, Helper>;
   onSetCompanion: (helperId: string) => void;
   onRemoveCompanion: () => void;
+  unavailability?: StaffUnavailability[];
+  day?: DayOfWeek;
 }
 
 export function CompanionDialog({
@@ -46,6 +48,8 @@ export function CompanionDialog({
   helpers,
   onSetCompanion,
   onRemoveCompanion,
+  unavailability,
+  day,
 }: CompanionDialogProps) {
   const [search, setSearch] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -63,8 +67,8 @@ export function CompanionDialog({
   }, [order.assigned_staff_ids, order.companion_staff_id, helpers]);
 
   const candidates = useMemo(
-    () => getCompanionCandidates({ order, customer, helpers }),
-    [order, customer, helpers],
+    () => getCompanionCandidates({ order, customer, helpers, unavailability, day }),
+    [order, customer, helpers, unavailability, day],
   );
 
   const filtered = useMemo(() => {

--- a/web/src/components/schedule/OrderDetailPanel.tsx
+++ b/web/src/components/schedule/OrderDetailPanel.tsx
@@ -15,7 +15,7 @@ import { StaffMultiSelect } from '@/components/masters/StaffMultiSelect';
 import { AssignmentDiffBadge } from '@/components/schedule/AssignmentDiffBadge';
 import { CompanionDialog } from '@/components/schedule/CompanionDialog';
 import { updateOrderStatus, isOrderStatus } from '@/lib/firestore/updateOrder';
-import type { Order, Customer, Helper } from '@/types';
+import type { Order, Customer, Helper, StaffUnavailability, DayOfWeek } from '@/types';
 import type { CompanionBeforeState } from '@/hooks/useOrderEdit';
 import type { Violation } from '@/lib/constraints/checker';
 import type { AssignmentDiff } from '@/hooks/useAssignmentDiff';
@@ -33,6 +33,8 @@ interface OrderDetailPanelProps {
   onCompanionChange?: (orderId: string, companionStaffId: string | null, beforeState: CompanionBeforeState) => void;
   diff?: AssignmentDiff;
   saving?: boolean;
+  unavailability?: StaffUnavailability[];
+  day?: DayOfWeek;
 }
 
 
@@ -85,6 +87,8 @@ export function OrderDetailPanel({
   onCompanionChange,
   diff,
   saving,
+  unavailability,
+  day,
 }: OrderDetailPanelProps) {
   const [statusSaving, setStatusSaving] = useState(false);
   const [companionDialogOpen, setCompanionDialogOpen] = useState(false);
@@ -286,6 +290,8 @@ export function OrderDetailPanel({
                 helpers={helpers}
                 onSetCompanion={(helperId) => onCompanionChange(order.id, helperId, beforeState)}
                 onRemoveCompanion={() => onCompanionChange(order.id, null, beforeState)}
+                unavailability={unavailability}
+                day={day}
               />
             </div>
             );

--- a/web/src/lib/companion/__tests__/filter.test.ts
+++ b/web/src/lib/companion/__tests__/filter.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { getCompanionCandidates } from '../filter';
-import type { Order, Customer, Helper } from '@/types';
+import type { Order, Customer, Helper, StaffUnavailability } from '@/types';
 
 /** テスト用ヘルパー生成ヘルパー */
-function makeHelper(id: string, lastName: string): Helper {
+function makeHelper(id: string, lastName: string, overrides: Partial<Helper> = {}): Helper {
   return {
     id,
     name: { family: lastName, given: 'テスト' },
@@ -18,6 +18,7 @@ function makeHelper(id: string, lastName: string): Helper {
     gender: 'female',
     created_at: new Date(),
     updated_at: new Date(),
+    ...overrides,
   } as Helper;
 }
 
@@ -26,6 +27,9 @@ function makeOrder(overrides: Partial<Order> = {}): Order {
     id: 'o1',
     customer_id: 'c1',
     assigned_staff_ids: ['h1'],
+    date: new Date('2025-01-06'),
+    start_time: '09:00',
+    end_time: '10:00',
     status: 'assigned',
     manually_edited: false,
     ...overrides,
@@ -121,5 +125,116 @@ describe('getCompanionCandidates', () => {
     });
 
     expect(result).toEqual([]);
+  });
+
+  describe('希望休による除外', () => {
+    it('終日希望休のスタッフを候補から除外する', () => {
+      const order = makeOrder({ assigned_staff_ids: ['h1'] });
+      const customer = makeCustomer();
+      const unavailability: StaffUnavailability[] = [{
+        id: 'u1',
+        staff_id: 'h2',
+        week_start_date: new Date('2025-01-06'),
+        unavailable_slots: [{ date: new Date('2025-01-06'), all_day: true }],
+        submitted_at: new Date(),
+      }];
+
+      const result = getCompanionCandidates({ order, customer, helpers, unavailability });
+
+      expect(result.map(h => h.id)).not.toContain('h2');
+      expect(result.map(h => h.id)).toContain('h3');
+      expect(result.map(h => h.id)).toContain('h4');
+    });
+
+    it('時間帯重複の希望休のスタッフを候補から除外する', () => {
+      const order = makeOrder({ assigned_staff_ids: ['h1'], start_time: '09:00', end_time: '10:00' });
+      const customer = makeCustomer();
+      const unavailability: StaffUnavailability[] = [{
+        id: 'u1',
+        staff_id: 'h3',
+        week_start_date: new Date('2025-01-06'),
+        unavailable_slots: [{
+          date: new Date('2025-01-06'),
+          all_day: false,
+          start_time: '08:00',
+          end_time: '09:30',
+        }],
+        submitted_at: new Date(),
+      }];
+
+      const result = getCompanionCandidates({ order, customer, helpers, unavailability });
+
+      expect(result.map(h => h.id)).not.toContain('h3');
+    });
+
+    it('別日の希望休は影響しない', () => {
+      const order = makeOrder({ assigned_staff_ids: ['h1'] });
+      const customer = makeCustomer();
+      const unavailability: StaffUnavailability[] = [{
+        id: 'u1',
+        staff_id: 'h2',
+        week_start_date: new Date('2025-01-06'),
+        unavailable_slots: [{ date: new Date('2025-01-07'), all_day: true }],
+        submitted_at: new Date(),
+      }];
+
+      const result = getCompanionCandidates({ order, customer, helpers, unavailability });
+
+      expect(result.map(h => h.id)).toContain('h2');
+    });
+  });
+
+  describe('勤務時間外による除外', () => {
+    it('該当曜日に勤務時間がないスタッフを除外する', () => {
+      const h2WithAvail = makeHelper('h2', '鈴木', {
+        weekly_availability: { tuesday: [{ start_time: '08:00', end_time: '17:00' }] },
+      });
+      const helpersWithAvail = new Map<string, Helper>([
+        ['h1', h1],
+        ['h2', h2WithAvail],
+        ['h3', h3],
+        ['h4', h4],
+      ]);
+      const order = makeOrder({ assigned_staff_ids: ['h1'] });
+      const customer = makeCustomer();
+
+      const result = getCompanionCandidates({
+        order, customer, helpers: helpersWithAvail, day: 'monday',
+      });
+
+      // h2はmondayに勤務時間なし → 除外
+      expect(result.map(h => h.id)).not.toContain('h2');
+    });
+
+    it('オーダー時間が勤務時間外のスタッフを除外する', () => {
+      const h2Late = makeHelper('h2', '鈴木', {
+        weekly_availability: { monday: [{ start_time: '13:00', end_time: '17:00' }] },
+      });
+      const helpersWithAvail = new Map<string, Helper>([
+        ['h1', h1],
+        ['h2', h2Late],
+        ['h3', h3],
+        ['h4', h4],
+      ]);
+      const order = makeOrder({ assigned_staff_ids: ['h1'], start_time: '09:00', end_time: '10:00' });
+      const customer = makeCustomer();
+
+      const result = getCompanionCandidates({
+        order, customer, helpers: helpersWithAvail, day: 'monday',
+      });
+
+      // h2はmondayの勤務時間が13:00-17:00で、09:00-10:00はカバーできない → 除外
+      expect(result.map(h => h.id)).not.toContain('h2');
+    });
+
+    it('day未指定の場合は勤務時間フィルタをスキップする', () => {
+      const order = makeOrder({ assigned_staff_ids: ['h1'] });
+      const customer = makeCustomer();
+
+      const result = getCompanionCandidates({ order, customer, helpers });
+
+      // day未指定 → フィルタなし、h2,h3,h4が候補
+      expect(result).toHaveLength(3);
+    });
   });
 });

--- a/web/src/lib/companion/filter.ts
+++ b/web/src/lib/companion/filter.ts
@@ -1,15 +1,18 @@
-import type { Order, Customer, Helper } from '@/types';
+import { isOverlapping } from '@/components/gantt/constants';
+import type { Order, Customer, Helper, StaffUnavailability, DayOfWeek } from '@/types';
 
 /**
  * 同行（OJT）候補ヘルパーを返す。
- * 除外: NG / 割当済み / (allowed非空時) allowed + preferred
+ * 除外: NG / 割当済み / (allowed非空時) allowed + preferred / 希望休 / 勤務時間外
  */
 export function getCompanionCandidates(input: {
   order: Order;
   customer: Customer;
   helpers: Map<string, Helper>;
+  unavailability?: StaffUnavailability[];
+  day?: DayOfWeek;
 }): Helper[] {
-  const { order, customer, helpers } = input;
+  const { order, customer, helpers, unavailability, day } = input;
 
   const excludeIds = new Set<string>([
     ...customer.ng_staff_ids,
@@ -24,7 +27,9 @@ export function getCompanionCandidates(input: {
   }
 
   const candidates = Array.from(helpers.values())
-    .filter(h => !excludeIds.has(h.id));
+    .filter(h => !excludeIds.has(h.id))
+    .filter(h => !isUnavailable(h, order, unavailability))
+    .filter(h => !isOutsideWorkingHours(h, order, day));
 
   // 名前順ソート
   candidates.sort((a, b) =>
@@ -35,4 +40,51 @@ export function getCompanionCandidates(input: {
   );
 
   return candidates;
+}
+
+/** 希望休（終日 or 時間帯重複）に該当するか */
+function isUnavailable(
+  helper: Helper,
+  order: Order,
+  unavailability?: StaffUnavailability[],
+): boolean {
+  if (!unavailability) return false;
+
+  for (const u of unavailability) {
+    if (u.staff_id !== helper.id) continue;
+    for (const slot of u.unavailable_slots) {
+      if (!isSameDate(slot.date, order.date)) continue;
+      if (slot.all_day) return true;
+      if (
+        slot.start_time && slot.end_time &&
+        isOverlapping(order.start_time, order.end_time, slot.start_time, slot.end_time)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** 勤務時間外か */
+function isOutsideWorkingHours(
+  helper: Helper,
+  order: Order,
+  day?: DayOfWeek,
+): boolean {
+  if (!day || !helper.weekly_availability) return false;
+
+  const availability = helper.weekly_availability[day];
+  if (!availability || availability.length === 0) return true;
+
+  const withinAny = availability.some(
+    (slot) => slot.start_time <= order.start_time && slot.end_time >= order.end_time,
+  );
+  return !withinAny;
+}
+
+function isSameDate(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
 }


### PR DESCRIPTION
## Summary
- `getCompanionCandidates` に `unavailability` と `day` パラメータを追加
- 該当日に希望休（終日/時間帯重複）のスタッフを候補から除外
- 該当曜日に勤務時間外のスタッフを候補から除外
- props チェーンで page.tsx → OrderDetailPanel → CompanionDialog にデータを伝搬

Closes #275

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `web/src/lib/companion/filter.ts` | 希望休・勤務時間外フィルタ追加 |
| `web/src/lib/companion/__tests__/filter.test.ts` | テスト6件追加 |
| `web/src/components/schedule/CompanionDialog.tsx` | unavailability/day props追加 |
| `web/src/components/schedule/OrderDetailPanel.tsx` | unavailability/day props追加・伝搬 |
| `web/src/app/page.tsx` | OrderDetailPanelにunavailability/day渡し |

## Test plan
- [x] filter.test.ts: 12件全パス（新規6件含む）
- [x] TypeScript型チェック通過
- [x] 既存テスト回帰なし（失敗5件は既存フレーキーテスト、変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)