### PR TITLE
feat: オーダー変更時のヘルパー自動通知API（Phase 6c-1）

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -73,6 +73,9 @@ from optimizer.api.schemas import (
     ChatReminderResponse,
     ChatReminderResultItem,
     IrregularPatternExclusion,
+    OrderChangeNotifyRequest,
+    OrderChangeNotifyResponse,
+    OrderChangeNotifyResultItem,
     UnavailabilityRemovalItem,
 )
 from optimizer.data.firestore_loader import (
@@ -1019,4 +1022,107 @@ def apply_irregular_patterns_endpoint(
             )
             for ex in result.excluded_customers
         ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# オーダー変更通知
+# ---------------------------------------------------------------------------
+
+_CHANGE_TYPE_LABELS = {
+    "reassigned": "担当変更",
+    "time_changed": "時間変更",
+    "cancelled": "キャンセル",
+}
+
+_ORDER_CHANGE_TEMPLATE = (
+    "[VisitCare] 【シフト変更】\n\n"
+    "日付: {date}\n"
+    "利用者: {customer_name}\n"
+    "変更内容: {change_type_label}\n\n"
+    "詳細はシフト管理画面をご確認ください。\n"
+    "{app_url}"
+)
+
+
+@router.post(
+    "/notify/order-change",
+    response_model=OrderChangeNotifyResponse,
+    responses={500: {"model": ErrorResponse}},
+)
+def notify_order_change(
+    req: OrderChangeNotifyRequest,
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> OrderChangeNotifyResponse:
+    """オーダー変更を影響スタッフにGoogle Chat DMで通知"""
+    # ヘルパーのメールアドレスを取得
+    try:
+        db = get_firestore_client()
+        staff_emails: dict[str, str] = {}
+        for sid in req.affected_staff_ids:
+            doc = db.collection("helpers").document(sid).get()
+            if doc.exists:
+                d = doc.to_dict()
+                email = (d or {}).get("email", "")
+                if email:
+                    staff_emails[sid] = email
+    except Exception as e:
+        logger.error("ヘルパー情報取得失敗: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"ヘルパー情報取得エラー: {e}"
+        ) from e
+
+    if not staff_emails:
+        return OrderChangeNotifyResponse(
+            messages_sent=0,
+            total_targets=len(req.affected_staff_ids),
+            results=[
+                OrderChangeNotifyResultItem(
+                    staff_id=sid, email="", success=False,
+                )
+                for sid in req.affected_staff_ids
+            ],
+        )
+
+    change_label = _CHANGE_TYPE_LABELS.get(req.change_type, req.change_type)
+    message_text = req.message or _ORDER_CHANGE_TEMPLATE.format(
+        date=req.date,
+        customer_name=req.customer_name,
+        change_type_label=change_label,
+        app_url=APP_URL,
+    )
+
+    emails = list(staff_emails.values())
+    sent_count, raw_results = send_chat_dms(emails, message_text)
+
+    # email → staff_id の逆引き
+    email_to_staff = {v: k for k, v in staff_emails.items()}
+    results = [
+        OrderChangeNotifyResultItem(
+            staff_id=email_to_staff.get(str(r["email"]), ""),
+            email=str(r["email"]),
+            success=bool(r["success"]),
+        )
+        for r in raw_results
+    ]
+
+    # email未登録のスタッフも結果に含める
+    notified_staff = {r.staff_id for r in results}
+    for sid in req.affected_staff_ids:
+        if sid not in notified_staff:
+            results.append(
+                OrderChangeNotifyResultItem(
+                    staff_id=sid, email="", success=False,
+                )
+            )
+
+    logger.info(
+        "オーダー変更通知: sent=%d/%d (order=%s, change=%s)",
+        sent_count, len(req.affected_staff_ids), req.order_id, req.change_type,
+    )
+
+    return OrderChangeNotifyResponse(
+        messages_sent=sent_count,
+        total_targets=len(req.affected_staff_ids),
+        results=results,
     )

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -315,3 +315,41 @@ class IrregularPatternExclusion(BaseModel):
 class ApplyIrregularPatternsResponse(BaseModel):
     cancelled_count: int = Field(description="除外（キャンセル）したオーダー数")
     excluded_customers: list[IrregularPatternExclusion] = Field(description="除外された利用者リスト")
+
+
+# ---------------------------------------------------------------------------
+# オーダー変更通知
+# ---------------------------------------------------------------------------
+
+
+class OrderChangeNotifyRequest(BaseModel):
+    order_id: str = Field(..., description="変更対象のオーダーID")
+    change_type: str = Field(
+        ...,
+        description="変更種別: reassigned / time_changed / cancelled",
+    )
+    affected_staff_ids: list[str] = Field(
+        ..., min_length=1, description="通知対象のスタッフIDリスト",
+    )
+    customer_name: str = Field(..., description="利用者名（通知メッセージ用）")
+    date: str = Field(
+        ...,
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        description="オーダー日付 YYYY-MM-DD",
+    )
+    message: str | None = Field(
+        default=None,
+        description="カスタムメッセージ（省略時はデフォルトテンプレート使用）",
+    )
+
+
+class OrderChangeNotifyResultItem(BaseModel):
+    staff_id: str
+    email: str
+    success: bool
+
+
+class OrderChangeNotifyResponse(BaseModel):
+    messages_sent: int = Field(description="送信成功件数")
+    total_targets: int = Field(description="送信対象件数")
+    results: list[OrderChangeNotifyResultItem]

--- a/optimizer/tests/test_api.py
+++ b/optimizer/tests/test_api.py
@@ -990,3 +990,76 @@ class TestApplyIrregularPatternsLogic:
 
         assert result.cancelled_count == 0
         assert len(result.excluded_customers) == 0
+
+
+class TestOrderChangeNotifyEndpoint:
+    """POST /notify/order-change のテスト"""
+
+    @patch("optimizer.api.routes.send_chat_dms")
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_successful_notify(
+        self,
+        mock_get_db: MagicMock,
+        mock_send: MagicMock,
+    ) -> None:
+        db = MagicMock()
+        mock_get_db.return_value = db
+
+        # ヘルパードキュメントモック
+        helper_doc = MagicMock()
+        helper_doc.exists = True
+        helper_doc.to_dict.return_value = {"email": "h003@example.com"}
+        db.collection.return_value.document.return_value.get.return_value = helper_doc
+
+        mock_send.return_value = (1, [{"email": "h003@example.com", "success": True}])
+
+        response = client.post(
+            "/notify/order-change",
+            json={
+                "order_id": "ORD001",
+                "change_type": "reassigned",
+                "affected_staff_ids": ["H003"],
+                "customer_name": "田中 太郎",
+                "date": "2026-02-11",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages_sent"] == 1
+        assert data["total_targets"] == 1
+        assert data["results"][0]["success"] is True
+
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_no_email_returns_zero_sent(
+        self,
+        mock_get_db: MagicMock,
+    ) -> None:
+        db = MagicMock()
+        mock_get_db.return_value = db
+
+        # ヘルパーにemailがない
+        helper_doc = MagicMock()
+        helper_doc.exists = True
+        helper_doc.to_dict.return_value = {}
+        db.collection.return_value.document.return_value.get.return_value = helper_doc
+
+        response = client.post(
+            "/notify/order-change",
+            json={
+                "order_id": "ORD001",
+                "change_type": "cancelled",
+                "affected_staff_ids": ["H003"],
+                "customer_name": "田中 太郎",
+                "date": "2026-02-11",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages_sent"] == 0
+
+    def test_missing_required_fields_returns_422(self) -> None:
+        response = client.post(
+            "/notify/order-change",
+            json={"order_id": "ORD001"},
+        )
+        assert response.status_code == 422

--- a/web/src/lib/api/optimizer.ts
+++ b/web/src/lib/api/optimizer.ts
@@ -455,3 +455,42 @@ export async function applyIrregularPatterns(params: {
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// オーダー変更通知
+// ---------------------------------------------------------------------------
+
+export interface OrderChangeNotifyResultItem {
+  staff_id: string;
+  email: string;
+  success: boolean;
+}
+
+export interface OrderChangeNotifyResponse {
+  messages_sent: number;
+  total_targets: number;
+  results: OrderChangeNotifyResultItem[];
+}
+
+export async function notifyOrderChange(params: {
+  order_id: string;
+  change_type: string;
+  affected_staff_ids: string[];
+  customer_name: string;
+  date: string;
+  message?: string;
+}): Promise<OrderChangeNotifyResponse> {
+  const headers = await getAuthHeaders();
+  const res = await fetchWithRetry(() =>
+    fetch(`${API_URL}/notify/order-change`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    }),
+  );
+  if (!res.ok) {
+    const error: OptimizeError = await res.json();
+    throw new OptimizeApiError(res.status, error.detail);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- `POST /notify/order-change` エンドポイント追加
- affected_staff_ids → helpers.email取得 → `send_chat_dms()` で通知
- 変更種別ラベル（担当変更/時間変更/キャンセル）のテンプレート
- `notifyOrderChange()` API関数追加
- テスト3件追加

## Test plan
- [x] optimizer pytest: 359 passed
- [x] web tsc --noEmit: PASS

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)