### PR TITLE
feat: 休み希望の自動反映API+UI（Phase 6b-2）

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -44,6 +44,8 @@ def _get_sheets_credentials() -> object:
 
 from optimizer.api.auth import require_manager_or_above
 from optimizer.api.schemas import (
+    ApplyUnavailabilityRequest,
+    ApplyUnavailabilityResponse,
     AssignmentResponse,
     DuplicateWeekRequest,
     DuplicateWeekResponse,
@@ -68,6 +70,7 @@ from optimizer.api.schemas import (
     ChatReminderRequest,
     ChatReminderResponse,
     ChatReminderResultItem,
+    UnavailabilityRemovalItem,
 )
 from optimizer.data.firestore_loader import (
     get_firestore_client,
@@ -78,6 +81,7 @@ from optimizer.data.firestore_loader import (
     load_optimization_input,
 )
 from optimizer.data.firestore_writer import (
+    apply_unavailability_to_orders,
     duplicate_week_orders,
     reset_assignments,
     save_optimization_run,
@@ -907,4 +911,58 @@ def duplicate_week(
         created_count=created,
         skipped_count=skipped,
         target_week_start=req.target_week_start,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 休み希望の自動反映
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/orders/apply-unavailability",
+    response_model=ApplyUnavailabilityResponse,
+    responses={422: {"model": ErrorResponse}, 500: {"model": ErrorResponse}},
+)
+def apply_unavailability_endpoint(
+    req: ApplyUnavailabilityRequest,
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> ApplyUnavailabilityResponse:
+    """対象週の休み希望をオーダーに反映し、該当スタッフの割当を解除"""
+    try:
+        week_start = date.fromisoformat(req.week_start_date)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    if week_start.weekday() != 0:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{req.week_start_date} は月曜日ではありません"
+            f"（weekday={week_start.weekday()}）",
+        )
+
+    try:
+        db = get_firestore_client()
+        result = apply_unavailability_to_orders(db, week_start)
+    except Exception as e:
+        logger.error("休み希望反映失敗: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"休み希望反映エラー: {e}"
+        ) from e
+
+    return ApplyUnavailabilityResponse(
+        orders_modified=result.orders_modified,
+        removals_count=result.removals_count,
+        reverted_to_pending=result.reverted_to_pending,
+        removals=[
+            UnavailabilityRemovalItem(
+                order_id=r.order_id,
+                staff_id=r.staff_id,
+                customer_id=r.customer_id,
+                date=r.date,
+                start_time=r.start_time,
+                end_time=r.end_time,
+            )
+            for r in result.removals
+        ],
     )

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -259,3 +259,33 @@ class DuplicateWeekResponse(BaseModel):
     created_count: int = Field(description="作成したオーダー数")
     skipped_count: int = Field(description="スキップしたオーダー数（対象週に既存オーダーがある場合）")
     target_week_start: str
+
+
+# ---------------------------------------------------------------------------
+# 休み希望の自動反映
+# ---------------------------------------------------------------------------
+
+
+class ApplyUnavailabilityRequest(BaseModel):
+    week_start_date: str = Field(
+        ...,
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        description="対象週の開始日（月曜日）YYYY-MM-DD",
+        examples=["2026-02-09"],
+    )
+
+
+class UnavailabilityRemovalItem(BaseModel):
+    order_id: str
+    staff_id: str
+    customer_id: str
+    date: str
+    start_time: str
+    end_time: str
+
+
+class ApplyUnavailabilityResponse(BaseModel):
+    orders_modified: int = Field(description="変更したオーダー数")
+    removals_count: int = Field(description="解除したスタッフ割当数")
+    reverted_to_pending: int = Field(description="pendingに戻したオーダー数")
+    removals: list[UnavailabilityRemovalItem] = Field(description="解除した割当の詳細")

--- a/optimizer/src/optimizer/data/firestore_writer.py
+++ b/optimizer/src/optimizer/data/firestore_writer.py
@@ -2,6 +2,7 @@
 
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
@@ -250,3 +251,174 @@ def duplicate_week_orders(
         created, source_week_start, target_week_start,
     )
     return created, 0
+
+
+@dataclass
+class UnavailabilityRemoval:
+    """休み希望による割当解除1件の情報"""
+    order_id: str
+    staff_id: str
+    customer_id: str
+    date: str
+    start_time: str
+    end_time: str
+
+
+@dataclass
+class ApplyUnavailabilityResult:
+    """休み希望反映の結果"""
+    orders_modified: int
+    removals_count: int
+    reverted_to_pending: int
+    removals: list[UnavailabilityRemoval]
+
+
+def _times_overlap(
+    order_start: str, order_end: str,
+    unavail_start: str, unavail_end: str,
+) -> bool:
+    """HH:MM形式の時間範囲が重複するか判定"""
+    return order_start < unavail_end and order_end > unavail_start
+
+
+def apply_unavailability_to_orders(
+    db: firestore.Client,
+    week_start: date,
+) -> ApplyUnavailabilityResult:
+    """対象週の休み希望をオーダーに反映し、該当スタッフの割当を解除する
+
+    Args:
+        db: Firestoreクライアント
+        week_start: 対象週の開始日（月曜日）
+
+    Returns:
+        ApplyUnavailabilityResult
+    """
+    JST = timezone(timedelta(hours=9))
+    week_start_dt = datetime(
+        week_start.year, week_start.month, week_start.day, tzinfo=JST,
+    )
+
+    # 休み希望を取得
+    unavail_docs = list(
+        db.collection("staff_unavailability")
+        .where("week_start_date", "==", week_start_dt)
+        .stream()
+    )
+
+    if not unavail_docs:
+        logger.info("休み希望が0件 (week=%s)", week_start)
+        return ApplyUnavailabilityResult(0, 0, 0, [])
+
+    # 休み希望をパース: {(staff_id, date_str)} → list[slot]
+    from optimizer.data.firestore_loader import _ts_to_date_str
+
+    staff_unavail: dict[str, list[dict[str, Any]]] = {}  # staff_id → slots
+    for doc in unavail_docs:
+        d = doc.to_dict()
+        if d is None:
+            continue
+        staff_id = d["staff_id"]
+        for slot in d.get("unavailable_slots", []):
+            slot_date = _ts_to_date_str(slot["date"])
+            staff_unavail.setdefault(staff_id, []).append({
+                "date": slot_date,
+                "all_day": slot.get("all_day", True),
+                "start_time": slot.get("start_time"),
+                "end_time": slot.get("end_time"),
+            })
+
+    # 対象週のオーダーを取得（assigned のみ: 割当済みで解除対象）
+    order_docs = list(
+        db.collection("orders")
+        .where("week_start_date", "==", week_start_dt)
+        .where("status", "==", "assigned")
+        .stream()
+    )
+
+    if not order_docs:
+        logger.info("assigned オーダーが0件 (week=%s)", week_start)
+        return ApplyUnavailabilityResult(0, 0, 0, [])
+
+    # マッチング: 各オーダーのassigned_staff_idsから休み希望のスタッフを除外
+    removals: list[UnavailabilityRemoval] = []
+    updates: dict[str, dict[str, Any]] = {}  # order_id → update fields
+
+    for doc in order_docs:
+        d = doc.to_dict()
+        if d is None:
+            continue
+        order_id = doc.id
+        order_date = _ts_to_date_str(d["date"])
+        assigned = list(d.get("assigned_staff_ids", []))
+        order_start = d.get("start_time", "")
+        order_end = d.get("end_time", "")
+
+        staff_to_remove: list[str] = []
+        for staff_id in assigned:
+            if staff_id not in staff_unavail:
+                continue
+            for slot in staff_unavail[staff_id]:
+                if slot["date"] != order_date:
+                    continue
+                # 終日 or 時間帯重複チェック
+                if slot["all_day"] or _times_overlap(
+                    order_start, order_end,
+                    slot.get("start_time", "00:00"),
+                    slot.get("end_time", "23:59"),
+                ):
+                    staff_to_remove.append(staff_id)
+                    break
+
+        if not staff_to_remove:
+            continue
+
+        new_assigned = [s for s in assigned if s not in staff_to_remove]
+        new_status = "pending" if not new_assigned else "assigned"
+
+        updates[order_id] = {
+            "assigned_staff_ids": new_assigned,
+            "status": new_status,
+            "updated_at": SERVER_TIMESTAMP,
+        }
+
+        for sid in staff_to_remove:
+            removals.append(UnavailabilityRemoval(
+                order_id=order_id,
+                staff_id=sid,
+                customer_id=d.get("customer_id", ""),
+                date=order_date,
+                start_time=order_start,
+                end_time=order_end,
+            ))
+
+    if not updates:
+        return ApplyUnavailabilityResult(0, 0, 0, [])
+
+    # バッチ書き込み
+    BATCH_LIMIT = 500
+    modified = 0
+    reverted = 0
+    update_list = list(updates.items())
+
+    for i in range(0, len(update_list), BATCH_LIMIT):
+        batch = db.batch()
+        chunk = update_list[i : i + BATCH_LIMIT]
+        for order_id, fields in chunk:
+            ref = db.collection("orders").document(order_id)
+            batch.update(ref, fields)
+            if fields["status"] == "pending":
+                reverted += 1
+        batch.commit()
+        modified += len(chunk)
+
+    logger.info(
+        "休み希望反映完了: modified=%d, removals=%d, reverted=%d (week=%s)",
+        modified, len(removals), reverted, week_start,
+    )
+    return ApplyUnavailabilityResult(
+        orders_modified=modified,
+        removals_count=len(removals),
+        reverted_to_pending=reverted,
+        removals=removals,
+    )

--- a/optimizer/tests/test_api.py
+++ b/optimizer/tests/test_api.py
@@ -542,3 +542,271 @@ class TestDuplicateWeekEndpoint:
             json={"source_week_start": "2026-02-09"},
         )
         assert response.status_code == 422
+
+
+class TestApplyUnavailabilityEndpoint:
+    """POST /orders/apply-unavailability のテスト"""
+
+    @patch("optimizer.api.routes.apply_unavailability_to_orders")
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_successful_apply(
+        self,
+        mock_get_db: MagicMock,
+        mock_apply: MagicMock,
+    ) -> None:
+        from optimizer.data.firestore_writer import (
+            ApplyUnavailabilityResult,
+            UnavailabilityRemoval,
+        )
+        mock_get_db.return_value = MagicMock()
+        mock_apply.return_value = ApplyUnavailabilityResult(
+            orders_modified=3,
+            removals_count=4,
+            reverted_to_pending=1,
+            removals=[
+                UnavailabilityRemoval(
+                    order_id="ORD001", staff_id="H003",
+                    customer_id="C001", date="2026-02-11",
+                    start_time="09:00", end_time="10:00",
+                ),
+            ],
+        )
+
+        response = client.post(
+            "/orders/apply-unavailability",
+            json={"week_start_date": "2026-02-09"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["orders_modified"] == 3
+        assert data["removals_count"] == 4
+        assert data["reverted_to_pending"] == 1
+        assert len(data["removals"]) == 1
+        assert data["removals"][0]["staff_id"] == "H003"
+
+    def test_not_monday_returns_422(self) -> None:
+        response = client.post(
+            "/orders/apply-unavailability",
+            json={"week_start_date": "2026-02-10"},
+        )
+        assert response.status_code == 422
+        assert "月曜日ではありません" in response.json()["detail"]
+
+    @patch("optimizer.api.routes.apply_unavailability_to_orders")
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_no_modifications(
+        self,
+        mock_get_db: MagicMock,
+        mock_apply: MagicMock,
+    ) -> None:
+        from optimizer.data.firestore_writer import ApplyUnavailabilityResult
+        mock_get_db.return_value = MagicMock()
+        mock_apply.return_value = ApplyUnavailabilityResult(0, 0, 0, [])
+
+        response = client.post(
+            "/orders/apply-unavailability",
+            json={"week_start_date": "2026-02-09"},
+        )
+        assert response.status_code == 200
+        assert response.json()["orders_modified"] == 0
+
+
+class TestApplyUnavailabilityLogic:
+    """apply_unavailability_to_orders のユニットテスト"""
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_removes_unavailable_staff_from_orders(self) -> None:
+        from datetime import datetime, timezone, timedelta
+        from optimizer.data.firestore_writer import apply_unavailability_to_orders
+
+        JST = timezone(timedelta(hours=9))
+
+        # 休み希望: H003は水曜終日休み
+        unavail_doc = MagicMock()
+        unavail_doc.to_dict.return_value = {
+            "staff_id": "H003",
+            "unavailable_slots": [
+                {
+                    "date": datetime(2026, 2, 11, tzinfo=JST),  # 水曜
+                    "all_day": True,
+                }
+            ],
+        }
+
+        # 割当済みオーダー: H003が水曜に割当
+        order_doc = MagicMock()
+        order_doc.id = "ORD001"
+        order_doc.to_dict.return_value = {
+            "customer_id": "C001",
+            "date": datetime(2026, 2, 11, tzinfo=JST),  # 水曜
+            "start_time": "09:00",
+            "end_time": "10:00",
+            "assigned_staff_ids": ["H003"],
+            "status": "assigned",
+        }
+
+        db = MagicMock()
+        batch = MagicMock()
+        db.batch.return_value = batch
+
+        # staff_unavailability クエリ
+        unavail_query = MagicMock()
+        unavail_query.where.return_value = unavail_query
+        unavail_query.stream.return_value = iter([unavail_doc])
+
+        # orders クエリ
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([order_doc])
+
+        call_count = {"n": 0}
+        def collection_side_effect(name: str) -> MagicMock:
+            call_count["n"] += 1
+            if name == "staff_unavailability":
+                return unavail_query
+            return order_query
+
+        db.collection.side_effect = collection_side_effect
+
+        from datetime import date
+        result = apply_unavailability_to_orders(db, date(2026, 2, 9))
+
+        assert result.orders_modified == 1
+        assert result.removals_count == 1
+        assert result.reverted_to_pending == 1
+        assert result.removals[0].staff_id == "H003"
+
+        # バッチ更新が呼ばれたか
+        batch.update.assert_called_once()
+        update_args = batch.update.call_args[0][1]
+        assert update_args["assigned_staff_ids"] == []
+        assert update_args["status"] == "pending"
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_partial_day_overlap(self) -> None:
+        """部分休みが時間帯重複するオーダーのみ解除"""
+        from datetime import datetime, timezone, timedelta
+        from optimizer.data.firestore_writer import apply_unavailability_to_orders
+
+        JST = timezone(timedelta(hours=9))
+
+        unavail_doc = MagicMock()
+        unavail_doc.to_dict.return_value = {
+            "staff_id": "H008",
+            "unavailable_slots": [
+                {
+                    "date": datetime(2026, 2, 11, tzinfo=JST),
+                    "all_day": False,
+                    "start_time": "09:00",
+                    "end_time": "12:00",
+                }
+            ],
+        }
+
+        # 重複するオーダー (10:00-11:00)
+        order_overlap = MagicMock()
+        order_overlap.id = "ORD-OVERLAP"
+        order_overlap.to_dict.return_value = {
+            "customer_id": "C001",
+            "date": datetime(2026, 2, 11, tzinfo=JST),
+            "start_time": "10:00",
+            "end_time": "11:00",
+            "assigned_staff_ids": ["H008"],
+            "status": "assigned",
+        }
+
+        # 重複しないオーダー (14:00-15:00)
+        order_no_overlap = MagicMock()
+        order_no_overlap.id = "ORD-OK"
+        order_no_overlap.to_dict.return_value = {
+            "customer_id": "C002",
+            "date": datetime(2026, 2, 11, tzinfo=JST),
+            "start_time": "14:00",
+            "end_time": "15:00",
+            "assigned_staff_ids": ["H008"],
+            "status": "assigned",
+        }
+
+        db = MagicMock()
+        batch = MagicMock()
+        db.batch.return_value = batch
+
+        unavail_query = MagicMock()
+        unavail_query.where.return_value = unavail_query
+        unavail_query.stream.return_value = iter([unavail_doc])
+
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([order_overlap, order_no_overlap])
+
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "staff_unavailability":
+                return unavail_query
+            return order_query
+
+        db.collection.side_effect = collection_side_effect
+
+        from datetime import date
+        result = apply_unavailability_to_orders(db, date(2026, 2, 9))
+
+        # 重複するオーダーのみ解除
+        assert result.orders_modified == 1
+        assert result.removals_count == 1
+        assert result.removals[0].order_id == "ORD-OVERLAP"
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_multi_staff_partial_removal(self) -> None:
+        """2人割当のオーダーから1人だけ除外 → assignedのまま"""
+        from datetime import datetime, timezone, timedelta
+        from optimizer.data.firestore_writer import apply_unavailability_to_orders
+
+        JST = timezone(timedelta(hours=9))
+
+        unavail_doc = MagicMock()
+        unavail_doc.to_dict.return_value = {
+            "staff_id": "H003",
+            "unavailable_slots": [
+                {"date": datetime(2026, 2, 11, tzinfo=JST), "all_day": True}
+            ],
+        }
+
+        order_doc = MagicMock()
+        order_doc.id = "ORD-MULTI"
+        order_doc.to_dict.return_value = {
+            "customer_id": "C001",
+            "date": datetime(2026, 2, 11, tzinfo=JST),
+            "start_time": "09:00",
+            "end_time": "10:00",
+            "assigned_staff_ids": ["H003", "H005"],
+            "status": "assigned",
+        }
+
+        db = MagicMock()
+        batch = MagicMock()
+        db.batch.return_value = batch
+
+        unavail_query = MagicMock()
+        unavail_query.where.return_value = unavail_query
+        unavail_query.stream.return_value = iter([unavail_doc])
+
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([order_doc])
+
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "staff_unavailability":
+                return unavail_query
+            return order_query
+
+        db.collection.side_effect = collection_side_effect
+
+        from datetime import date
+        result = apply_unavailability_to_orders(db, date(2026, 2, 9))
+
+        assert result.orders_modified == 1
+        assert result.removals_count == 1
+        assert result.reverted_to_pending == 0  # まだH005がいるのでassignedのまま
+
+        update_args = batch.update.call_args[0][1]
+        assert update_args["assigned_staff_ids"] == ["H005"]
+        assert update_args["status"] == "assigned"

--- a/web/src/components/schedule/UnavailabilityApplyButton.tsx
+++ b/web/src/components/schedule/UnavailabilityApplyButton.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { UserX, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { toast } from 'sonner';
+import { applyUnavailability, OptimizeApiError } from '@/lib/api/optimizer';
+import { useScheduleContext } from '@/contexts/ScheduleContext';
+
+/**
+ * 対象週の休み希望をオーダーに自動反映するボタン。
+ * 該当スタッフの割当を解除し、空になったオーダーはpendingに戻す。
+ */
+export function UnavailabilityApplyButton() {
+  const { weekStart } = useScheduleContext();
+
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const weekStartStr = format(weekStart, 'yyyy-MM-dd');
+
+  const handleApply = async () => {
+    setLoading(true);
+    try {
+      const result = await applyUnavailability({
+        week_start_date: weekStartStr,
+      });
+      if (result.orders_modified === 0) {
+        toast.info('反映対象のオーダーはありませんでした');
+      } else {
+        toast.success(
+          `${result.orders_modified}件のオーダーから${result.removals_count}件の割当を解除しました` +
+            (result.reverted_to_pending > 0
+              ? `（${result.reverted_to_pending}件がpendingに変更）`
+              : ''),
+        );
+      }
+      setOpen(false);
+    } catch (e) {
+      if (e instanceof OptimizeApiError) {
+        toast.error(`エラー: ${e.message}`);
+      } else {
+        toast.error('休み希望の反映に失敗しました');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+      >
+        <UserX className="mr-1 h-4 w-4" />
+        休み反映
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>休み希望をオーダーに反映</DialogTitle>
+            <DialogDescription>
+              {format(weekStart, 'M/d')}週の休み希望を確認し、
+              該当スタッフの割当を自動解除します。割当がなくなったオーダーはpendingに戻ります。
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              キャンセル
+            </Button>
+            <Button onClick={handleApply} disabled={loading}>
+              {loading && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+              反映実行
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/lib/api/optimizer.ts
+++ b/web/src/lib/api/optimizer.ts
@@ -383,3 +383,41 @@ export async function duplicateWeek(params: {
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// 休み希望の自動反映
+// ---------------------------------------------------------------------------
+
+export interface UnavailabilityRemovalItem {
+  order_id: string;
+  staff_id: string;
+  customer_id: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+}
+
+export interface ApplyUnavailabilityResponse {
+  orders_modified: number;
+  removals_count: number;
+  reverted_to_pending: number;
+  removals: UnavailabilityRemovalItem[];
+}
+
+export async function applyUnavailability(params: {
+  week_start_date: string;
+}): Promise<ApplyUnavailabilityResponse> {
+  const headers = await getAuthHeaders();
+  const res = await fetchWithRetry(() =>
+    fetch(`${API_URL}/orders/apply-unavailability`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    }),
+  );
+  if (!res.ok) {
+    const error: OptimizeError = await res.json();
+    throw new OptimizeApiError(res.status, error.detail);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- `POST /orders/apply-unavailability` エンドポイント追加
- `apply_unavailability_to_orders()` ロジック（終日/部分休み対応、時間帯重複判定、部分除外）
- `UnavailabilityApplyButton.tsx` 新規
- `applyUnavailability()` API関数追加
- テスト6件追加（エンドポイント3件 + ロジック3件: 終日除外、部分時間帯重複、複数スタッフ部分除外）

## Test plan
- [x] optimizer pytest: 351 passed
- [x] web tsc --noEmit: PASS

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)