### PR TITLE
refactor: timeToMinutes を共通ユーティリティに統合

### DIFF
--- a/web/src/components/gantt/CustomerGanttChart.tsx
+++ b/web/src/components/gantt/CustomerGanttChart.tsx
@@ -7,9 +7,9 @@ import {
   GANTT_END_HOUR,
   HELPER_NAME_WIDTH_PX,
   ROW_HEIGHT_PX,
-  timeToMinutes,
   getServiceColor,
 } from './constants';
+import { timeToMinutes } from '@/utils/time';
 import type { DaySchedule } from '@/hooks/useScheduleData';
 import type { Customer, Helper, Order } from '@/types';
 

--- a/web/src/components/gantt/WeeklyGanttChart.tsx
+++ b/web/src/components/gantt/WeeklyGanttChart.tsx
@@ -3,7 +3,8 @@
 import { useMemo, useRef, useState, useEffect } from 'react';
 import { addDays, format } from 'date-fns';
 import { cn } from '@/lib/utils';
-import { getServiceColor, GANTT_START_HOUR, GANTT_END_HOUR, timeToMinutes } from './constants';
+import { getServiceColor, GANTT_START_HOUR, GANTT_END_HOUR } from './constants';
+import { timeToMinutes } from '@/utils/time';
 import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
 import type { DayOfWeek, Helper, Customer, Order, StaffUnavailability } from '@/types';
 import type { DaySchedule } from '@/hooks/useScheduleData';

--- a/web/src/components/gantt/__tests__/constants.test.ts
+++ b/web/src/components/gantt/__tests__/constants.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { timeToColumn, timeToMinutes, isOverlapping, TOTAL_SLOTS, SLOT_WIDTH_PX, calculateUnavailableBlocks, minutesToTime, addMinutesToTime, snapTo10Min, deltaToTimeShift, computeShiftedTimes } from '../constants';
+import { timeToColumn, isOverlapping, TOTAL_SLOTS, SLOT_WIDTH_PX, calculateUnavailableBlocks, minutesToTime, addMinutesToTime, snapTo10Min, deltaToTimeShift, computeShiftedTimes } from '../constants';
+import { timeToMinutes } from '@/utils/time';
 import type { AvailabilitySlot, UnavailableSlot, DayOfWeek } from '@/types';
 
 describe('timeToColumn', () => {

--- a/web/src/components/gantt/constants.ts
+++ b/web/src/components/gantt/constants.ts
@@ -1,3 +1,5 @@
+import { timeToMinutes } from '@/utils/time';
+
 /** ガントチャート時間軸定数 */
 export const GANTT_START_HOUR = 7;
 export const GANTT_END_HOUR = 21;
@@ -16,12 +18,6 @@ export function timeToColumn(time: string): number {
   const startMinutes = GANTT_START_HOUR * 60;
   const slot = Math.round((totalMinutes - startMinutes) / MINUTES_PER_SLOT);
   return Math.max(1, Math.min(slot + 1, TOTAL_SLOTS + 1));
-}
-
-/** "HH:MM" → 開始からの分数 */
-export function timeToMinutes(time: string): number {
-  const [h, m] = time.split(':').map(Number);
-  return h * 60 + m;
 }
 
 /** 分数 → ピクセル位置（ガント開始からの相対位置） */

--- a/web/src/lib/constraints/checker.ts
+++ b/web/src/lib/constraints/checker.ts
@@ -2,11 +2,7 @@ import type { Order, Customer, Helper, StaffUnavailability, DayOfWeek, ServiceTy
 import { isOverlapping } from '@/components/gantt/constants';
 import { getStaffCount } from '@/lib/dnd/staffCount';
 import { getTravelMinutes } from '@/lib/travelTime';
-
-function timeToMinutes(time: string): number {
-  const [h, m] = time.split(':').map(Number);
-  return h * 60 + m;
-}
+import { timeToMinutes } from '@/utils/time';
 
 function isSameDate(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() &&

--- a/web/src/lib/dnd/validation.ts
+++ b/web/src/lib/dnd/validation.ts
@@ -4,10 +4,7 @@ import type { DropValidationResult } from './types';
 import { getStaffCount } from './staffCount';
 import { getTravelMinutes } from '@/lib/travelTime';
 
-function timeToMinutes(time: string): number {
-  const [h, m] = time.split(':').map(Number);
-  return h * 60 + m;
-}
+import { timeToMinutes } from '@/utils/time';
 
 function isSameDate(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() &&

--- a/web/src/lib/report/__tests__/aggregation.test.ts
+++ b/web/src/lib/report/__tests__/aggregation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { timeToMinutes } from '@/utils/time';
 import {
-  timeToMinutes,
   orderDurationMinutes,
   aggregateStaffSummary,
   aggregateCustomerSummary,

--- a/web/src/lib/report/aggregation.ts
+++ b/web/src/lib/report/aggregation.ts
@@ -1,4 +1,5 @@
 import type { Order, Helper, Customer, ServiceType, ServiceTypeDoc } from '@/types';
+import { timeToMinutes } from '@/utils/time';
 
 // ── 型定義 ────────────────────────────────────────────────────
 
@@ -40,12 +41,6 @@ export function formatMinutesToHours(minutes: number): string {
 }
 
 // ── ユーティリティ ─────────────────────────────────────────────
-
-/** "HH:MM" → 分数 */
-export function timeToMinutes(time: string): number {
-  const [h, m] = time.split(':').map(Number);
-  return h * 60 + m;
-}
 
 /** オーダーのサービス時間（分）*/
 export function orderDurationMinutes(order: Order): number {

--- a/web/src/lib/validation/allowed-staff-check.ts
+++ b/web/src/lib/validation/allowed-staff-check.ts
@@ -1,4 +1,5 @@
 import type { Customer, Helper, Order, StaffUnavailability, DayOfWeek } from '@/types';
+import { timeToMinutes } from '@/utils/time';
 
 export interface AllowedStaffWarning {
   customer_id: string;
@@ -22,11 +23,6 @@ export interface CheckAllowedStaffInput {
 const DAY_OF_WEEK_ORDER: DayOfWeek[] = [
   'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
 ];
-
-function timeToMinutes(time: string): number {
-  const [h, m] = time.split(':').map(Number);
-  return h * 60 + m;
-}
 
 function getDayOfWeek(date: Date): DayOfWeek {
   const jsDay = date.getDay();

--- a/web/src/lib/validation/timeOverlap.ts
+++ b/web/src/lib/validation/timeOverlap.ts
@@ -1,10 +1,5 @@
 import type { ServiceSlot } from '@/types';
-
-/** "HH:MM" を分単位の整数に変換 */
-function toMinutes(time: string): number {
-  const [h, m] = time.split(':').map(Number);
-  return h * 60 + m;
-}
+import { timeToMinutes } from '@/utils/time';
 
 /**
  * 同一曜日のスロット配列の中から重複する時間帯のインデックスペアを返す。
@@ -16,10 +11,10 @@ export function detectOverlaps(slots: ServiceSlot[]): Set<number> {
 
   for (let i = 0; i < slots.length; i++) {
     for (let j = i + 1; j < slots.length; j++) {
-      const aStart = toMinutes(slots[i].start_time);
-      const aEnd = toMinutes(slots[i].end_time);
-      const bStart = toMinutes(slots[j].start_time);
-      const bEnd = toMinutes(slots[j].end_time);
+      const aStart = timeToMinutes(slots[i].start_time);
+      const aEnd = timeToMinutes(slots[i].end_time);
+      const bStart = timeToMinutes(slots[j].start_time);
+      const bEnd = timeToMinutes(slots[j].end_time);
 
       // 境界接触は重複としない（aEnd === bStart は OK）
       if (aStart < bEnd && bStart < aEnd) {

--- a/web/src/utils/__tests__/time.test.ts
+++ b/web/src/utils/__tests__/time.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { timeToMinutes } from '../time';
+
+describe('timeToMinutes', () => {
+  it('0:00 → 0', () => {
+    expect(timeToMinutes('0:00')).toBe(0);
+  });
+
+  it('09:30 → 570', () => {
+    expect(timeToMinutes('09:30')).toBe(570);
+  });
+
+  it('12:00 → 720', () => {
+    expect(timeToMinutes('12:00')).toBe(720);
+  });
+
+  it('23:59 → 1439', () => {
+    expect(timeToMinutes('23:59')).toBe(1439);
+  });
+});

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -1,0 +1,5 @@
+/** "HH:MM" → 0時からの経過分数 */
+export function timeToMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}


### PR DESCRIPTION
## Summary
- `web/src/utils/time.ts` に `timeToMinutes` 関数を統一定義
- web/src/ 内の7箇所の重複定義（`constants.ts`, `aggregation.ts`, `checker.ts`, `validation.ts`, `allowed-staff-check.ts`, `timeOverlap.ts`）を削除し、共通importに切替
- 全importをファイル先頭に配置、re-exportパターンを排除

Closes #270

## Test plan
- [x] `web/src/utils/__tests__/time.test.ts` 新規テスト4件PASS
- [x] tsc --noEmit PASS
- [x] 既存テスト1,080件全PASS（回帰なし）
- [x] ロジック変更なし（純粋なDRYリファクタリング）

🤖 Generated with [Claude Code](https://claude.com/claude-code)