### PR TITLE
fix: Phase 6b-6c品質ゲート対応

### DIFF
--- a/optimizer/src/optimizer/api/routes.py
+++ b/optimizer/src/optimizer/api/routes.py
@@ -122,6 +122,20 @@ from optimizer.report.sheets_writer import create_monthly_report_spreadsheet
 logger = logging.getLogger(__name__)
 
 
+def _parse_monday(date_str: str) -> date:
+    """日付文字列をパースし月曜日であることを検証する。不正時はHTTPException。"""
+    try:
+        d = date.fromisoformat(date_str)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    if d.weekday() != 0:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{date_str} は月曜日ではありません（weekday={d.weekday()}）",
+        )
+    return d
+
+
 def _serialize_executed_at(value: object) -> str:
     """Firestore Timestamp/datetimeをISO 8601文字列に変換"""
     if hasattr(value, "isoformat"):
@@ -876,26 +890,8 @@ def duplicate_week(
     _auth: dict | None = Depends(require_manager_or_above),
 ) -> DuplicateWeekResponse:
     """基本シフト（ソース週）のオーダーをターゲット週に一括複製"""
-    # 日付パース
-    try:
-        source_week = date.fromisoformat(req.source_week_start)
-        target_week = date.fromisoformat(req.target_week_start)
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e)) from e
-
-    # 月曜日チェック
-    if source_week.weekday() != 0:
-        raise HTTPException(
-            status_code=422,
-            detail=f"{req.source_week_start} は月曜日ではありません"
-            f"（weekday={source_week.weekday()}）",
-        )
-    if target_week.weekday() != 0:
-        raise HTTPException(
-            status_code=422,
-            detail=f"{req.target_week_start} は月曜日ではありません"
-            f"（weekday={target_week.weekday()}）",
-        )
+    source_week = _parse_monday(req.source_week_start)
+    target_week = _parse_monday(req.target_week_start)
 
     # 同一週チェック
     if source_week == target_week:
@@ -942,17 +938,7 @@ def apply_unavailability_endpoint(
     _auth: dict | None = Depends(require_manager_or_above),
 ) -> ApplyUnavailabilityResponse:
     """対象週の休み希望をオーダーに反映し、該当スタッフの割当を解除"""
-    try:
-        week_start = date.fromisoformat(req.week_start_date)
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e)) from e
-
-    if week_start.weekday() != 0:
-        raise HTTPException(
-            status_code=422,
-            detail=f"{req.week_start_date} は月曜日ではありません"
-            f"（weekday={week_start.weekday()}）",
-        )
+    week_start = _parse_monday(req.week_start_date)
 
     try:
         db = get_firestore_client()
@@ -996,17 +982,7 @@ def apply_irregular_patterns_endpoint(
     _auth: dict | None = Depends(require_manager_or_above),
 ) -> ApplyIrregularPatternsResponse:
     """対象週の不定期パターンを評価し、該当オーダーをキャンセル"""
-    try:
-        week_start = date.fromisoformat(req.week_start_date)
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e)) from e
-
-    if week_start.weekday() != 0:
-        raise HTTPException(
-            status_code=422,
-            detail=f"{req.week_start_date} は月曜日ではありません"
-            f"（weekday={week_start.weekday()}）",
-        )
+    week_start = _parse_monday(req.week_start_date)
 
     try:
         db = get_firestore_client()
@@ -1061,17 +1037,17 @@ def notify_order_change(
     _auth: dict | None = Depends(require_manager_or_above),
 ) -> OrderChangeNotifyResponse:
     """オーダー変更を影響スタッフにGoogle Chat DMで通知"""
-    # ヘルパーのメールアドレスを取得
+    # ヘルパーのメールアドレスを一括取得（N+1回避）
     try:
         db = get_firestore_client()
         staff_emails: dict[str, str] = {}
-        for sid in req.affected_staff_ids:
-            doc = db.collection("helpers").document(sid).get()
-            if doc.exists:
-                d = doc.to_dict()
+        helper_refs = [db.collection("helpers").document(sid) for sid in req.affected_staff_ids]
+        for hdoc in db.get_all(helper_refs):
+            if hdoc.exists:
+                d = hdoc.to_dict()
                 email = (d or {}).get("email", "")
                 if email:
-                    staff_emails[sid] = email
+                    staff_emails[hdoc.id] = email
     except Exception as e:
         logger.error("ヘルパー情報取得失敗: %s", e, exc_info=True)
         raise HTTPException(
@@ -1153,7 +1129,7 @@ def get_daily_checklist(
     _auth: dict | None = Depends(require_manager_or_above),
 ) -> DailyChecklistResponse:
     """指定日のオーダーをヘルパー別にグルーピングしたチェックリストを返す"""
-    from optimizer.data.firestore_loader import _ts_to_date_str
+    from optimizer.data.firestore_loader import ts_to_date_str
 
     try:
         target_date = date.fromisoformat(date_param)
@@ -1203,23 +1179,24 @@ def get_daily_checklist(
                 helper_ids_needed.add(sid)
             customer_ids_needed.add(d.get("customer_id", ""))
 
-        # ヘルパー名を一括取得
-        for sid in helper_ids_needed:
-            hdoc = db.collection("helpers").document(sid).get()
-            if hdoc.exists:
-                hd = hdoc.to_dict() or {}
-                name = hd.get("name", {})
-                helper_names[sid] = f"{name.get('family', '')} {name.get('given', '')}"
+        # ヘルパー名を一括取得（N+1回避）
+        if helper_ids_needed:
+            helper_refs = [db.collection("helpers").document(sid) for sid in helper_ids_needed]
+            for hdoc in db.get_all(helper_refs):
+                if hdoc.exists:
+                    hd = hdoc.to_dict() or {}
+                    name = hd.get("name", {})
+                    helper_names[hdoc.id] = f"{name.get('family', '')} {name.get('given', '')}"
 
-        # 利用者名を一括取得
-        for cid in customer_ids_needed:
-            if not cid:
-                continue
-            cdoc = db.collection("customers").document(cid).get()
-            if cdoc.exists:
-                cd = cdoc.to_dict() or {}
-                name = cd.get("name", {})
-                customer_names[cid] = f"{name.get('family', '')} {name.get('given', '')}"
+        # 利用者名を一括取得（N+1回避）
+        customer_ids_needed.discard("")
+        if customer_ids_needed:
+            customer_refs = [db.collection("customers").document(cid) for cid in customer_ids_needed]
+            for cdoc in db.get_all(customer_refs):
+                if cdoc.exists:
+                    cd = cdoc.to_dict() or {}
+                    name = cd.get("name", {})
+                    customer_names[cdoc.id] = f"{name.get('family', '')} {name.get('given', '')}"
 
         # ヘルパー別にグルーピング
         staff_orders: dict[str, list[ChecklistOrderItem]] = {}
@@ -1334,6 +1311,7 @@ def notify_next_day(
         staff_orders: dict[str, list[dict]] = {}
         customer_names: dict[str, str] = {}
 
+        customer_ids_set: set[str] = set()
         for doc in order_docs:
             d = doc.to_dict()
             if d is None:
@@ -1341,40 +1319,55 @@ def notify_next_day(
             for sid in d.get("assigned_staff_ids", []):
                 staff_orders.setdefault(sid, []).append(d)
             cid = d.get("customer_id", "")
-            if cid and cid not in customer_names:
-                cdoc = db.collection("customers").document(cid).get()
+            if cid:
+                customer_ids_set.add(cid)
+
+        # 利用者名を一括取得（N+1回避）
+        if customer_ids_set:
+            cust_refs = [db.collection("customers").document(cid) for cid in customer_ids_set]
+            for cdoc in db.get_all(cust_refs):
                 if cdoc.exists:
                     cd = cdoc.to_dict() or {}
                     name = cd.get("name", {})
-                    customer_names[cid] = f"{name.get('family', '')} {name.get('given', '')}"
+                    customer_names[cdoc.id] = f"{name.get('family', '')} {name.get('given', '')}"
 
-        # 各ヘルパーにChat DM送信
-        results: list[NextDayNotifyResultItem] = []
-        sent_count = 0
-
-        for sid, orders in staff_orders.items():
-            # ヘルパー情報取得
-            hdoc = db.collection("helpers").document(sid).get()
+        # ヘルパー情報を一括取得
+        helper_refs = [db.collection("helpers").document(sid) for sid in staff_orders]
+        helper_docs = db.get_all(helper_refs)
+        helper_info: dict[str, tuple[str, str]] = {}  # sid → (name, email)
+        for hdoc in helper_docs:
             if not hdoc.exists:
-                results.append(NextDayNotifyResultItem(
-                    staff_id=sid, staff_name=sid, email="",
-                    success=False, orders_count=len(orders),
-                ))
                 continue
-
             hd = hdoc.to_dict() or {}
             hname = hd.get("name", {})
-            staff_name = f"{hname.get('family', '')} {hname.get('given', '')}"
-            email = hd.get("email", "")
+            helper_info[hdoc.id] = (
+                f"{hname.get('family', '')} {hname.get('given', '')}",
+                hd.get("email", ""),
+            )
 
-            if not email:
-                results.append(NextDayNotifyResultItem(
-                    staff_id=sid, staff_name=staff_name, email="",
-                    success=False, orders_count=len(orders),
-                ))
-                continue
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("翌日通知データ取得失敗: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"翌日通知エラー: {e}"
+        ) from e
 
-            # スケジュールテキスト生成
+    # 各ヘルパーにChat DM送信（個別try/exceptで1件失敗しても継続）
+    results: list[NextDayNotifyResultItem] = []
+    sent_count = 0
+
+    for sid, orders in staff_orders.items():
+        staff_name, email = helper_info.get(sid, (sid, ""))
+
+        if not email:
+            results.append(NextDayNotifyResultItem(
+                staff_id=sid, staff_name=staff_name, email="",
+                success=False, orders_count=len(orders),
+            ))
+            continue
+
+        try:
             sorted_orders = sorted(orders, key=lambda o: o.get("start_time", ""))
             schedule_lines = []
             for o in sorted_orders:
@@ -1391,21 +1384,17 @@ def notify_next_day(
             )
 
             success = send_chat_dm(email, message)
-            if success:
-                sent_count += 1
+        except Exception:
+            logger.exception("翌日通知DM送信失敗: staff=%s", sid)
+            success = False
 
-            results.append(NextDayNotifyResultItem(
-                staff_id=sid, staff_name=staff_name, email=email,
-                success=success, orders_count=len(orders),
-            ))
+        if success:
+            sent_count += 1
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("翌日通知失敗: %s", e, exc_info=True)
-        raise HTTPException(
-            status_code=500, detail=f"翌日通知エラー: {e}"
-        ) from e
+        results.append(NextDayNotifyResultItem(
+            staff_id=sid, staff_name=staff_name, email=email,
+            success=success, orders_count=len(orders),
+        ))
 
     return NextDayNotifyResponse(
         date=req.date,

--- a/optimizer/src/optimizer/api/schemas.py
+++ b/optimizer/src/optimizer/api/schemas.py
@@ -1,5 +1,7 @@
 """APIリクエスト/レスポンススキーマ"""
 
+from typing import Literal
+
 from pydantic import BaseModel, EmailStr, Field
 
 
@@ -324,9 +326,9 @@ class ApplyIrregularPatternsResponse(BaseModel):
 
 class OrderChangeNotifyRequest(BaseModel):
     order_id: str = Field(..., description="変更対象のオーダーID")
-    change_type: str = Field(
+    change_type: Literal["reassigned", "time_changed", "cancelled"] = Field(
         ...,
-        description="変更種別: reassigned / time_changed / cancelled",
+        description="変更種別",
     )
     affected_staff_ids: list[str] = Field(
         ..., min_length=1, description="通知対象のスタッフIDリスト",
@@ -393,9 +395,9 @@ class NextDayNotifyRequest(BaseModel):
         pattern=r"^\d{4}-\d{2}-\d{2}$",
         description="通知対象日 YYYY-MM-DD",
     )
-    channel: str = Field(
+    channel: Literal["chat", "email"] = Field(
         default="chat",
-        description="通知チャネル: chat / email（emailは未実装）",
+        description="通知チャネル（emailは未実装）",
     )
 
 

--- a/optimizer/src/optimizer/data/firestore_loader.py
+++ b/optimizer/src/optimizer/data/firestore_loader.py
@@ -36,7 +36,7 @@ OFFSET_TO_DAY_OF_WEEK: dict[int, DayOfWeek] = {
 }
 
 
-def _ts_to_date_str(ts: datetime | object) -> str:
+def ts_to_date_str(ts: datetime | object) -> str:
     """Firestore Timestamp/datetime → 'YYYY-MM-DD' (JST)"""
     JST = timezone(timedelta(hours=9))
     if isinstance(ts, datetime):
@@ -208,7 +208,7 @@ def load_orders(
         d = doc.to_dict()
         if d is None:
             continue
-        order_date_str = _ts_to_date_str(d["date"])
+        order_date_str = ts_to_date_str(d["date"])
         dow = _date_to_day_of_week(order_date_str)
 
         # staff_count: Firestoreにあればそれを使う、なければcustomer weekly_servicesから導出
@@ -292,7 +292,7 @@ def load_staff_unavailabilities(
             continue
         slots = [
             UnavailableSlot(
-                date=_ts_to_date_str(s["date"]),
+                date=ts_to_date_str(s["date"]),
                 all_day=s.get("all_day", True),
                 start_time=s.get("start_time"),
                 end_time=s.get("end_time"),
@@ -378,7 +378,7 @@ def load_monthly_orders(
             {
                 "id": doc.id,
                 "customer_id": d.get("customer_id", ""),
-                "date": _ts_to_date_str(d["date"]),
+                "date": ts_to_date_str(d["date"]),
                 "start_time": d.get("start_time", ""),
                 "end_time": d.get("end_time", ""),
                 "service_type": d.get("service_type", ""),

--- a/optimizer/src/optimizer/data/firestore_writer.py
+++ b/optimizer/src/optimizer/data/firestore_writer.py
@@ -13,6 +13,8 @@ from optimizer.models import Assignment, OptimizationRunRecord
 
 logger = logging.getLogger(__name__)
 
+_FIRESTORE_BATCH_LIMIT = 500
+
 
 def write_assignments(
     db: firestore.Client,
@@ -27,7 +29,7 @@ def write_assignments(
         return 0
 
     # Firestore batch write（最大500件/batch）
-    BATCH_LIMIT = 500
+    BATCH_LIMIT = _FIRESTORE_BATCH_LIMIT
     updated = 0
 
     for i in range(0, len(assignments), BATCH_LIMIT):
@@ -101,7 +103,7 @@ def reset_assignments(
     if not docs:
         return 0
 
-    BATCH_LIMIT = 500
+    BATCH_LIMIT = _FIRESTORE_BATCH_LIMIT
     reset_count = 0
 
     for i in range(0, len(docs), BATCH_LIMIT):
@@ -235,7 +237,7 @@ def duplicate_week_orders(
             order_data["linked_order_id"] = id_mapping[original_linked]
 
     # バッチ書き込み
-    BATCH_LIMIT = 500
+    BATCH_LIMIT = _FIRESTORE_BATCH_LIMIT
     created = 0
     for i in range(0, len(new_orders), BATCH_LIMIT):
         batch = db.batch()
@@ -311,7 +313,7 @@ def apply_unavailability_to_orders(
         return ApplyUnavailabilityResult(0, 0, 0, [])
 
     # 休み希望をパース: {(staff_id, date_str)} → list[slot]
-    from optimizer.data.firestore_loader import _ts_to_date_str
+    from optimizer.data.firestore_loader import ts_to_date_str
 
     staff_unavail: dict[str, list[dict[str, Any]]] = {}  # staff_id → slots
     for doc in unavail_docs:
@@ -320,7 +322,7 @@ def apply_unavailability_to_orders(
             continue
         staff_id = d["staff_id"]
         for slot in d.get("unavailable_slots", []):
-            slot_date = _ts_to_date_str(slot["date"])
+            slot_date = ts_to_date_str(slot["date"])
             staff_unavail.setdefault(staff_id, []).append({
                 "date": slot_date,
                 "all_day": slot.get("all_day", True),
@@ -349,7 +351,7 @@ def apply_unavailability_to_orders(
         if d is None:
             continue
         order_id = doc.id
-        order_date = _ts_to_date_str(d["date"])
+        order_date = ts_to_date_str(d["date"])
         assigned = list(d.get("assigned_staff_ids", []))
         order_start = d.get("start_time", "")
         order_end = d.get("end_time", "")
@@ -396,7 +398,7 @@ def apply_unavailability_to_orders(
         return ApplyUnavailabilityResult(0, 0, 0, [])
 
     # バッチ書き込み
-    BATCH_LIMIT = 500
+    BATCH_LIMIT = _FIRESTORE_BATCH_LIMIT
     modified = 0
     reverted = 0
     update_list = list(updates.items())
@@ -492,7 +494,8 @@ def apply_irregular_patterns(
         week_start.year, week_start.month, week_start.day, tzinfo=JST,
     )
 
-    # 不定期パターンを持つ利用者を取得
+    # TODO: 全利用者フルスキャン。利用者数が増えた場合、
+    # irregular_patternsの有無でフィルタするComposite Indexの追加を検討。
     customer_docs = list(db.collection("customers").stream())
 
     # customer_id → (exclude, pattern_type, description, customer_name)
@@ -543,7 +546,7 @@ def apply_irregular_patterns(
         return ApplyIrregularPatternsResult(0, exclusions)
 
     # バッチキャンセル
-    BATCH_LIMIT = 500
+    BATCH_LIMIT = _FIRESTORE_BATCH_LIMIT
     cancelled = 0
     for i in range(0, len(orders_to_cancel), BATCH_LIMIT):
         batch = db.batch()

--- a/optimizer/tests/test_api.py
+++ b/optimizer/tests/test_api.py
@@ -1007,9 +1007,10 @@ class TestOrderChangeNotifyEndpoint:
 
         # ヘルパードキュメントモック
         helper_doc = MagicMock()
+        helper_doc.id = "H003"
         helper_doc.exists = True
         helper_doc.to_dict.return_value = {"email": "h003@example.com"}
-        db.collection.return_value.document.return_value.get.return_value = helper_doc
+        db.get_all.return_value = [helper_doc]
 
         mock_send.return_value = (1, [{"email": "h003@example.com", "success": True}])
 
@@ -1037,11 +1038,11 @@ class TestOrderChangeNotifyEndpoint:
         db = MagicMock()
         mock_get_db.return_value = db
 
-        # ヘルパーにemailがない
         helper_doc = MagicMock()
+        helper_doc.id = "H003"
         helper_doc.exists = True
         helper_doc.to_dict.return_value = {}
-        db.collection.return_value.document.return_value.get.return_value = helper_doc
+        db.get_all.return_value = [helper_doc]
 
         response = client.post(
             "/notify/order-change",
@@ -1096,31 +1097,25 @@ class TestDailyChecklistEndpoint:
         order_query.where.return_value = order_query
         order_query.stream.return_value = iter([order_doc])
 
-        # helpersドキュメント
+        # helpersドキュメント（db.get_all用）
         helper_doc = MagicMock()
+        helper_doc.id = "H003"
         helper_doc.exists = True
         helper_doc.to_dict.return_value = {
             "name": {"family": "佐藤", "given": "花子"},
         }
 
-        # customersドキュメント
+        # customersドキュメント（db.get_all用）
         customer_doc = MagicMock()
+        customer_doc.id = "C001"
         customer_doc.exists = True
         customer_doc.to_dict.return_value = {
             "name": {"family": "田中", "given": "太郎"},
         }
 
-        def collection_side_effect(name: str) -> MagicMock:
-            if name == "orders":
-                return order_query
-            mock_col = MagicMock()
-            if name == "helpers":
-                mock_col.document.return_value.get.return_value = helper_doc
-            elif name == "customers":
-                mock_col.document.return_value.get.return_value = customer_doc
-            return mock_col
-
-        db.collection.side_effect = collection_side_effect
+        db.collection.return_value = order_query
+        # get_all は helpers と customers の両方で呼ばれる
+        db.get_all.side_effect = [[helper_doc], [customer_doc]]
 
         response = client.get("/checklist/next-day?date=2026-02-11")
         assert response.status_code == 200
@@ -1187,32 +1182,26 @@ class TestNextDayNotifyEndpoint:
         order_query.where.return_value = order_query
         order_query.stream.return_value = iter([order_doc])
 
-        # ヘルパー
+        # ヘルパー（db.get_all用）
         helper_doc = MagicMock()
+        helper_doc.id = "H003"
         helper_doc.exists = True
         helper_doc.to_dict.return_value = {
             "name": {"family": "佐藤", "given": "花子"},
             "email": "h003@example.com",
         }
 
-        # 利用者
+        # 利用者（db.get_all用）
         customer_doc = MagicMock()
+        customer_doc.id = "C001"
         customer_doc.exists = True
         customer_doc.to_dict.return_value = {
             "name": {"family": "田中", "given": "太郎"},
         }
 
-        def collection_side_effect(name: str) -> MagicMock:
-            if name == "orders":
-                return order_query
-            mock_col = MagicMock()
-            if name == "helpers":
-                mock_col.document.return_value.get.return_value = helper_doc
-            elif name == "customers":
-                mock_col.document.return_value.get.return_value = customer_doc
-            return mock_col
-
-        db.collection.side_effect = collection_side_effect
+        db.collection.return_value = order_query
+        # get_all: 1回目=customer, 2回目=helper
+        db.get_all.side_effect = [[customer_doc], [helper_doc]]
 
         response = client.post(
             "/notify/next-day",
@@ -1255,3 +1244,53 @@ class TestNextDayNotifyEndpoint:
         data = response.json()
         assert data["messages_sent"] == 0
         assert data["total_targets"] == 0
+
+
+class TestTimesOverlap:
+    """_times_overlap の境界値テスト"""
+
+    def test_overlap(self) -> None:
+        from optimizer.data.firestore_writer import _times_overlap
+        assert _times_overlap("09:00", "10:00", "09:30", "11:00") is True
+
+    def test_no_overlap(self) -> None:
+        from optimizer.data.firestore_writer import _times_overlap
+        assert _times_overlap("09:00", "10:00", "10:30", "11:00") is False
+
+    def test_boundary_touching_no_overlap(self) -> None:
+        """境界接触（end == start）は重複しない"""
+        from optimizer.data.firestore_writer import _times_overlap
+        assert _times_overlap("09:00", "10:00", "10:00", "11:00") is False
+
+    def test_contained(self) -> None:
+        """一方が他方に完全に含まれる"""
+        from optimizer.data.firestore_writer import _times_overlap
+        assert _times_overlap("09:00", "12:00", "10:00", "11:00") is True
+
+    def test_same_range(self) -> None:
+        from optimizer.data.firestore_writer import _times_overlap
+        assert _times_overlap("09:00", "10:00", "09:00", "10:00") is True
+
+
+class TestShouldExcludeCustomer:
+    """_should_exclude_customer のテスト"""
+
+    def test_string_active_weeks(self) -> None:
+        """active_weeksが文字列カンマ区切りの場合"""
+        from optimizer.data.firestore_writer import _should_exclude_customer
+        from datetime import date
+
+        patterns = [{"type": "biweekly", "description": "隔週", "active_weeks": "0,2"}]
+        # 2月9日 → week index 1 → NOT in [0,2]
+        exclude, ptype, _ = _should_exclude_customer(patterns, date(2026, 2, 9))
+        assert exclude is True
+        assert ptype == "biweekly"
+
+    def test_empty_active_weeks_no_exclude(self) -> None:
+        """active_weeksが空の場合は除外しない"""
+        from optimizer.data.firestore_writer import _should_exclude_customer
+        from datetime import date
+
+        patterns = [{"type": "biweekly", "description": "隔週", "active_weeks": []}]
+        exclude, _, _ = _should_exclude_customer(patterns, date(2026, 2, 9))
+        assert exclude is False

--- a/optimizer/tests/test_firestore_loader.py
+++ b/optimizer/tests/test_firestore_loader.py
@@ -8,7 +8,7 @@ import pytest
 from optimizer.data.firestore_loader import (
     _build_staff_count_lookup,
     _date_to_day_of_week,
-    _ts_to_date_str,
+    ts_to_date_str,
     load_all_customers,
     load_all_helpers,
     load_all_service_types,
@@ -65,12 +65,12 @@ def _mock_db_with_collections(collection_data: dict[str, list[MagicMock]]) -> Ma
 class TestTsToDateStr:
     def test_datetime(self) -> None:
         dt = datetime(2026, 2, 9, 0, 0, 0)
-        assert _ts_to_date_str(dt) == "2026-02-09"
+        assert ts_to_date_str(dt) == "2026-02-09"
 
     def test_firestore_timestamp(self) -> None:
         ts = MagicMock()
         ts.to_pydatetime.return_value = datetime(2026, 2, 10, 12, 0, 0)
-        assert _ts_to_date_str(ts) == "2026-02-10"
+        assert ts_to_date_str(ts) == "2026-02-10"
 
 
 class TestDateToDay:

--- a/web/src/components/schedule/DailyChecklist.tsx
+++ b/web/src/components/schedule/DailyChecklist.tsx
@@ -18,14 +18,10 @@ import {
   OptimizeApiError,
   type DailyChecklistResponse,
 } from '@/lib/api/optimizer';
-import { useScheduleContext } from '@/contexts/ScheduleContext';
-
 /**
  * 翌日のオーダーをヘルパー別にグルーピングして表示するチェックリスト。
  */
 export function DailyChecklist() {
-  const { weekStart } = useScheduleContext();
-
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<DailyChecklistResponse | null>(null);


### PR DESCRIPTION
## Summary
Phase 6b-6cの追加コードに対する品質チェック（`/simplify` + `/safe-refactor`相当）の結果修正。

### HIGH修正
- `notify_next_day`の1件失敗=全件中断バグ修正（送信ループを個別try/exceptで囲む）
- N+1 Firestoreクエリをdb.get_all()バッチ取得に変更（checklist, order-change, next-day の3箇所）
- `change_type`/`channel`をLiteral型に変更（不正値バリデーション）

### MEDIUM修正
- 月曜日チェック重複を`_parse_monday()`ヘルパー関数に抽出（DRY）
- `BATCH_LIMIT`をモジュール定数`_FIRESTORE_BATCH_LIMIT`に統一
- `_ts_to_date_str`を`ts_to_date_str`に公開化（カプセル化違反修正）
- `DailyChecklist.tsx`の未使用`weekStart`削除
- `apply_irregular_patterns`の全件スキャンTODOコメント追加

### テスト補強（+7件）
- `_times_overlap`境界値テスト5件
- `_should_exclude_customer`文字列パース/空配列テスト2件

## Test plan
- [x] optimizer pytest: 372 passed
- [x] web tsc --noEmit: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)