### PR TITLE
feat: 基本→当週シフト一括複製API+UI（Phase 6b-1）

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -45,6 +45,8 @@ def _get_sheets_credentials() -> object:
 from optimizer.api.auth import require_manager_or_above
 from optimizer.api.schemas import (
     AssignmentResponse,
+    DuplicateWeekRequest,
+    DuplicateWeekResponse,
     ErrorResponse,
     ExportReportRequest,
     ExportReportResponse,
@@ -76,6 +78,7 @@ from optimizer.data.firestore_loader import (
     load_optimization_input,
 )
 from optimizer.data.firestore_writer import (
+    duplicate_week_orders,
     reset_assignments,
     save_optimization_run,
     write_assignments,
@@ -838,4 +841,70 @@ def import_notes_apply(
         applied_count=applied_count,
         marked_count=marked_count,
         total_requested=len(req.post_ids),
+    )
+
+
+# ---------------------------------------------------------------------------
+# オーダー一括複製
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/orders/duplicate-week",
+    response_model=DuplicateWeekResponse,
+    responses={409: {"model": ErrorResponse}, 422: {"model": ErrorResponse}},
+)
+def duplicate_week(
+    req: DuplicateWeekRequest,
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> DuplicateWeekResponse:
+    """基本シフト（ソース週）のオーダーをターゲット週に一括複製"""
+    # 日付パース
+    try:
+        source_week = date.fromisoformat(req.source_week_start)
+        target_week = date.fromisoformat(req.target_week_start)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    # 月曜日チェック
+    if source_week.weekday() != 0:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{req.source_week_start} は月曜日ではありません"
+            f"（weekday={source_week.weekday()}）",
+        )
+    if target_week.weekday() != 0:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{req.target_week_start} は月曜日ではありません"
+            f"（weekday={target_week.weekday()}）",
+        )
+
+    # 同一週チェック
+    if source_week == target_week:
+        raise HTTPException(
+            status_code=422,
+            detail="コピー元とコピー先が同じ週です",
+        )
+
+    try:
+        db = get_firestore_client()
+        created, skipped = duplicate_week_orders(db, source_week, target_week)
+    except Exception as e:
+        logger.error("オーダー複製失敗: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"オーダー複製エラー: {e}"
+        ) from e
+
+    if skipped > 0:
+        raise HTTPException(
+            status_code=409,
+            detail=f"ターゲット週 {req.target_week_start} に既存オーダーが"
+            f"あるため複製をスキップしました（{skipped}件）",
+        )
+
+    return DuplicateWeekResponse(
+        created_count=created,
+        skipped_count=skipped,
+        target_week_start=req.target_week_start,
     )

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -233,3 +233,29 @@ class NoteImportApplyResponse(BaseModel):
     applied_count: int = Field(description="Firestoreに反映したアクション数")
     marked_count: int = Field(description="スプレッドシートで対応済みにした行数")
     total_requested: int = Field(description="リクエストされたアクション数")
+
+
+# ---------------------------------------------------------------------------
+# オーダー一括複製
+# ---------------------------------------------------------------------------
+
+
+class DuplicateWeekRequest(BaseModel):
+    source_week_start: str = Field(
+        ...,
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        description="コピー元週の開始日（月曜日）YYYY-MM-DD",
+        examples=["2026-02-09"],
+    )
+    target_week_start: str = Field(
+        ...,
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        description="コピー先週の開始日（月曜日）YYYY-MM-DD",
+        examples=["2026-02-16"],
+    )
+
+
+class DuplicateWeekResponse(BaseModel):
+    created_count: int = Field(description="作成したオーダー数")
+    skipped_count: int = Field(description="スキップしたオーダー数（対象週に既存オーダーがある場合）")
+    target_week_start: str

--- a/optimizer/src/optimizer/data/firestore_writer.py
+++ b/optimizer/src/optimizer/data/firestore_writer.py
@@ -3,6 +3,7 @@
 import logging
 import uuid
 from datetime import date, datetime, timedelta, timezone
+from typing import Any
 
 from google.cloud import firestore  # type: ignore[attr-defined]
 from google.cloud.firestore_v1 import SERVER_TIMESTAMP  # type: ignore[import-untyped]
@@ -122,3 +123,130 @@ def reset_assignments(
 
     logger.info("オーダーリセット完了: %d件 (week=%s)", reset_count, week_start)
     return reset_count
+
+
+def duplicate_week_orders(
+    db: firestore.Client,
+    source_week_start: date,
+    target_week_start: date,
+) -> tuple[int, int]:
+    """ソース週のオーダーをターゲット週に一括複製する
+
+    Args:
+        db: Firestoreクライアント
+        source_week_start: コピー元の週開始日（月曜日）
+        target_week_start: コピー先の週開始日（月曜日）
+
+    Returns:
+        (created_count, skipped_count) タプル
+    """
+    JST = timezone(timedelta(hours=9))
+    source_dt = datetime(
+        source_week_start.year, source_week_start.month, source_week_start.day,
+        tzinfo=JST,
+    )
+    target_dt = datetime(
+        target_week_start.year, target_week_start.month, target_week_start.day,
+        tzinfo=JST,
+    )
+
+    # ソース週のオーダーを取得（cancelled以外）
+    source_docs = list(
+        db.collection("orders")
+        .where("week_start_date", "==", source_dt)
+        .where("status", "in", ["pending", "assigned"])
+        .stream()
+    )
+
+    if not source_docs:
+        logger.info("複製元オーダーが0件 (source_week=%s)", source_week_start)
+        return 0, 0
+
+    # ターゲット週に既存オーダーがあるか確認
+    existing_target = list(
+        db.collection("orders")
+        .where("week_start_date", "==", target_dt)
+        .where("status", "in", ["pending", "assigned"])
+        .stream()
+    )
+    if existing_target:
+        logger.warning(
+            "ターゲット週に既存オーダー %d件あり、スキップ (target_week=%s)",
+            len(existing_target),
+            target_week_start,
+        )
+        return 0, len(source_docs)
+
+    # 日付差分を計算
+    day_offset = (target_week_start - source_week_start).days
+
+    # linked_order_id のリマッピング用: old_id → new_id
+    id_mapping: dict[str, str] = {}
+    new_orders: list[tuple[str, dict[str, Any]]] = []
+
+    for doc in source_docs:
+        d = doc.to_dict()
+        if d is None:
+            continue
+        new_id = str(uuid.uuid4())
+        id_mapping[doc.id] = new_id
+
+        # 日付をオフセット
+        source_date = d["date"]
+        if hasattr(source_date, "to_pydatetime"):
+            source_date_dt = source_date.to_pydatetime()
+        elif isinstance(source_date, datetime):
+            source_date_dt = source_date
+        else:
+            source_date_dt = datetime.fromisoformat(str(source_date))
+
+        target_date_dt = source_date_dt + timedelta(days=day_offset)
+
+        new_order: dict[str, Any] = {
+            "customer_id": d["customer_id"],
+            "week_start_date": target_dt,
+            "date": target_date_dt,
+            "start_time": d["start_time"],
+            "end_time": d["end_time"],
+            "service_type": d["service_type"],
+            "assigned_staff_ids": [],
+            "status": "pending",
+            "manually_edited": False,
+            "created_at": SERVER_TIMESTAMP,
+            "updated_at": SERVER_TIMESTAMP,
+        }
+        # オプショナルフィールド
+        if d.get("staff_count") is not None:
+            new_order["staff_count"] = d["staff_count"]
+        if d.get("linked_order_id"):
+            # 後でリマッピング
+            new_order["_original_linked_order_id"] = d["linked_order_id"]
+        if d.get("companion_staff_id"):
+            # OJTスタッフは複製しない（再割当が必要）
+            pass
+
+        new_orders.append((new_id, new_order))
+
+    # linked_order_id をリマッピング
+    for _, order_data in new_orders:
+        original_linked = order_data.pop("_original_linked_order_id", None)
+        if original_linked and original_linked in id_mapping:
+            order_data["linked_order_id"] = id_mapping[original_linked]
+
+    # バッチ書き込み
+    BATCH_LIMIT = 500
+    created = 0
+    for i in range(0, len(new_orders), BATCH_LIMIT):
+        batch = db.batch()
+        chunk = new_orders[i : i + BATCH_LIMIT]
+        for new_id, order_data in chunk:
+            doc_ref = db.collection("orders").document(new_id)
+            batch.set(doc_ref, order_data)
+        batch.commit()
+        created += len(chunk)
+
+    logger.info(
+        "オーダー複製完了: %d件 (source=%s → target=%s)",
+        created, source_week_start, target_week_start,
+    )
+    return created, 0

--- a/optimizer/tests/test_api.py
+++ b/optimizer/tests/test_api.py
@@ -245,6 +245,152 @@ class TestFirestoreWriter:
         assert batch.commit.call_count == 2
 
 
+class TestDuplicateWeekOrders:
+    """duplicate_week_orders 関数のユニットテスト"""
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_duplicate_creates_new_orders(self) -> None:
+        from datetime import datetime, timezone, timedelta
+        from optimizer.data.firestore_writer import duplicate_week_orders
+
+        JST = timezone(timedelta(hours=9))
+        source_date = datetime(2026, 2, 9, tzinfo=JST)  # 月曜日
+
+        # ソースオーダー2件のモック
+        doc1 = MagicMock()
+        doc1.id = "order-1"
+        doc1.to_dict.return_value = {
+            "customer_id": "C001",
+            "date": datetime(2026, 2, 9, tzinfo=JST),  # 月曜日
+            "start_time": "09:00",
+            "end_time": "10:00",
+            "service_type": "physical_care",
+            "staff_count": 1,
+        }
+
+        doc2 = MagicMock()
+        doc2.id = "order-2"
+        doc2.to_dict.return_value = {
+            "customer_id": "C002",
+            "date": datetime(2026, 2, 11, tzinfo=JST),  # 水曜日
+            "start_time": "14:00",
+            "end_time": "15:00",
+            "service_type": "daily_living",
+            "linked_order_id": "order-1",
+        }
+
+        db = MagicMock()
+        batch = MagicMock()
+        db.batch.return_value = batch
+
+        # ソース週クエリ → 2件返す
+        source_query = MagicMock()
+        source_query.where.return_value = source_query
+        source_query.stream.return_value = iter([doc1, doc2])
+
+        # ターゲット週クエリ → 0件（既存なし）
+        target_query = MagicMock()
+        target_query.where.return_value = target_query
+        target_query.stream.return_value = iter([])
+
+        # 最初のcollection("orders")呼び出し→ソース、2回目→ターゲット
+        call_count = {"n": 0}
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "orders":
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    return source_query
+                return target_query
+            return MagicMock()
+
+        db.collection.side_effect = collection_side_effect
+
+        from datetime import date
+        created, skipped = duplicate_week_orders(
+            db, date(2026, 2, 9), date(2026, 2, 16)
+        )
+
+        assert created == 2
+        assert skipped == 0
+        assert batch.set.call_count == 2
+        batch.commit.assert_called_once()
+
+        # 作成されたオーダーの内容を検証
+        set_calls = batch.set.call_args_list
+        order_data_list = [call[0][1] for call in set_calls]
+
+        # customer_idが保持されていること
+        customer_ids = {d["customer_id"] for d in order_data_list}
+        assert customer_ids == {"C001", "C002"}
+
+        # 全てpending/空割当
+        for d in order_data_list:
+            assert d["status"] == "pending"
+            assert d["assigned_staff_ids"] == []
+            assert d["manually_edited"] is False
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_duplicate_skips_when_target_has_orders(self) -> None:
+        from datetime import datetime, timezone, timedelta
+        from optimizer.data.firestore_writer import duplicate_week_orders
+
+        JST = timezone(timedelta(hours=9))
+
+        doc1 = MagicMock()
+        doc1.id = "source-1"
+        doc1.to_dict.return_value = {"customer_id": "C001"}
+
+        existing_doc = MagicMock()
+
+        db = MagicMock()
+        source_query = MagicMock()
+        source_query.where.return_value = source_query
+        source_query.stream.return_value = iter([doc1])
+
+        target_query = MagicMock()
+        target_query.where.return_value = target_query
+        target_query.stream.return_value = iter([existing_doc])
+
+        call_count = {"n": 0}
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "orders":
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    return source_query
+                return target_query
+            return MagicMock()
+
+        db.collection.side_effect = collection_side_effect
+
+        from datetime import date
+        created, skipped = duplicate_week_orders(
+            db, date(2026, 2, 9), date(2026, 2, 16)
+        )
+
+        assert created == 0
+        assert skipped == 1
+        db.batch.assert_not_called()
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_duplicate_empty_source(self) -> None:
+        from optimizer.data.firestore_writer import duplicate_week_orders
+
+        db = MagicMock()
+        source_query = MagicMock()
+        source_query.where.return_value = source_query
+        source_query.stream.return_value = iter([])
+
+        db.collection.return_value = source_query
+
+        from datetime import date
+        created, skipped = duplicate_week_orders(
+            db, date(2026, 2, 9), date(2026, 2, 16)
+        )
+
+        assert created == 0
+        assert skipped == 0
+
+
 class TestResetAssignmentsEndpoint:
     """POST /reset-assignments のテスト"""
 
@@ -309,3 +455,90 @@ class TestResetAssignmentsEndpoint:
         )
         assert response.status_code == 200
         assert response.json()["orders_reset"] == 0
+
+
+class TestDuplicateWeekEndpoint:
+    """オーダー一括複製エンドポイントのテスト"""
+
+    @patch("optimizer.api.routes.duplicate_week_orders")
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_successful_duplicate(
+        self,
+        mock_get_db: MagicMock,
+        mock_duplicate: MagicMock,
+    ) -> None:
+        mock_get_db.return_value = MagicMock()
+        mock_duplicate.return_value = (10, 0)
+
+        response = client.post(
+            "/orders/duplicate-week",
+            json={
+                "source_week_start": "2026-02-09",
+                "target_week_start": "2026-02-16",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["created_count"] == 10
+        assert data["skipped_count"] == 0
+        assert data["target_week_start"] == "2026-02-16"
+
+    @patch("optimizer.api.routes.duplicate_week_orders")
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_existing_target_orders_returns_409(
+        self,
+        mock_get_db: MagicMock,
+        mock_duplicate: MagicMock,
+    ) -> None:
+        mock_get_db.return_value = MagicMock()
+        mock_duplicate.return_value = (0, 5)
+
+        response = client.post(
+            "/orders/duplicate-week",
+            json={
+                "source_week_start": "2026-02-09",
+                "target_week_start": "2026-02-16",
+            },
+        )
+        assert response.status_code == 409
+        assert "既存オーダー" in response.json()["detail"]
+
+    def test_source_not_monday_returns_422(self) -> None:
+        response = client.post(
+            "/orders/duplicate-week",
+            json={
+                "source_week_start": "2026-02-10",  # 火曜日
+                "target_week_start": "2026-02-16",
+            },
+        )
+        assert response.status_code == 422
+        assert "月曜日ではありません" in response.json()["detail"]
+
+    def test_target_not_monday_returns_422(self) -> None:
+        response = client.post(
+            "/orders/duplicate-week",
+            json={
+                "source_week_start": "2026-02-09",
+                "target_week_start": "2026-02-17",  # 火曜日
+            },
+        )
+        assert response.status_code == 422
+        assert "月曜日ではありません" in response.json()["detail"]
+
+    def test_same_week_returns_422(self) -> None:
+        response = client.post(
+            "/orders/duplicate-week",
+            json={
+                "source_week_start": "2026-02-09",
+                "target_week_start": "2026-02-09",
+            },
+        )
+        assert response.status_code == 422
+        assert "同じ週" in response.json()["detail"]
+
+    def test_missing_fields_returns_422(self) -> None:
+        response = client.post(
+            "/orders/duplicate-week",
+            json={"source_week_start": "2026-02-09"},
+        )
+        assert response.status_code == 422

--- a/web/src/components/schedule/WeekDuplicateButton.tsx
+++ b/web/src/components/schedule/WeekDuplicateButton.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import { Copy, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { toast } from 'sonner';
+import { duplicateWeek, OptimizeApiError } from '@/lib/api/optimizer';
+import { useScheduleContext } from '@/contexts/ScheduleContext';
+
+/**
+ * 基本シフト（ソース週）のオーダーを現在表示中の週に一括複製するボタン。
+ * ソース週はダイアログ内で指定する（デフォルト: 前週）。
+ */
+export function WeekDuplicateButton() {
+  const { weekStart } = useScheduleContext();
+
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  // ソース週: デフォルトは前週
+  const defaultSourceWeek = new Date(weekStart);
+  defaultSourceWeek.setDate(defaultSourceWeek.getDate() - 7);
+
+  const [sourceDate, setSourceDate] = useState<string>(
+    format(defaultSourceWeek, 'yyyy-MM-dd'),
+  );
+
+  const targetDateStr = format(weekStart, 'yyyy-MM-dd');
+
+  const handleDuplicate = async () => {
+    setLoading(true);
+    try {
+      const result = await duplicateWeek({
+        source_week_start: sourceDate,
+        target_week_start: targetDateStr,
+      });
+      toast.success(
+        `${result.created_count}件のオーダーを複製しました`,
+      );
+      setOpen(false);
+    } catch (e) {
+      if (e instanceof OptimizeApiError) {
+        if (e.statusCode === 409) {
+          toast.error(e.message);
+        } else if (e.statusCode === 422) {
+          toast.error(`入力エラー: ${e.message}`);
+        } else {
+          toast.error(`エラー: ${e.message}`);
+        }
+      } else {
+        toast.error('オーダーの複製に失敗しました');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          // ダイアログを開くたびにソース週をリセット
+          const src = new Date(weekStart);
+          src.setDate(src.getDate() - 7);
+          setSourceDate(format(src, 'yyyy-MM-dd'));
+          setOpen(true);
+        }}
+      >
+        <Copy className="mr-1 h-4 w-4" />
+        週複製
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>基本シフト → 当週に複製</DialogTitle>
+            <DialogDescription>
+              コピー元週のオーダーを{' '}
+              <strong>
+                {format(weekStart, 'M/d', { locale: ja })}週
+              </strong>{' '}
+              に一括複製します。ターゲット週に既存オーダーがある場合はスキップされます。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3 py-2">
+            <label className="block text-sm font-medium">
+              コピー元の週（月曜日）
+            </label>
+            <input
+              type="date"
+              value={sourceDate}
+              onChange={(e) => setSourceDate(e.target.value)}
+              className="w-full rounded-md border px-3 py-2 text-sm"
+            />
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              キャンセル
+            </Button>
+            <Button onClick={handleDuplicate} disabled={loading}>
+              {loading && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+              複製実行
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/lib/api/optimizer.ts
+++ b/web/src/lib/api/optimizer.ts
@@ -354,3 +354,32 @@ export async function importNotesApply(params: {
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// オーダー一括複製
+// ---------------------------------------------------------------------------
+
+export interface DuplicateWeekResponse {
+  created_count: number;
+  skipped_count: number;
+  target_week_start: string;
+}
+
+export async function duplicateWeek(params: {
+  source_week_start: string;
+  target_week_start: string;
+}): Promise<DuplicateWeekResponse> {
+  const headers = await getAuthHeaders();
+  const res = await fetchWithRetry(() =>
+    fetch(`${API_URL}/orders/duplicate-week`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    }),
+  );
+  if (!res.ok) {
+    const error: OptimizeError = await res.json();
+    throw new OptimizeApiError(res.status, error.detail);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- `POST /orders/duplicate-week` エンドポイント追加（ソース週→ターゲット週にオーダーを一括複製）
- `duplicate_week_orders()` ロジック（linked_order_idリマッピング、バッチ書き込み）
- `WeekDuplicateButton.tsx` 新規（日付選択ダイアログ付き確認UI）
- `duplicateWeek()` API関数追加
- テスト9件追加（エンドポイント6件 + ユニット3件）

## Test plan
- [x] optimizer pytest: 345 passed
- [x] web vitest: 1076 passed (99 files)
- [x] web tsc --noEmit: PASS

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)