### PR TITLE
feat: ヘルパーへの翌日Chat DM通知API（Phase 6c-3）

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -51,6 +51,9 @@ from optimizer.api.schemas import (
     AssignmentResponse,
     ChecklistOrderItem,
     DailyChecklistResponse,
+    NextDayNotifyRequest,
+    NextDayNotifyResponse,
+    NextDayNotifyResultItem,
     DuplicateWeekRequest,
     DuplicateWeekResponse,
     ErrorResponse,
@@ -107,7 +110,7 @@ from optimizer.integrations.note_diff import (
 from optimizer.integrations.note_parser import ParsedNote, TimeRange, parse_notes
 from optimizer.integrations.sheets_reader import mark_notes_as_handled, read_note_rows
 from optimizer.models import Assignment, OptimizationParameters, OptimizationRunRecord
-from optimizer.notification.chat_sender import send_chat_dms
+from optimizer.notification.chat_sender import send_chat_dm, send_chat_dms
 from optimizer.report.aggregation import (
     aggregate_customer_summary,
     aggregate_service_type_summary,
@@ -1269,4 +1272,144 @@ def get_daily_checklist(
         date=date_param,
         total_orders=len(orders_data),
         staff_checklists=checklists,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 翌日通知
+# ---------------------------------------------------------------------------
+
+_NEXT_DAY_NOTIFY_TEMPLATE = (
+    "[VisitCare] 翌日の予定をお知らせします\n\n"
+    "{date} の予定:\n"
+    "{schedule_text}\n\n"
+    "詳細はシフト管理画面をご確認ください。\n"
+    "{app_url}"
+)
+
+
+@router.post(
+    "/notify/next-day",
+    response_model=NextDayNotifyResponse,
+    responses={422: {"model": ErrorResponse}, 500: {"model": ErrorResponse}},
+)
+def notify_next_day(
+    req: NextDayNotifyRequest,
+    _auth: dict | None = Depends(require_manager_or_above),
+) -> NextDayNotifyResponse:
+    """翌日のチェックリストをヘルパーにChat DMで通知"""
+    if req.channel == "email":
+        raise HTTPException(
+            status_code=422,
+            detail="email通知は未実装です。channel=chatを使用してください。",
+        )
+
+    try:
+        target_date = date.fromisoformat(req.date)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    JST = timezone(timedelta(hours=9))
+    target_dt = datetime(target_date.year, target_date.month, target_date.day, tzinfo=JST)
+    target_dt_end = target_dt + timedelta(days=1)
+
+    try:
+        db = get_firestore_client()
+
+        # 対象日のassignedオーダーを取得
+        order_docs = list(
+            db.collection("orders")
+            .where("date", ">=", target_dt)
+            .where("date", "<", target_dt_end)
+            .where("status", "==", "assigned")
+            .stream()
+        )
+
+        if not order_docs:
+            return NextDayNotifyResponse(
+                date=req.date, messages_sent=0, total_targets=0, results=[],
+            )
+
+        # ヘルパー別にグルーピング
+        staff_orders: dict[str, list[dict]] = {}
+        customer_names: dict[str, str] = {}
+
+        for doc in order_docs:
+            d = doc.to_dict()
+            if d is None:
+                continue
+            for sid in d.get("assigned_staff_ids", []):
+                staff_orders.setdefault(sid, []).append(d)
+            cid = d.get("customer_id", "")
+            if cid and cid not in customer_names:
+                cdoc = db.collection("customers").document(cid).get()
+                if cdoc.exists:
+                    cd = cdoc.to_dict() or {}
+                    name = cd.get("name", {})
+                    customer_names[cid] = f"{name.get('family', '')} {name.get('given', '')}"
+
+        # 各ヘルパーにChat DM送信
+        results: list[NextDayNotifyResultItem] = []
+        sent_count = 0
+
+        for sid, orders in staff_orders.items():
+            # ヘルパー情報取得
+            hdoc = db.collection("helpers").document(sid).get()
+            if not hdoc.exists:
+                results.append(NextDayNotifyResultItem(
+                    staff_id=sid, staff_name=sid, email="",
+                    success=False, orders_count=len(orders),
+                ))
+                continue
+
+            hd = hdoc.to_dict() or {}
+            hname = hd.get("name", {})
+            staff_name = f"{hname.get('family', '')} {hname.get('given', '')}"
+            email = hd.get("email", "")
+
+            if not email:
+                results.append(NextDayNotifyResultItem(
+                    staff_id=sid, staff_name=staff_name, email="",
+                    success=False, orders_count=len(orders),
+                ))
+                continue
+
+            # スケジュールテキスト生成
+            sorted_orders = sorted(orders, key=lambda o: o.get("start_time", ""))
+            schedule_lines = []
+            for o in sorted_orders:
+                cid = o.get("customer_id", "")
+                cname = customer_names.get(cid, cid)
+                schedule_lines.append(
+                    f"  {o.get('start_time', '')}–{o.get('end_time', '')} {cname}"
+                )
+
+            message = _NEXT_DAY_NOTIFY_TEMPLATE.format(
+                date=req.date,
+                schedule_text="\n".join(schedule_lines),
+                app_url=APP_URL,
+            )
+
+            success = send_chat_dm(email, message)
+            if success:
+                sent_count += 1
+
+            results.append(NextDayNotifyResultItem(
+                staff_id=sid, staff_name=staff_name, email=email,
+                success=success, orders_count=len(orders),
+            ))
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("翌日通知失敗: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"翌日通知エラー: {e}"
+        ) from e
+
+    return NextDayNotifyResponse(
+        date=req.date,
+        messages_sent=sent_count,
+        total_targets=len(staff_orders),
+        results=results,
     )

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -380,3 +380,35 @@ class DailyChecklistResponse(BaseModel):
     date: str
     total_orders: int = Field(description="対象オーダー数")
     staff_checklists: list[StaffChecklist]
+
+
+# ---------------------------------------------------------------------------
+# 翌日通知
+# ---------------------------------------------------------------------------
+
+
+class NextDayNotifyRequest(BaseModel):
+    date: str = Field(
+        ...,
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        description="通知対象日 YYYY-MM-DD",
+    )
+    channel: str = Field(
+        default="chat",
+        description="通知チャネル: chat / email（emailは未実装）",
+    )
+
+
+class NextDayNotifyResultItem(BaseModel):
+    staff_id: str
+    staff_name: str
+    email: str
+    success: bool
+    orders_count: int
+
+
+class NextDayNotifyResponse(BaseModel):
+    date: str
+    messages_sent: int = Field(description="送信成功件数")
+    total_targets: int = Field(description="送信対象件数")
+    results: list[NextDayNotifyResultItem]

--- a/optimizer/tests/test_api.py
+++ b/optimizer/tests/test_api.py
@@ -1154,3 +1154,104 @@ class TestDailyChecklistEndpoint:
     def test_invalid_date_returns_422(self) -> None:
         response = client.get("/checklist/next-day?date=bad-date")
         assert response.status_code == 422
+
+
+class TestNextDayNotifyEndpoint:
+    """POST /notify/next-day のテスト"""
+
+    @patch("optimizer.api.routes.send_chat_dm")
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_successful_notify(
+        self,
+        mock_get_db: MagicMock,
+        mock_send_dm: MagicMock,
+    ) -> None:
+        from datetime import datetime, timezone, timedelta
+        JST = timezone(timedelta(hours=9))
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        mock_send_dm.return_value = True
+
+        # オーダー
+        order_doc = MagicMock()
+        order_doc.to_dict.return_value = {
+            "customer_id": "C001",
+            "start_time": "09:00",
+            "end_time": "10:00",
+            "status": "assigned",
+            "assigned_staff_ids": ["H003"],
+        }
+
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([order_doc])
+
+        # ヘルパー
+        helper_doc = MagicMock()
+        helper_doc.exists = True
+        helper_doc.to_dict.return_value = {
+            "name": {"family": "佐藤", "given": "花子"},
+            "email": "h003@example.com",
+        }
+
+        # 利用者
+        customer_doc = MagicMock()
+        customer_doc.exists = True
+        customer_doc.to_dict.return_value = {
+            "name": {"family": "田中", "given": "太郎"},
+        }
+
+        def collection_side_effect(name: str) -> MagicMock:
+            if name == "orders":
+                return order_query
+            mock_col = MagicMock()
+            if name == "helpers":
+                mock_col.document.return_value.get.return_value = helper_doc
+            elif name == "customers":
+                mock_col.document.return_value.get.return_value = customer_doc
+            return mock_col
+
+        db.collection.side_effect = collection_side_effect
+
+        response = client.post(
+            "/notify/next-day",
+            json={"date": "2026-02-11"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages_sent"] == 1
+        assert data["total_targets"] == 1
+        assert data["results"][0]["staff_name"] == "佐藤 花子"
+        assert data["results"][0]["success"] is True
+        mock_send_dm.assert_called_once()
+
+    def test_email_channel_returns_422(self) -> None:
+        response = client.post(
+            "/notify/next-day",
+            json={"date": "2026-02-11", "channel": "email"},
+        )
+        assert response.status_code == 422
+        assert "未実装" in response.json()["detail"]
+
+    @patch("optimizer.api.routes.get_firestore_client")
+    def test_no_orders_returns_empty(
+        self,
+        mock_get_db: MagicMock,
+    ) -> None:
+        db = MagicMock()
+        mock_get_db.return_value = db
+
+        order_query = MagicMock()
+        order_query.where.return_value = order_query
+        order_query.stream.return_value = iter([])
+        db.collection.return_value = order_query
+
+        response = client.post(
+            "/notify/next-day",
+            json={"date": "2026-02-11"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages_sent"] == 0
+        assert data["total_targets"] == 0

--- a/web/src/lib/api/optimizer.ts
+++ b/web/src/lib/api/optimizer.ts
@@ -537,3 +537,41 @@ export async function fetchDailyChecklist(
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// 翌日通知
+// ---------------------------------------------------------------------------
+
+export interface NextDayNotifyResultItem {
+  staff_id: string;
+  staff_name: string;
+  email: string;
+  success: boolean;
+  orders_count: number;
+}
+
+export interface NextDayNotifyResponse {
+  date: string;
+  messages_sent: number;
+  total_targets: number;
+  results: NextDayNotifyResultItem[];
+}
+
+export async function notifyNextDay(params: {
+  date: string;
+  channel?: string;
+}): Promise<NextDayNotifyResponse> {
+  const headers = await getAuthHeaders();
+  const res = await fetchWithRetry(() =>
+    fetch(`${API_URL}/notify/next-day`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    }),
+  );
+  if (!res.ok) {
+    const error: OptimizeError = await res.json();
+    throw new OptimizeApiError(res.status, error.detail);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- `POST /notify/next-day` エンドポイント追加
- チェックリスト内容をヘルパー別にChat DM送信（ヘルパーごとに個別メッセージ）
- email通知はスタブ（422で未実装メッセージ返却、ADR-016 Gmail API DWD設定後に実装）
- `notifyNextDay()` API関数追加
- テスト3件追加

## Test plan
- [x] optimizer pytest: 365 passed
- [x] web tsc --noEmit: PASS

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)