### PR TITLE
feat: service_typesマスタにhospital_visit/meeting/otherを追加

### DIFF
--- a/optimizer/src/optimizer/integrations/note_diff.py
+++ b/optimizer/src/optimizer/integrations/note_diff.py
@@ -371,8 +371,6 @@ def _build_update_time_action(
     )
 
 
-# TODO: service_type値はFirestoreのservice_typesマスタに未登録。
-# 本番運用開始時にマスタへの追加、または既存値へのマッピングが必要。
 _ADD_ACTION_CONFIG: dict[NoteActionType, tuple[str, str]] = {
     NoteActionType.ADD_VISIT: ("hospital_visit", "受診同行"),
     NoteActionType.ADD_MEETING: ("meeting", "担当者会議"),

--- a/seed/data/service-types.csv
+++ b/seed/data/service-types.csv
@@ -104,3 +104,6 @@ code,category,label,duration,care_level,units,requires_physical_care_cert,sort_o
 通所介護Ⅱ63,大規模型（Ⅰ）,通所介護Ⅱ63,8時間以上9時間未満,要介護3,885,false,103
 通所介護Ⅱ64,大規模型（Ⅰ）,通所介護Ⅱ64,8時間以上9時間未満,要介護4,1007,false,104
 通所介護Ⅱ65,大規模型（Ⅰ）,通所介護Ⅱ65,8時間以上9時間未満,要介護5,1127,false,105
+hospital_visit,訪問介護,受診同行,,,,false,106
+meeting,訪問介護,担当者会議,,,,false,107
+other,訪問介護,その他,,,,false,108


### PR DESCRIPTION
## Summary
- `seed/data/service-types.csv` に `hospital_visit`/`meeting`/`other` の3行を追加
- `note_diff.py` のTODOコメントを解消

## Test plan
- [x] optimizer pytest: 336 passed
- [x] seed vitest: 28 passed, 14 skipped
- [x] web tsc --noEmit: PASS

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)