### PR TITLE
feat: 不定期パターン自動判定API（Phase 6b-3）

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -44,6 +44,8 @@ def _get_sheets_credentials() -> object:
 
 from optimizer.api.auth import require_manager_or_above
 from optimizer.api.schemas import (
+    ApplyIrregularPatternsRequest,
+    ApplyIrregularPatternsResponse,
     ApplyUnavailabilityRequest,
     ApplyUnavailabilityResponse,
     AssignmentResponse,
@@ -70,6 +72,7 @@ from optimizer.api.schemas import (
     ChatReminderRequest,
     ChatReminderResponse,
     ChatReminderResultItem,
+    IrregularPatternExclusion,
     UnavailabilityRemovalItem,
 )
 from optimizer.data.firestore_loader import (
@@ -81,6 +84,7 @@ from optimizer.data.firestore_loader import (
     load_optimization_input,
 )
 from optimizer.data.firestore_writer import (
+    apply_irregular_patterns,
     apply_unavailability_to_orders,
     duplicate_week_orders,
     reset_assignments,
@@ -964,5 +968,55 @@ def apply_unavailability_endpoint(
                 end_time=r.end_time,
             )
             for r in result.removals
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 不定期パターン自動判定
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/orders/apply-irregular-patterns",
+    response_model=ApplyIrregularPatternsResponse,
+    responses={422: {"model": ErrorResponse}, 500: {"model": ErrorResponse}},
+)
+def apply_irregular_patterns_endpoint(
+    req: ApplyIrregularPatternsRequest,
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> ApplyIrregularPatternsResponse:
+    """対象週の不定期パターンを評価し、該当オーダーをキャンセル"""
+    try:
+        week_start = date.fromisoformat(req.week_start_date)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    if week_start.weekday() != 0:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{req.week_start_date} は月曜日ではありません"
+            f"（weekday={week_start.weekday()}）",
+        )
+
+    try:
+        db = get_firestore_client()
+        result = apply_irregular_patterns(db, week_start)
+    except Exception as e:
+        logger.error("不定期パターン適用失敗: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"不定期パターン適用エラー: {e}"
+        ) from e
+
+    return ApplyIrregularPatternsResponse(
+        cancelled_count=result.cancelled_count,
+        excluded_customers=[
+            IrregularPatternExclusion(
+                customer_id=ex.customer_id,
+                customer_name=ex.customer_name,
+                pattern_type=ex.pattern_type,
+                description=ex.description,
+            )
+            for ex in result.excluded_customers
         ],
     )

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -289,3 +289,29 @@ class ApplyUnavailabilityResponse(BaseModel):
     removals_count: int = Field(description="解除したスタッフ割当数")
     reverted_to_pending: int = Field(description="pendingに戻したオーダー数")
     removals: list[UnavailabilityRemovalItem] = Field(description="解除した割当の詳細")
+
+
+# ---------------------------------------------------------------------------
+# 不定期パターン自動判定
+# ---------------------------------------------------------------------------
+
+
+class ApplyIrregularPatternsRequest(BaseModel):
+    week_start_date: str = Field(
+        ...,
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        description="対象週の開始日（月曜日）YYYY-MM-DD",
+        examples=["2026-02-09"],
+    )
+
+
+class IrregularPatternExclusion(BaseModel):
+    customer_id: str
+    customer_name: str
+    pattern_type: str
+    description: str
+
+
+class ApplyIrregularPatternsResponse(BaseModel):
+    cancelled_count: int = Field(description="除外（キャンセル）したオーダー数")
+    excluded_customers: list[IrregularPatternExclusion] = Field(description="除外された利用者リスト")

--- a/optimizer/src/optimizer/data/firestore_writer.py
+++ b/optimizer/src/optimizer/data/firestore_writer.py
@@ -422,3 +422,150 @@ def apply_unavailability_to_orders(
         reverted_to_pending=reverted,
         removals=removals,
     )
+
+
+@dataclass
+class IrregularPatternExclusionInfo:
+    """不定期パターンによる除外1件の情報"""
+    customer_id: str
+    customer_name: str
+    pattern_type: str
+    description: str
+
+
+@dataclass
+class ApplyIrregularPatternsResult:
+    """不定期パターン適用の結果"""
+    cancelled_count: int
+    excluded_customers: list[IrregularPatternExclusionInfo]
+
+
+def _get_week_of_month(d: date) -> int:
+    """日付の月内週番号（0-based）を返す。seedスクリプトと同じロジック。"""
+    return (d.day - 1) // 7
+
+
+def _should_exclude_customer(
+    patterns: list[dict[str, Any]],
+    target_week_start: date,
+) -> tuple[bool, str, str]:
+    """不定期パターンに基づき、対象週でサービスを除外すべきか判定。
+
+    Returns:
+        (exclude, pattern_type, description) タプル
+    """
+    for p in patterns:
+        ptype = p.get("type", "")
+        desc = p.get("description", "")
+
+        if ptype == "temporary_stop":
+            return True, ptype, desc
+
+        if ptype in ("biweekly", "monthly"):
+            active_weeks = p.get("active_weeks", [])
+            if isinstance(active_weeks, str):
+                active_weeks = [int(w.strip()) for w in active_weeks.split(",") if w.strip()]
+            if not active_weeks:
+                continue
+            week_of_month = _get_week_of_month(target_week_start)
+            if week_of_month not in active_weeks:
+                return True, ptype, desc
+
+    return False, "", ""
+
+
+def apply_irregular_patterns(
+    db: firestore.Client,
+    week_start: date,
+) -> ApplyIrregularPatternsResult:
+    """対象週の不定期パターンを評価し、該当オーダーをキャンセルする
+
+    Args:
+        db: Firestoreクライアント
+        week_start: 対象週の開始日（月曜日）
+
+    Returns:
+        ApplyIrregularPatternsResult
+    """
+    JST = timezone(timedelta(hours=9))
+    week_start_dt = datetime(
+        week_start.year, week_start.month, week_start.day, tzinfo=JST,
+    )
+
+    # 不定期パターンを持つ利用者を取得
+    customer_docs = list(db.collection("customers").stream())
+
+    # customer_id → (exclude, pattern_type, description, customer_name)
+    exclude_map: dict[str, tuple[str, str, str]] = {}
+    for doc in customer_docs:
+        d = doc.to_dict()
+        if d is None:
+            continue
+        patterns = d.get("irregular_patterns", [])
+        if not patterns:
+            continue
+        exclude, ptype, desc = _should_exclude_customer(patterns, week_start)
+        if exclude:
+            name = d.get("name", {})
+            customer_name = f"{name.get('family', '')} {name.get('given', '')}"
+            exclude_map[doc.id] = (ptype, desc, customer_name)
+
+    if not exclude_map:
+        logger.info("不定期パターンによる除外対象なし (week=%s)", week_start)
+        return ApplyIrregularPatternsResult(0, [])
+
+    # 対象週のオーダーを取得
+    order_docs = list(
+        db.collection("orders")
+        .where("week_start_date", "==", week_start_dt)
+        .where("status", "in", ["pending", "assigned"])
+        .stream()
+    )
+
+    # 除外対象のオーダーをフィルタ
+    orders_to_cancel: list[Any] = []
+    for doc in order_docs:
+        d = doc.to_dict()
+        if d is None:
+            continue
+        cid = d.get("customer_id", "")
+        if cid in exclude_map:
+            orders_to_cancel.append(doc)
+
+    if not orders_to_cancel:
+        exclusions = [
+            IrregularPatternExclusionInfo(
+                customer_id=cid, customer_name=name,
+                pattern_type=ptype, description=desc,
+            )
+            for cid, (ptype, desc, name) in exclude_map.items()
+        ]
+        return ApplyIrregularPatternsResult(0, exclusions)
+
+    # バッチキャンセル
+    BATCH_LIMIT = 500
+    cancelled = 0
+    for i in range(0, len(orders_to_cancel), BATCH_LIMIT):
+        batch = db.batch()
+        chunk = orders_to_cancel[i : i + BATCH_LIMIT]
+        for doc in chunk:
+            batch.update(doc.reference, {
+                "status": "cancelled",
+                "updated_at": SERVER_TIMESTAMP,
+            })
+        batch.commit()
+        cancelled += len(chunk)
+
+    exclusions = [
+        IrregularPatternExclusionInfo(
+            customer_id=cid, customer_name=name,
+            pattern_type=ptype, description=desc,
+        )
+        for cid, (ptype, desc, name) in exclude_map.items()
+    ]
+
+    logger.info(
+        "不定期パターン適用完了: cancelled=%d, excluded_customers=%d (week=%s)",
+        cancelled, len(exclusions), week_start,
+    )
+    return ApplyIrregularPatternsResult(cancelled, exclusions)

--- a/optimizer/tests/test_api.py
+++ b/optimizer/tests/test_api.py
@@ -810,3 +810,183 @@ class TestApplyUnavailabilityLogic:
         update_args = batch.update.call_args[0][1]
         assert update_args["assigned_staff_ids"] == ["H005"]
         assert update_args["status"] == "assigned"
+
+
+class TestApplyIrregularPatternsEndpoint:
+    """POST /orders/apply-irregular-patterns のテスト"""
+
+    @patch("optimizer.api.routes.apply_irregular_patterns")
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_successful_apply(
+        self,
+        mock_get_db: MagicMock,
+        mock_apply: MagicMock,
+    ) -> None:
+        from optimizer.data.firestore_writer import (
+            ApplyIrregularPatternsResult,
+            IrregularPatternExclusionInfo,
+        )
+        mock_get_db.return_value = MagicMock()
+        mock_apply.return_value = ApplyIrregularPatternsResult(
+            cancelled_count=5,
+            excluded_customers=[
+                IrregularPatternExclusionInfo(
+                    customer_id="C030", customer_name="田中 太郎",
+                    pattern_type="temporary_stop", description="入院中",
+                ),
+            ],
+        )
+
+        response = client.post(
+            "/orders/apply-irregular-patterns",
+            json={"week_start_date": "2026-02-09"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["cancelled_count"] == 5
+        assert len(data["excluded_customers"]) == 1
+        assert data["excluded_customers"][0]["pattern_type"] == "temporary_stop"
+
+    def test_not_monday_returns_422(self) -> None:
+        response = client.post(
+            "/orders/apply-irregular-patterns",
+            json={"week_start_date": "2026-02-10"},
+        )
+        assert response.status_code == 422
+
+
+class TestApplyIrregularPatternsLogic:
+    """不定期パターン適用ロジックのユニットテスト"""
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_temporary_stop_cancels_orders(self) -> None:
+        from datetime import datetime, timezone, timedelta
+        from optimizer.data.firestore_writer import apply_irregular_patterns
+
+        JST = timezone(timedelta(hours=9))
+
+        # 利用者: temporary_stop
+        customer_doc = MagicMock()
+        customer_doc.id = "C030"
+        customer_doc.to_dict.return_value = {
+            "name": {"family": "田中", "given": "太郎"},
+            "irregular_patterns": [
+                {"type": "temporary_stop", "description": "入院中"}
+            ],
+        }
+
+        # オーダー
+        order_doc = MagicMock()
+        order_doc.id = "ORD-C030"
+        order_doc.to_dict.return_value = {
+            "customer_id": "C030",
+            "status": "pending",
+        }
+
+        db = MagicMock()
+        batch = MagicMock()
+        db.batch.return_value = batch
+
+        customer_query = MagicMock()
+        customer_query.stream.return_value = iter([customer_doc])
+
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([order_doc])
+
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "customers":
+                return customer_query
+            return order_query
+
+        db.collection.side_effect = collection_side_effect
+
+        from datetime import date
+        result = apply_irregular_patterns(db, date(2026, 2, 9))
+
+        assert result.cancelled_count == 1
+        assert len(result.excluded_customers) == 1
+        assert result.excluded_customers[0].pattern_type == "temporary_stop"
+        batch.update.assert_called_once()
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_biweekly_excludes_inactive_week(self) -> None:
+        """隔週パターン: active_weeks=[0,2]で第2週(index=1)は除外"""
+        from optimizer.data.firestore_writer import apply_irregular_patterns
+
+        customer_doc = MagicMock()
+        customer_doc.id = "C005"
+        customer_doc.to_dict.return_value = {
+            "name": {"family": "佐藤", "given": "花子"},
+            "irregular_patterns": [
+                {"type": "biweekly", "description": "隔週", "active_weeks": [0, 2]}
+            ],
+        }
+
+        order_doc = MagicMock()
+        order_doc.id = "ORD-C005"
+        order_doc.to_dict.return_value = {
+            "customer_id": "C005",
+            "status": "pending",
+        }
+
+        db = MagicMock()
+        batch = MagicMock()
+        db.batch.return_value = batch
+
+        customer_query = MagicMock()
+        customer_query.stream.return_value = iter([customer_doc])
+
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([order_doc])
+
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "customers":
+                return customer_query
+            return order_query
+
+        db.collection.side_effect = collection_side_effect
+
+        from datetime import date
+        # 2026-02-09 = 2月9日 → (9-1)//7 = 1 → week index 1 → NOT in [0,2]
+        result = apply_irregular_patterns(db, date(2026, 2, 9))
+
+        assert result.cancelled_count == 1
+        assert result.excluded_customers[0].customer_id == "C005"
+
+    @patch("optimizer.data.firestore_writer.SERVER_TIMESTAMP", "MOCK_TS")
+    def test_biweekly_includes_active_week(self) -> None:
+        """隔週パターン: active_weeks=[0,2]で第1週(index=0)は除外しない"""
+        from optimizer.data.firestore_writer import apply_irregular_patterns
+
+        customer_doc = MagicMock()
+        customer_doc.id = "C005"
+        customer_doc.to_dict.return_value = {
+            "name": {"family": "佐藤", "given": "花子"},
+            "irregular_patterns": [
+                {"type": "biweekly", "description": "隔週", "active_weeks": [0, 2]}
+            ],
+        }
+
+        db = MagicMock()
+        customer_query = MagicMock()
+        customer_query.stream.return_value = iter([customer_doc])
+
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([])
+
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "customers":
+                return customer_query
+            return order_query
+
+        db.collection.side_effect = collection_side_effect
+
+        from datetime import date
+        # 2026-02-02 = 2月2日 → (2-1)//7 = 0 → week index 0 → IN [0,2]
+        result = apply_irregular_patterns(db, date(2026, 2, 2))
+
+        assert result.cancelled_count == 0
+        assert len(result.excluded_customers) == 0

--- a/web/src/lib/api/optimizer.ts
+++ b/web/src/lib/api/optimizer.ts
@@ -421,3 +421,37 @@ export async function applyUnavailability(params: {
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// 不定期パターン自動判定
+// ---------------------------------------------------------------------------
+
+export interface IrregularPatternExclusion {
+  customer_id: string;
+  customer_name: string;
+  pattern_type: string;
+  description: string;
+}
+
+export interface ApplyIrregularPatternsResponse {
+  cancelled_count: number;
+  excluded_customers: IrregularPatternExclusion[];
+}
+
+export async function applyIrregularPatterns(params: {
+  week_start_date: string;
+}): Promise<ApplyIrregularPatternsResponse> {
+  const headers = await getAuthHeaders();
+  const res = await fetchWithRetry(() =>
+    fetch(`${API_URL}/orders/apply-irregular-patterns`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    }),
+  );
+  if (!res.ok) {
+    const error: OptimizeError = await res.json();
+    throw new OptimizeApiError(res.status, error.detail);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- `POST /orders/apply-irregular-patterns` エンドポイント追加
- `apply_irregular_patterns()` ロジック（temporary_stop / biweekly / monthly パターン評価）
- `applyIrregularPatterns()` API関数追加
- テスト5件追加（エンドポイント2件 + ロジック3件: 一時停止キャンセル、隔週除外、隔週アクティブ週）

## Test plan
- [x] optimizer pytest: 356 passed
- [x] web tsc --noEmit: PASS

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)