### PR TITLE
refactor: ヘルパー/利用者名フォーマットを共通関数に統合

### DIFF
--- a/web/src/app/history/page.tsx
+++ b/web/src/app/history/page.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/sheet';
 import { useOptimizationRuns, useOptimizationRunDetail } from '@/hooks/useOptimizationRuns';
 import { useHelpers } from '@/hooks/useHelpers';
+import { formatFullName } from '@/utils/name';
 
 function StatusBadge({ status, dryRun }: { status: string; dryRun: boolean }) {
   if (dryRun) {
@@ -70,7 +71,7 @@ function RunDetailPanel({
   const { helpers } = useHelpers();
 
   const helperNameMap = new Map<string, string>();
-  helpers.forEach((h, id) => helperNameMap.set(id, `${h.name.family} ${h.name.given}`));
+  helpers.forEach((h, id) => helperNameMap.set(id, formatFullName(h.name)));
 
   if (loading || !detail) {
     return (

--- a/web/src/app/masters/customers/page.tsx
+++ b/web/src/app/masters/customers/page.tsx
@@ -21,6 +21,7 @@ import { CustomerEditDialog } from '@/components/masters/CustomerEditDialog';
 import { CustomerDetailSheet } from '@/components/masters/CustomerDetailSheet';
 import { useCustomerDetailViewModel } from '@/components/masters/customerDetailViewModel';
 import { DAY_OF_WEEK_ORDER } from '@/types';
+import { formatFullName } from '@/utils/name';
 import type { Customer } from '@/types';
 
 /** カタカナをひらがなに変換（検索正規化用） */
@@ -247,7 +248,7 @@ export default function CustomersPage() {
                     {customer.aozora_id ?? '-'}
                   </TableCell>
                   <TableCell className="font-medium">
-                    <div>{customer.name.family} {customer.name.given}</div>
+                    <div>{formatFullName(customer.name)}</div>
                     {(customer.name.family_kana || customer.name.given_kana) && (
                       <div className="text-xs text-muted-foreground font-normal">
                         {customer.name.family_kana} {customer.name.given_kana}

--- a/web/src/app/masters/helpers/page.tsx
+++ b/web/src/app/masters/helpers/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/table';
 import { HelperEditDialog } from '@/components/masters/HelperEditDialog';
 import { HelperDetailSheet } from '@/components/masters/HelperDetailSheet';
+import { formatFullName } from '@/utils/name';
 import type { Helper } from '@/types';
 
 const TRANSPORTATION_LABELS: Record<string, string> = {
@@ -135,7 +136,7 @@ export default function HelpersPage() {
                   onClick={() => openDetail(helper)}
                 >
                   <TableCell className="font-medium">
-                    {helper.name.family} {helper.name.given}
+                    {formatFullName(helper.name)}
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
                     {helper.qualifications.join(', ') || '-'}

--- a/web/src/app/masters/unavailability/page.tsx
+++ b/web/src/app/masters/unavailability/page.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { UnavailabilityEditDialog } from '@/components/masters/UnavailabilityEditDialog';
+import { formatFullName } from '@/utils/name';
 import type { StaffUnavailability } from '@/types';
 import { DAY_OF_WEEK_LABELS, DAY_OF_WEEK_ORDER } from '@/types';
 
@@ -60,7 +61,7 @@ export default function UnavailabilityPage() {
     () =>
       Array.from(helpers.values())
         .filter((h) => !submittedStaffIds.has(h.id))
-        .map((h) => ({ id: h.id, name: `${h.name.family} ${h.name.given}` })),
+        .map((h) => ({ id: h.id, name: formatFullName(h.name) })),
     [helpers, submittedStaffIds],
   );
 
@@ -189,7 +190,7 @@ export default function UnavailabilityPage() {
                 return (
                   <TableRow key={u.id} className={index % 2 === 1 ? 'bg-muted/30' : ''}>
                     <TableCell className="font-medium">
-                      {h ? `${h.name.family} ${h.name.given}` : u.staff_id}
+                      {h ? formatFullName(h.name) : u.staff_id}
                     </TableCell>
                     <TableCell>
                       <div className="flex flex-wrap gap-1">

--- a/web/src/app/masters/weekly-schedule/page.tsx
+++ b/web/src/app/masters/weekly-schedule/page.tsx
@@ -8,6 +8,7 @@ import { useServiceTypes } from '@/hooks/useServiceTypes';
 import { useAuthRole } from '@/lib/auth/AuthProvider';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import { formatDisplayName, formatFullName } from '@/utils/name';
 import {
   Table,
   TableBody,
@@ -84,8 +85,8 @@ export default function WeeklySchedulePage() {
 
   const filtered = useMemo(() => {
     const list = Array.from(customers.values()).sort((a, b) => {
-      const na = a.name.short ?? `${a.name.family}${a.name.given}`;
-      const nb = b.name.short ?? `${b.name.family}${b.name.given}`;
+      const na = formatDisplayName(a.name);
+      const nb = formatDisplayName(b.name);
       return na.localeCompare(nb, 'ja');
     });
     if (!search.trim()) return list;
@@ -153,8 +154,7 @@ export default function WeeklySchedulePage() {
               filtered.map((customer, index) => {
                 const total = totalWeeklySlots(customer);
                 const name =
-                  customer.name.short ??
-                  `${customer.name.family} ${customer.name.given}`;
+                  customer.name.short ?? formatFullName(customer.name);
                 return (
                   <TableRow
                     key={customer.id}
@@ -164,7 +164,7 @@ export default function WeeklySchedulePage() {
                     <TableCell
                       className="font-medium sticky left-0 z-10 border-r"
                       style={{ backgroundColor: index % 2 === 1 ? 'hsl(var(--muted) / 0.3)' : 'hsl(var(--background))' }}
-                      title={`${customer.name.family} ${customer.name.given}`}
+                      title={formatFullName(customer.name)}
                     >
                       <div className="truncate max-w-[120px]">{name}</div>
                       {(customer.name.family_kana || customer.name.given_kana) && (

--- a/web/src/components/gantt/CustomerGanttChart.tsx
+++ b/web/src/components/gantt/CustomerGanttChart.tsx
@@ -10,6 +10,7 @@ import {
   getServiceColor,
 } from './constants';
 import { timeToMinutes } from '@/utils/time';
+import { formatDisplayName } from '@/utils/name';
 import type { DaySchedule } from '@/hooks/useScheduleData';
 import type { Customer, Helper, Order } from '@/types';
 
@@ -45,7 +46,7 @@ function CustomerOrderBar({ order, chartWidth, helpers, onOrderClick }: Customer
     order.assigned_staff_ids
       .map((id) => {
         const h = helpers.get(id);
-        return h ? (h.name.short ?? `${h.name.family}${h.name.given}`) : id;
+        return h ? (formatDisplayName(h.name)) : id;
       })
       .join(' ') || '未割当';
 
@@ -126,10 +127,10 @@ export function CustomerGanttChart({
       }))
       .sort((a, b) => {
         const nameA = a.customer
-          ? (a.customer.name.short ?? `${a.customer.name.family}${a.customer.name.given}`)
+          ? (formatDisplayName(a.customer.name))
           : a.customerId;
         const nameB = b.customer
-          ? (b.customer.name.short ?? `${b.customer.name.family}${b.customer.name.given}`)
+          ? (formatDisplayName(b.customer.name))
           : b.customerId;
         return nameA.localeCompare(nameB, 'ja');
       });
@@ -174,7 +175,7 @@ export function CustomerGanttChart({
       {/* 利用者行 */}
       {customerRows.map(({ customer, customerId, orders }) => {
         const customerName = customer
-          ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+          ? (formatDisplayName(customer.name))
           : customerId;
         return (
           <div key={customerId} className="flex border-b" style={{ height: ROW_HEIGHT_PX }}>
@@ -213,7 +214,7 @@ export function CustomerGanttChart({
             {schedule.unassignedOrders.map((order) => {
               const customer = customers.get(order.customer_id);
               const customerName = customer
-                ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+                ? (formatDisplayName(customer.name))
                 : order.customer_id;
               return (
                 <UnassignedOrderBar

--- a/web/src/components/gantt/GanttBar.tsx
+++ b/web/src/components/gantt/GanttBar.tsx
@@ -7,6 +7,7 @@ import { Check, Users, X } from 'lucide-react';
 import { timeToColumn, getServiceColor } from './constants';
 import { useSlotWidth } from './GanttScaleContext';
 import type { Order, Customer } from '@/types';
+import { formatDisplayName } from '@/utils/name';
 import type { DragData } from '@/lib/dnd/types';
 import { cn } from '@/lib/utils';
 import { ADDRESS_GROUP_COLOR } from '@/hooks/useAddressGroups';
@@ -50,7 +51,7 @@ export const GanttBar = memo(function GanttBar({ order, customer, hasViolation, 
 
   const colors = getServiceColor(order.service_type);
   const customerName = customer
-    ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+    ? formatDisplayName(customer.name)
     : order.customer_id;
 
   const addressColor = addressGroupInfo ? ADDRESS_GROUP_COLOR : undefined;

--- a/web/src/components/gantt/GanttRow.tsx
+++ b/web/src/components/gantt/GanttRow.tsx
@@ -8,6 +8,7 @@ import { TOTAL_SLOTS, HELPER_NAME_WIDTH_PX, GANTT_START_HOUR, GANTT_END_HOUR, ca
 import { useSlotWidth } from './GanttScaleContext';
 import type { Order, Customer, StaffUnavailability, DayOfWeek } from '@/types';
 import { getStaffCount } from '@/lib/dnd/staffCount';
+import { formatDisplayName } from '@/utils/name';
 import type { HelperScheduleRow } from '@/hooks/useScheduleData';
 import type { ViolationMap } from '@/lib/constraints/checker';
 import type { DropZoneStatus } from '@/lib/dnd/types';
@@ -60,7 +61,7 @@ const TOTAL_10MIN_INTERVALS = (GANTT_END_HOUR - GANTT_START_HOUR) * 6; // 14h ×
 export const GanttRow = memo(function GanttRow({ row, customers, violations, onOrderClick, dropZoneStatus = 'idle', index, unavailability, day, dayDate, activeOrder, previewTimes, dropMessage, onConfirmManualEdit, addressGroupMap }: GanttRowProps) {
   const slotWidth = useSlotWidth();
   const pxPer10Min = SLOTS_PER_10MIN * slotWidth;
-  const helperName = row.helper.name.short ?? `${row.helper.name.family}${row.helper.name.given}`;
+  const helperName = formatDisplayName(row.helper.name);
 
   const staffUnavailSlots = unavailability
     .filter((u) => u.staff_id === row.helper.id)
@@ -169,7 +170,7 @@ export const GanttRow = memo(function GanttRow({ row, customers, violations, onO
           const ghostColor = GHOST_COLORS[activeOrder.service_type] ?? GHOST_COLORS.physical_care;
           const customerName = customers.get(activeOrder.customer_id);
           const ghostLabel = customerName
-            ? (customerName.name.short ?? `${customerName.name.family}${customerName.name.given}`)
+            ? formatDisplayName(customerName.name)
             : '';
 
           // 10分単位（2スロット）にスナップ

--- a/web/src/components/gantt/UnassignedSection.tsx
+++ b/web/src/components/gantt/UnassignedSection.tsx
@@ -5,6 +5,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { PackageOpen } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import type { Order, Customer } from '@/types';
+import { formatDisplayName } from '@/utils/name';
 import type { DragData, DropZoneStatus } from '@/lib/dnd/types';
 import { cn } from '@/lib/utils';
 import { useServiceTypes } from '@/hooks/useServiceTypes';
@@ -59,7 +60,7 @@ function UnassignedOrderItem({
 }) {
   const customer = customers.get(order.customer_id);
   const name = customer
-    ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+    ? formatDisplayName(customer.name)
     : order.customer_id;
 
   const dragData: DragData = { orderId: order.id, sourceHelperId: null };

--- a/web/src/components/gantt/WeeklyGanttChart.tsx
+++ b/web/src/components/gantt/WeeklyGanttChart.tsx
@@ -5,6 +5,7 @@ import { addDays, format } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { getServiceColor, GANTT_START_HOUR, GANTT_END_HOUR } from './constants';
 import { timeToMinutes } from '@/utils/time';
+import { formatDisplayName } from '@/utils/name';
 import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
 import type { DayOfWeek, Helper, Customer, Order, StaffUnavailability } from '@/types';
 import type { DaySchedule } from '@/hooks/useScheduleData';
@@ -72,7 +73,7 @@ function WeeklyMiniBar({ order, customer, dayColWidth, onDayClick }: WeeklyMiniB
 
   const colors = getServiceColor(order.service_type);
   const customerName = customer
-    ? (customer.name.short ?? `${customer.name.family}${customer.name.given}`)
+    ? formatDisplayName(customer.name)
     : order.customer_id;
 
   return (
@@ -142,7 +143,7 @@ function WeeklyHelperRow({
   weekStart,
   onDayClick,
 }: WeeklyHelperRowProps) {
-  const helperName = helper.name.short ?? `${helper.name.family}${helper.name.given}`;
+  const helperName = formatDisplayName(helper.name);
 
   return (
     <div className="flex border-b" style={{ height: ROW_HEIGHT }}>

--- a/web/src/components/masters/CustomerEditDialog.tsx
+++ b/web/src/components/masters/CustomerEditDialog.tsx
@@ -35,6 +35,7 @@ import { createCustomer, updateCustomer } from '@/lib/firestore/customers';
 import { geocodeAddress } from '@/lib/geocoding';
 import { useHelpers } from '@/hooks/useHelpers';
 import { useCustomers } from '@/hooks/useCustomers';
+import { formatFullName } from '@/utils/name';
 import type { Customer } from '@/types';
 
 const GOOGLE_MAPS_API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? '';
@@ -496,7 +497,7 @@ export function CustomerEditDialog({
                                   className="flex-1 text-sm cursor-pointer select-none"
                                 >
                                   {h
-                                    ? `${h.name.family} ${h.name.given}`
+                                    ? formatFullName(h.name)
                                     : id}
                                   {isPreferred && (
                                     <span className="ml-2 text-xs text-amber-600 font-medium">

--- a/web/src/components/masters/CustomerMultiSelect.tsx
+++ b/web/src/components/masters/CustomerMultiSelect.tsx
@@ -15,6 +15,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Checkbox } from '@/components/ui/checkbox';
+import { formatFullName } from '@/utils/name';
 import type { Customer } from '@/types';
 
 interface CustomerMultiSelectProps {
@@ -95,7 +96,7 @@ export function CustomerMultiSelect({
             const c = customers.get(id);
             return (
               <Badge key={id} variant="secondary" className="gap-1 pr-1">
-                {c ? `${c.name.family} ${c.name.given}` : id}
+                {c ? formatFullName(c.name) : id}
                 <button
                   type="button"
                   onClick={() => removeCustomer(id)}
@@ -139,7 +140,7 @@ export function CustomerMultiSelect({
                   onCheckedChange={() => toggleCustomer(c.id)}
                 />
                 <span className="text-sm">
-                  {c.name.family} {c.name.given}
+                  {formatFullName(c.name)}
                 </span>
                 <span className="text-xs text-muted-foreground ml-auto truncate max-w-[150px]">
                   {c.address}

--- a/web/src/components/masters/CustomerTrainingStatusEditor.tsx
+++ b/web/src/components/masters/CustomerTrainingStatusEditor.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { formatFullName } from '@/utils/name';
 import type { Customer, TrainingStatus } from '@/types';
 
 interface CustomerTrainingStatusEditorProps {
@@ -107,7 +108,7 @@ export function CustomerTrainingStatusEditor({
                 className="flex items-center gap-2 rounded-md border px-2 py-1.5"
               >
                 <span className="text-sm flex-1">
-                  {c ? `${c.name.family} ${c.name.given}` : customerId}
+                  {c ? formatFullName(c.name) : customerId}
                 </span>
                 <Select
                   value={status}
@@ -171,7 +172,7 @@ export function CustomerTrainingStatusEditor({
                 onClick={() => setSelectedCustomerId(c.id)}
               >
                 <span className="text-sm">
-                  {c.name.family} {c.name.given}
+                  {formatFullName(c.name)}
                 </span>
               </label>
             ))}

--- a/web/src/components/masters/HelperDetailSheet.tsx
+++ b/web/src/components/masters/HelperDetailSheet.tsx
@@ -10,6 +10,7 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet';
 import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
+import { formatFullName } from '@/utils/name';
 import type { Helper, Customer, TrainingStatus } from '@/types';
 
 const TRANSPORTATION_LABELS: Record<string, string> = {
@@ -76,7 +77,7 @@ export function HelperDetailSheet({
 }: HelperDetailSheetProps) {
   if (!helper) return null;
 
-  const fullName = `${helper.name.family} ${helper.name.given}`;
+  const fullName = formatFullName(helper.name);
 
   const hasWeeklyAvailability = DAY_OF_WEEK_ORDER.some(
     (d) => helper.weekly_availability[d] && helper.weekly_availability[d]!.length > 0
@@ -222,7 +223,7 @@ export function HelperDetailSheet({
                       {pendingTraining.map(([customerId, status]) => {
                         const customer = customers.get(customerId);
                         const displayName = customer
-                          ? `${customer.name.family} ${customer.name.given}`
+                          ? formatFullName(customer.name)
                           : customerId;
                         return (
                           <div key={customerId} className="flex items-center justify-between text-sm">
@@ -246,7 +247,7 @@ export function HelperDetailSheet({
                       {independentEntries.map(([customerId]) => {
                         const customer = customers.get(customerId);
                         const displayName = customer
-                          ? `${customer.name.family} ${customer.name.given}`
+                          ? formatFullName(customer.name)
                           : customerId;
                         return (
                           <Badge key={customerId} variant="default" className="text-xs">

--- a/web/src/components/masters/StaffMultiSelect.tsx
+++ b/web/src/components/masters/StaffMultiSelect.tsx
@@ -15,6 +15,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Checkbox } from '@/components/ui/checkbox';
+import { formatFullName, formatCompactName } from '@/utils/name';
 import type { Helper, Customer, TrainingStatus, GenderRequirement } from '@/types';
 import { TRAINING_STATUS_LABELS, TRAINING_STATUS_VARIANT } from '@/lib/labels/training-status';
 
@@ -115,7 +116,7 @@ export function StaffMultiSelect({
     const hasAllowed = allowedIds.length > 0;
 
     const sortByName = (a: Helper, b: Helper) =>
-      `${a.name.family}${a.name.given}`.localeCompare(`${b.name.family}${b.name.given}`, 'ja');
+      formatCompactName(a.name).localeCompare(formatCompactName(b.name), 'ja');
 
     if (preferred.length > 0) {
       groups.push({ group: 'preferred', label: GROUP_LABELS.preferred, items: preferred.sort(sortByName) });
@@ -164,7 +165,7 @@ export function StaffMultiSelect({
           onCheckedChange={() => toggleStaff(h.id)}
         />
         <span className="text-sm">
-          {h.name.family} {h.name.given}
+          {formatFullName(h.name)}
         </span>
         <span className="text-xs text-muted-foreground ml-auto">
           {h.qualifications.join(', ') || '-'}
@@ -288,7 +289,7 @@ export function StaffMultiSelect({
             const h = helpers.get(id);
             return (
               <Badge key={id} variant="secondary" className="gap-1 pr-1">
-                {h ? `${h.name.family} ${h.name.given}` : id}
+                {h ? formatFullName(h.name) : id}
                 <button
                   type="button"
                   onClick={() => removeStaff(id)}

--- a/web/src/components/masters/UnavailabilityEditDialog.tsx
+++ b/web/src/components/masters/UnavailabilityEditDialog.tsx
@@ -34,6 +34,7 @@ import {
   updateStaffUnavailability,
   deleteStaffUnavailability,
 } from '@/lib/firestore/staff-unavailability';
+import { formatFullName } from '@/utils/name';
 import type { Helper, StaffUnavailability } from '@/types';
 import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
 
@@ -155,7 +156,7 @@ export function UnavailabilityEditDialog({
               <SelectContent>
                 {helperList.map((h) => (
                   <SelectItem key={h.id} value={h.id}>
-                    {h.name.family} {h.name.given}
+                    {formatFullName(h.name)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/web/src/components/masters/customerDetailViewModel.ts
+++ b/web/src/components/masters/customerDetailViewModel.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { DAY_OF_WEEK_ORDER, DAY_OF_WEEK_LABELS } from '@/types';
 import type { Customer, Helper, ServiceTypeDoc, DayOfWeek } from '@/types';
+import { formatFullName, formatFullNameKana } from '@/utils/name';
 
 // ── 表示ラベル定数 ──────────────────────────────────────────
 const GENDER_REQUIREMENT_LABELS: Record<string, string> = {
@@ -79,12 +80,12 @@ export interface CustomerDetailViewModel {
 
 function resolveStaffName(id: string, helpers: Map<string, Helper>): string {
   const h = helpers.get(id);
-  return h ? `${h.name.family} ${h.name.given}` : id;
+  return h ? formatFullName(h.name) : id;
 }
 
 function resolveCustomerName(id: string, customers: Map<string, Customer>): string {
   const c = customers.get(id);
-  return c ? `${c.name.family} ${c.name.given}` : id;
+  return c ? formatFullName(c.name) : id;
 }
 
 export function buildCustomerDetailViewModel(
@@ -93,10 +94,10 @@ export function buildCustomerDetailViewModel(
   customers: Map<string, Customer>,
   serviceTypes: Map<string, ServiceTypeDoc>,
 ): CustomerDetailViewModel {
-  const fullName = `${customer.name.family} ${customer.name.given}`;
+  const fullName = formatFullName(customer.name);
   const fullKana =
     customer.name.family_kana || customer.name.given_kana
-      ? `${customer.name.family_kana ?? ''} ${customer.name.given_kana ?? ''}`.trim()
+      ? formatFullNameKana(customer.name)
       : null;
 
   const preferredSet = new Set(customer.preferred_staff_ids ?? []);

--- a/web/src/components/schedule/AssignmentDiffBadge.tsx
+++ b/web/src/components/schedule/AssignmentDiffBadge.tsx
@@ -3,6 +3,7 @@
 import { Badge } from '@/components/ui/badge';
 import type { Helper } from '@/types';
 import type { AssignmentDiff } from '@/hooks/useAssignmentDiff';
+import { formatFullName } from '@/utils/name';
 
 interface AssignmentDiffBadgeProps {
   diff: AssignmentDiff;
@@ -11,7 +12,7 @@ interface AssignmentDiffBadgeProps {
 
 function staffName(id: string, helpers: Map<string, Helper>): string {
   const h = helpers.get(id);
-  return h ? `${h.name.family} ${h.name.given}` : id;
+  return h ? formatFullName(h.name) : id;
 }
 
 export function AssignmentDiffBadge({ diff, helpers }: AssignmentDiffBadgeProps) {

--- a/web/src/components/schedule/CompanionDialog.tsx
+++ b/web/src/components/schedule/CompanionDialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { getCompanionCandidates } from '@/lib/companion/filter';
+import { formatFullName } from '@/utils/name';
 import type { Order, Customer, Helper, TrainingStatus, StaffUnavailability, DayOfWeek } from '@/types';
 import { TRAINING_STATUS_LABELS, TRAINING_STATUS_VARIANT } from '@/lib/labels/training-status';
 
@@ -113,7 +114,7 @@ export function CompanionDialog({
             <div className="flex flex-wrap gap-1.5">
               {teachingStaff.map((h) => (
                 <Badge key={h.id} variant="secondary" className="text-xs">
-                  {h.name.family} {h.name.given}
+                  {formatFullName(h.name)}
                 </Badge>
               ))}
             </div>
@@ -126,7 +127,7 @@ export function CompanionDialog({
             <div className="flex items-center gap-2">
               <Users className="h-4 w-4 text-muted-foreground" />
               <span className="text-sm font-medium">
-                現在の同行者: {currentCompanion.name.family} {currentCompanion.name.given}
+                現在の同行者: {formatFullName(currentCompanion.name)}
               </span>
             </div>
             <Button
@@ -174,7 +175,7 @@ export function CompanionDialog({
                   className="h-4 w-4 text-primary"
                 />
                 <span className="text-sm">
-                  {h.name.family} {h.name.given}
+                  {formatFullName(h.name)}
                 </span>
                 <span className="text-xs text-muted-foreground">
                   {h.qualifications.join(', ') || '-'}

--- a/web/src/components/schedule/OrderDetailPanel.tsx
+++ b/web/src/components/schedule/OrderDetailPanel.tsx
@@ -15,6 +15,7 @@ import { StaffMultiSelect } from '@/components/masters/StaffMultiSelect';
 import { AssignmentDiffBadge } from '@/components/schedule/AssignmentDiffBadge';
 import { CompanionDialog } from '@/components/schedule/CompanionDialog';
 import { updateOrderStatus, isOrderStatus } from '@/lib/firestore/updateOrder';
+import { formatFullName } from '@/utils/name';
 import type { Order, Customer, Helper, StaffUnavailability, DayOfWeek } from '@/types';
 import type { CompanionBeforeState } from '@/hooks/useOrderEdit';
 import type { Violation } from '@/lib/constraints/checker';
@@ -97,7 +98,7 @@ export function OrderDetailPanel({
   if (!order) return null;
 
   const customerName = customer
-    ? `${customer.name.family} ${customer.name.given}`
+    ? formatFullName(customer.name)
     : order.customer_id;
 
   const isFinalized = order.status === 'completed' || order.status === 'cancelled';
@@ -226,7 +227,7 @@ export function OrderDetailPanel({
               <ul className="space-y-1.5 pl-6">
                 {assignedHelpers.map((h) => (
                   <li key={h.id} className="flex items-center gap-2 text-sm">
-                    <span>{h.name.family} {h.name.given}</span>
+                    <span>{formatFullName(h.name)}</span>
                     {h.can_physical_care && (
                       <Badge variant="secondary" className="text-[10px] bg-[oklch(0.55_0.15_225)]/10 text-[oklch(0.45_0.15_225)]">身体可</Badge>
                     )}
@@ -242,7 +243,7 @@ export function OrderDetailPanel({
           {onCompanionChange && helpers && customer && !isFinalized && (() => {
             const companionHelper = order.companion_staff_id ? helpers.get(order.companion_staff_id) : undefined;
             const companionName = companionHelper
-              ? `${companionHelper.name.family} ${companionHelper.name.given}`
+              ? formatFullName(companionHelper.name)
               : order.companion_staff_id;
             const beforeState: CompanionBeforeState = {
               companion_staff_id: order.companion_staff_id,

--- a/web/src/components/unavailability/ChatReminderDialog.tsx
+++ b/web/src/components/unavailability/ChatReminderDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { sendChatReminder, OptimizeApiError } from '@/lib/api/optimizer';
 import { toast } from 'sonner';
+import { formatFullName } from '@/utils/name';
 import type { Helper } from '@/types';
 
 interface ChatReminderDialogProps {
@@ -83,7 +84,7 @@ export function ChatReminderDialog({
       .filter((h) => selected.has(h.id))
       .map((h) => ({
         staff_id: h.id,
-        name: `${h.name.family} ${h.name.given}`,
+        name: formatFullName(h.name),
         email: h.email!,
       }));
 
@@ -157,7 +158,7 @@ export function ChatReminderDialog({
                   onCheckedChange={() => toggleStaff(h.id)}
                 />
                 <span className="text-sm flex-1">
-                  {h.name.family} {h.name.given}
+                  {formatFullName(h.name)}
                 </span>
                 {isUnsub && (
                   <span className="text-xs text-destructive font-medium">未提出</span>
@@ -177,7 +178,7 @@ export function ChatReminderDialog({
 
         {noEmailStaff.length > 0 && (
           <p className="text-xs text-amber-600">
-            {noEmailStaff.map((h) => `${h.name.family} ${h.name.given}`).join('、')}
+            {noEmailStaff.map((h) => formatFullName(h.name)).join('、')}
             はメールアドレス未登録のため送信できません
           </p>
         )}

--- a/web/src/hooks/useDragAndDrop.ts
+++ b/web/src/hooks/useDragAndDrop.ts
@@ -13,6 +13,7 @@ import { getStaffCount } from '@/lib/dnd/staffCount';
 import { computeNewStaffIds } from '@/lib/dnd/computeStaffIds';
 import { createDragDropCommand } from '@/lib/undo/commands';
 import type { UndoCommand } from '@/lib/undo/types';
+import { formatFullName } from '@/utils/name';
 
 interface UseDragAndDropInput {
   helperRows: HelperScheduleRow[];
@@ -277,7 +278,7 @@ export function useDragAndDrop(input: UseDragAndDropInput) {
         if (onCommand) {
           const targetHelper = helpers.get(targetId);
           const targetHelperName = targetHelper
-            ? `${targetHelper.name.family} ${targetHelper.name.given}`
+            ? formatFullName(targetHelper.name)
             : targetId;
           const timeLabel = shifted ? `${shifted.newStartTime}-${shifted.newEndTime}` : null;
           const label = isSameHelper

--- a/web/src/lib/companion/filter.ts
+++ b/web/src/lib/companion/filter.ts
@@ -1,5 +1,6 @@
 import { isOverlapping } from '@/components/gantt/constants';
 import type { Order, Customer, Helper, StaffUnavailability, DayOfWeek } from '@/types';
+import { formatCompactName } from '@/utils/name';
 
 /**
  * 同行（OJT）候補ヘルパーを返す。
@@ -38,8 +39,8 @@ export function getCompanionCandidates(input: {
 
   // 名前順ソート
   candidates.sort((a, b) =>
-    `${a.name.family}${a.name.given}`.localeCompare(
-      `${b.name.family}${b.name.given}`,
+    formatCompactName(a.name).localeCompare(
+      formatCompactName(b.name),
       'ja',
     ),
   );

--- a/web/src/lib/report/aggregation.ts
+++ b/web/src/lib/report/aggregation.ts
@@ -1,5 +1,6 @@
 import type { Order, Helper, Customer, ServiceType, ServiceTypeDoc } from '@/types';
 import { timeToMinutes } from '@/utils/time';
+import { formatFullName } from '@/utils/name';
 
 // ── 型定義 ────────────────────────────────────────────────────
 
@@ -61,7 +62,7 @@ export function aggregateStaffSummary(
     for (const helperId of order.assigned_staff_ids) {
       const existing = map.get(helperId);
       const helper = helpers.get(helperId);
-      const name = helper ? `${helper.name.family} ${helper.name.given}` : '(不明)';
+      const name = helper ? formatFullName(helper.name) : '(不明)';
       if (existing) {
         existing.visitCount += 1;
         existing.totalMinutes += duration;
@@ -88,7 +89,7 @@ export function aggregateCustomerSummary(
     const customerId = order.customer_id;
     const existing = map.get(customerId);
     const customer = customers.get(customerId);
-    const name = customer ? `${customer.name.family} ${customer.name.given}` : '(不明)';
+    const name = customer ? formatFullName(customer.name) : '(不明)';
     if (existing) {
       existing.visitCount += 1;
       existing.totalMinutes += duration;

--- a/web/src/lib/validation/allowed-staff-check.ts
+++ b/web/src/lib/validation/allowed-staff-check.ts
@@ -1,5 +1,6 @@
 import type { Customer, Helper, Order, StaffUnavailability, DayOfWeek } from '@/types';
 import { timeToMinutes } from '@/utils/time';
+import { formatDisplayName } from '@/utils/name';
 
 export interface AllowedStaffWarning {
   customer_id: string;
@@ -103,14 +104,14 @@ export function checkAllowedStaff(input: CheckAllowedStaffInput): AllowedStaffWa
     if (feasible.length === 0) {
       warnings.push({
         customer_id: customer.id,
-        customer_name: customer.name.short ?? `${customer.name.family}${customer.name.given}`,
+        customer_name: formatDisplayName(customer.name),
         order_id: order.id,
         date: order.date,
         day_of_week: dayOfWeek,
         start_time: order.start_time,
         end_time: order.end_time,
         allowed_helper_names: allowedHelpers.map(
-          (h) => h.name.short ?? `${h.name.family}${h.name.given}`,
+          (h) => formatDisplayName(h.name),
         ),
       });
     }

--- a/web/src/utils/__tests__/name.test.ts
+++ b/web/src/utils/__tests__/name.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { formatFullName, formatCompactName, formatDisplayName, formatFullNameKana } from '../name';
+import type { PersonName } from '@/types';
+
+const name: PersonName = {
+  family: '山田',
+  given: '太郎',
+  short: '太郎',
+  family_kana: 'ヤマダ',
+  given_kana: 'タロウ',
+};
+
+describe('formatFullName', () => {
+  it('スペース区切りのフルネームを返す', () => {
+    expect(formatFullName(name)).toBe('山田 太郎');
+  });
+});
+
+describe('formatCompactName', () => {
+  it('スペースなしのフルネームを返す', () => {
+    expect(formatCompactName(name)).toBe('山田太郎');
+  });
+});
+
+describe('formatDisplayName', () => {
+  it('shortがある場合はshortを返す', () => {
+    expect(formatDisplayName(name)).toBe('太郎');
+  });
+
+  it('shortがない場合はコンパクト名を返す', () => {
+    const noShort: PersonName = { family: '山田', given: '太郎' };
+    expect(formatDisplayName(noShort)).toBe('山田太郎');
+  });
+});
+
+describe('formatFullNameKana', () => {
+  it('カナのフルネームを返す', () => {
+    expect(formatFullNameKana(name)).toBe('ヤマダ タロウ');
+  });
+
+  it('カナがない場合は空文字を返す', () => {
+    const noKana: PersonName = { family: '山田', given: '太郎' };
+    expect(formatFullNameKana(noKana)).toBe('');
+  });
+});

--- a/web/src/utils/name.ts
+++ b/web/src/utils/name.ts
@@ -1,0 +1,21 @@
+import type { PersonName } from '@/types';
+
+/** フルネーム表示（スペース区切り）: "山田 太郎" */
+export function formatFullName(name: PersonName): string {
+  return `${name.family} ${name.given}`;
+}
+
+/** コンパクト表示（スペースなし）: "山田太郎" */
+export function formatCompactName(name: PersonName): string {
+  return `${name.family}${name.given}`;
+}
+
+/** 表示名（short優先、フォールバック: コンパクト名）: "太郎" or "山田太郎" */
+export function formatDisplayName(name: PersonName): string {
+  return name.short ?? formatCompactName(name);
+}
+
+/** フルネーム（カナ）: "ヤマダ タロウ"。未設定時は空文字 */
+export function formatFullNameKana(name: PersonName): string {
+  return `${name.family_kana ?? ''} ${name.given_kana ?? ''}`.trim();
+}


### PR DESCRIPTION
## Summary
- `web/src/utils/name.ts` に名前フォーマット共通関数4つを定義
  - `formatFullName(name)`: スペース区切り「山田 太郎」
  - `formatCompactName(name)`: スペースなし「山田太郎」（ソート用）
  - `formatDisplayName(name)`: short優先フォールバック（ガント表示）
  - `formatFullNameKana(name)`: カナ表示
- 25ファイル40箇所以上のインライン名前フォーマットを統合
- `name.family` のみ使用（バリデーションメッセージ）は意図的に対象外

Closes #271

## Test plan
- [x] `web/src/utils/__tests__/name.test.ts` 新規テスト6件PASS
- [x] tsc --noEmit PASS
- [x] 既存テスト1,086件全PASS（回帰なし）
- [x] ロジック変更なし（純粋なDRYリファクタリング）

🤖 Generated with [Claude Code](https://claude.com/claude-code)