### PR TITLE
feat: 翌日チェックリスト自動生成API+UI（Phase 6c-2）

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import re
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta, timezone
 
 import google.auth  # type: ignore[import-untyped]
 from google.cloud import firestore as firestore_client  # type: ignore[import-untyped]
@@ -49,6 +49,8 @@ from optimizer.api.schemas import (
     ApplyUnavailabilityRequest,
     ApplyUnavailabilityResponse,
     AssignmentResponse,
+    ChecklistOrderItem,
+    DailyChecklistResponse,
     DuplicateWeekRequest,
     DuplicateWeekResponse,
     ErrorResponse,
@@ -76,6 +78,7 @@ from optimizer.api.schemas import (
     OrderChangeNotifyRequest,
     OrderChangeNotifyResponse,
     OrderChangeNotifyResultItem,
+    StaffChecklist,
     UnavailabilityRemovalItem,
 )
 from optimizer.data.firestore_loader import (
@@ -1125,4 +1128,145 @@ def notify_order_change(
         messages_sent=sent_count,
         total_targets=len(req.affected_staff_ids),
         results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 翌日チェックリスト
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/checklist/next-day",
+    response_model=DailyChecklistResponse,
+    responses={422: {"model": ErrorResponse}, 500: {"model": ErrorResponse}},
+)
+def get_daily_checklist(
+    date_param: str = Query(
+        ..., alias="date",
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        description="チェックリスト対象日 YYYY-MM-DD",
+    ),
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> DailyChecklistResponse:
+    """指定日のオーダーをヘルパー別にグルーピングしたチェックリストを返す"""
+    from optimizer.data.firestore_loader import _ts_to_date_str
+
+    try:
+        target_date = date.fromisoformat(date_param)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    JST = timezone(timedelta(hours=9))
+    target_dt = datetime(target_date.year, target_date.month, target_date.day, tzinfo=JST)
+    # 翌日の00:00まで
+    target_dt_end = target_dt + timedelta(days=1)
+
+    try:
+        db = get_firestore_client()
+
+        # 対象日のオーダーを取得（pending + assigned）
+        order_docs = list(
+            db.collection("orders")
+            .where("date", ">=", target_dt)
+            .where("date", "<", target_dt_end)
+            .where("status", "in", ["pending", "assigned"])
+            .stream()
+        )
+
+        if not order_docs:
+            return DailyChecklistResponse(
+                date=date_param,
+                total_orders=0,
+                staff_checklists=[],
+            )
+
+        # ヘルパー名とcustomer名の取得
+        helper_names: dict[str, str] = {}
+        customer_names: dict[str, str] = {}
+
+        # ヘルパー名キャッシュ
+        helper_ids_needed: set[str] = set()
+        customer_ids_needed: set[str] = set()
+
+        orders_data: list[dict] = []
+        for doc in order_docs:
+            d = doc.to_dict()
+            if d is None:
+                continue
+            d["_id"] = doc.id
+            orders_data.append(d)
+            for sid in d.get("assigned_staff_ids", []):
+                helper_ids_needed.add(sid)
+            customer_ids_needed.add(d.get("customer_id", ""))
+
+        # ヘルパー名を一括取得
+        for sid in helper_ids_needed:
+            hdoc = db.collection("helpers").document(sid).get()
+            if hdoc.exists:
+                hd = hdoc.to_dict() or {}
+                name = hd.get("name", {})
+                helper_names[sid] = f"{name.get('family', '')} {name.get('given', '')}"
+
+        # 利用者名を一括取得
+        for cid in customer_ids_needed:
+            if not cid:
+                continue
+            cdoc = db.collection("customers").document(cid).get()
+            if cdoc.exists:
+                cd = cdoc.to_dict() or {}
+                name = cd.get("name", {})
+                customer_names[cid] = f"{name.get('family', '')} {name.get('given', '')}"
+
+        # ヘルパー別にグルーピング
+        staff_orders: dict[str, list[ChecklistOrderItem]] = {}
+        unassigned_orders: list[ChecklistOrderItem] = []
+
+        for d in orders_data:
+            cid = d.get("customer_id", "")
+            item = ChecklistOrderItem(
+                order_id=d["_id"],
+                customer_id=cid,
+                customer_name=customer_names.get(cid, ""),
+                start_time=d.get("start_time", ""),
+                end_time=d.get("end_time", ""),
+                service_type=d.get("service_type", ""),
+                status=d.get("status", ""),
+            )
+
+            assigned = d.get("assigned_staff_ids", [])
+            if not assigned:
+                unassigned_orders.append(item)
+            else:
+                for sid in assigned:
+                    staff_orders.setdefault(sid, []).append(item)
+
+        # 時間順ソート
+        checklists: list[StaffChecklist] = []
+        for sid in sorted(staff_orders.keys()):
+            orders = sorted(staff_orders[sid], key=lambda o: o.start_time)
+            checklists.append(StaffChecklist(
+                staff_id=sid,
+                staff_name=helper_names.get(sid, sid),
+                orders=orders,
+            ))
+
+        # 未割当オーダー
+        if unassigned_orders:
+            checklists.append(StaffChecklist(
+                staff_id="",
+                staff_name="未割当",
+                orders=sorted(unassigned_orders, key=lambda o: o.start_time),
+            ))
+
+    except Exception as e:
+        logger.error("チェックリスト生成失敗: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"チェックリスト生成エラー: {e}"
+        ) from e
+
+    return DailyChecklistResponse(
+        date=date_param,
+        total_orders=len(orders_data),
+        staff_checklists=checklists,
     )

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -353,3 +353,30 @@ class OrderChangeNotifyResponse(BaseModel):
     messages_sent: int = Field(description="送信成功件数")
     total_targets: int = Field(description="送信対象件数")
     results: list[OrderChangeNotifyResultItem]
+
+
+# ---------------------------------------------------------------------------
+# 翌日チェックリスト
+# ---------------------------------------------------------------------------
+
+
+class ChecklistOrderItem(BaseModel):
+    order_id: str
+    customer_id: str
+    customer_name: str
+    start_time: str
+    end_time: str
+    service_type: str
+    status: str
+
+
+class StaffChecklist(BaseModel):
+    staff_id: str
+    staff_name: str
+    orders: list[ChecklistOrderItem]
+
+
+class DailyChecklistResponse(BaseModel):
+    date: str
+    total_orders: int = Field(description="対象オーダー数")
+    staff_checklists: list[StaffChecklist]

--- a/optimizer/tests/test_api.py
+++ b/optimizer/tests/test_api.py
@@ -1063,3 +1063,94 @@ class TestOrderChangeNotifyEndpoint:
             json={"order_id": "ORD001"},
         )
         assert response.status_code == 422
+
+
+class TestDailyChecklistEndpoint:
+    """GET /checklist/next-day のテスト"""
+
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_successful_checklist(
+        self,
+        mock_get_db: MagicMock,
+    ) -> None:
+        from datetime import datetime, timezone, timedelta
+        JST = timezone(timedelta(hours=9))
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+
+        # オーダードキュメント
+        order_doc = MagicMock()
+        order_doc.id = "ORD001"
+        order_doc.to_dict.return_value = {
+            "customer_id": "C001",
+            "start_time": "09:00",
+            "end_time": "10:00",
+            "service_type": "physical_care",
+            "status": "assigned",
+            "assigned_staff_ids": ["H003"],
+        }
+
+        # ordersコレクションクエリ
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([order_doc])
+
+        # helpersドキュメント
+        helper_doc = MagicMock()
+        helper_doc.exists = True
+        helper_doc.to_dict.return_value = {
+            "name": {"family": "佐藤", "given": "花子"},
+        }
+
+        # customersドキュメント
+        customer_doc = MagicMock()
+        customer_doc.exists = True
+        customer_doc.to_dict.return_value = {
+            "name": {"family": "田中", "given": "太郎"},
+        }
+
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "orders":
+                return order_query
+            mock_col = MagicMock()
+            if name == "helpers":
+                mock_col.document.return_value.get.return_value = helper_doc
+            elif name == "customers":
+                mock_col.document.return_value.get.return_value = customer_doc
+            return mock_col
+
+        db.collection.side_effect = collection_side_effect
+
+        response = client.get("/checklist/next-day?date=2026-02-11")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["date"] == "2026-02-11"
+        assert data["total_orders"] == 1
+        assert len(data["staff_checklists"]) == 1
+        assert data["staff_checklists"][0]["staff_id"] == "H003"
+        assert data["staff_checklists"][0]["staff_name"] == "佐藤 花子"
+        assert len(data["staff_checklists"][0]["orders"]) == 1
+
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_empty_checklist(
+        self,
+        mock_get_db: MagicMock,
+    ) -> None:
+        db = MagicMock()
+        mock_get_db.return_value = db
+
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([])
+        db.collection.return_value = order_query
+
+        response = client.get("/checklist/next-day?date=2026-02-11")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_orders"] == 0
+        assert data["staff_checklists"] == []
+
+    def test_invalid_date_returns_422(self) -> None:
+        response = client.get("/checklist/next-day?date=bad-date")
+        assert response.status_code == 422

--- a/web/src/components/schedule/DailyChecklist.tsx
+++ b/web/src/components/schedule/DailyChecklist.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState } from 'react';
+import { format, addDays } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import { ClipboardList, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { toast } from 'sonner';
+import {
+  fetchDailyChecklist,
+  OptimizeApiError,
+  type DailyChecklistResponse,
+} from '@/lib/api/optimizer';
+import { useScheduleContext } from '@/contexts/ScheduleContext';
+
+/**
+ * 翌日のオーダーをヘルパー別にグルーピングして表示するチェックリスト。
+ */
+export function DailyChecklist() {
+  const { weekStart } = useScheduleContext();
+
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<DailyChecklistResponse | null>(null);
+
+  const tomorrow = addDays(new Date(), 1);
+  const [targetDate, setTargetDate] = useState<string>(
+    format(tomorrow, 'yyyy-MM-dd'),
+  );
+
+  const handleFetch = async () => {
+    setLoading(true);
+    try {
+      const result = await fetchDailyChecklist(targetDate);
+      setData(result);
+      if (result.total_orders === 0) {
+        toast.info('対象日のオーダーはありません');
+      }
+    } catch (e) {
+      if (e instanceof OptimizeApiError) {
+        toast.error(`エラー: ${e.message}`);
+      } else {
+        toast.error('チェックリストの取得に失敗しました');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setTargetDate(format(addDays(new Date(), 1), 'yyyy-MM-dd'));
+          setData(null);
+          setOpen(true);
+        }}
+      >
+        <ClipboardList className="mr-1 h-4 w-4" />
+        翌日チェック
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>翌日チェックリスト</DialogTitle>
+            <DialogDescription>
+              ヘルパー別の翌日予定一覧
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex items-center gap-2 py-2">
+            <input
+              type="date"
+              value={targetDate}
+              onChange={(e) => setTargetDate(e.target.value)}
+              className="rounded-md border px-3 py-2 text-sm"
+            />
+            <Button onClick={handleFetch} disabled={loading} size="sm">
+              {loading && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+              取得
+            </Button>
+          </div>
+
+          {data && data.staff_checklists.length > 0 && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                {format(new Date(targetDate + 'T00:00:00'), 'M月d日(E)', { locale: ja })} /
+                合計 {data.total_orders}件
+              </p>
+              {data.staff_checklists.map((staff) => (
+                <div key={staff.staff_id || 'unassigned'} className="border rounded-md p-3">
+                  <h4 className="font-medium text-sm mb-2">
+                    {staff.staff_name}
+                    <span className="ml-2 text-muted-foreground">
+                      ({staff.orders.length}件)
+                    </span>
+                  </h4>
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-muted-foreground">
+                        <th className="pb-1 pr-2">時間</th>
+                        <th className="pb-1 pr-2">利用者</th>
+                        <th className="pb-1 pr-2">サービス</th>
+                        <th className="pb-1">状態</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {staff.orders.map((order) => (
+                        <tr key={order.order_id} className="border-b last:border-0">
+                          <td className="py-1 pr-2 whitespace-nowrap">
+                            {order.start_time}–{order.end_time}
+                          </td>
+                          <td className="py-1 pr-2">{order.customer_name}</td>
+                          <td className="py-1 pr-2">{order.service_type}</td>
+                          <td className="py-1">{order.status}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {data && data.staff_checklists.length === 0 && (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              対象日のオーダーはありません
+            </p>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/lib/api/optimizer.ts
+++ b/web/src/lib/api/optimizer.ts
@@ -494,3 +494,46 @@ export async function notifyOrderChange(params: {
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// 翌日チェックリスト
+// ---------------------------------------------------------------------------
+
+export interface ChecklistOrderItem {
+  order_id: string;
+  customer_id: string;
+  customer_name: string;
+  start_time: string;
+  end_time: string;
+  service_type: string;
+  status: string;
+}
+
+export interface StaffChecklist {
+  staff_id: string;
+  staff_name: string;
+  orders: ChecklistOrderItem[];
+}
+
+export interface DailyChecklistResponse {
+  date: string;
+  total_orders: number;
+  staff_checklists: StaffChecklist[];
+}
+
+export async function fetchDailyChecklist(
+  date: string,
+): Promise<DailyChecklistResponse> {
+  const headers = await getAuthHeaders();
+  const res = await fetchWithRetry(() =>
+    fetch(`${API_URL}/checklist/next-day?date=${encodeURIComponent(date)}`, {
+      method: 'GET',
+      headers,
+    }),
+  );
+  if (!res.ok) {
+    const error: OptimizeError = await res.json();
+    throw new OptimizeApiError(res.status, error.detail);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- `GET /checklist/next-day?date=YYYY-MM-DD` エンドポイント追加
- ヘルパー別オーダーグルーピング（時間順ソート、未割当セクション）
- `DailyChecklist.tsx` 新規
- `fetchDailyChecklist()` API関数追加
- テスト3件追加

## Test plan
- [x] optimizer pytest: 362 passed
- [x] web tsc --noEmit: PASS

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)