### PR TITLE
refactor: OptimizeButton の Firestore 二重サブスクリプション解消

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -39,7 +39,7 @@ import type { ViolationSeverity } from '@/lib/constraints/checker';
 function SchedulePage() {
   const { welcomeOpen, closeWelcome, reopenWelcome } = useWelcomeDialog();
   const { weekStart, selectedDay, setSelectedDay, viewMode, setViewMode, ganttAxis } = useScheduleContext();
-  const { customers, helpers, orderCounts, getDaySchedule, unavailability, loading, travelTimeLookup } =
+  const { customers, helpers, orders, orderCounts, getDaySchedule, unavailability, loading, travelTimeLookup } =
     useScheduleData(weekStart);
 
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
@@ -235,7 +235,7 @@ function SchedulePage() {
           {viewMode === 'day' && <BulkCompleteButton schedule={schedule} />}
           <NoteImportButton />
           <ResetButton onHistoryClear={clearHistory} />
-          <OptimizeButton onHistoryClear={clearHistory} onComplete={handleOptimizeComplete} />
+          <OptimizeButton customers={customers} helpers={helpers} orders={orders} unavailability={unavailability} onHistoryClear={clearHistory} onComplete={handleOptimizeComplete} />
         </div>
       </div>
       <StatsBar

--- a/web/src/components/schedule/OptimizeButton.tsx
+++ b/web/src/components/schedule/OptimizeButton.tsx
@@ -16,7 +16,6 @@ import {
 import { toast } from 'sonner';
 import { runOptimize, OptimizeApiError } from '@/lib/api/optimizer';
 import { useScheduleContext } from '@/contexts/ScheduleContext';
-import { useScheduleData } from '@/hooks/useScheduleData';
 import {
   ConstraintWeightsForm,
   DEFAULT_WEIGHTS,
@@ -25,15 +24,19 @@ import {
 import { checkAllowedStaff, type AllowedStaffWarning } from '@/lib/validation/allowed-staff-check';
 import { DAY_OF_WEEK_LABELS } from '@/types';
 import { clearCompanionField } from '@/lib/firestore/updateOrder';
+import type { Customer, Helper, Order, StaffUnavailability } from '@/types';
 
 interface OptimizeButtonProps {
+  customers: Map<string, Customer>;
+  helpers: Map<string, Helper>;
+  orders: Order[];
+  unavailability: StaffUnavailability[];
   onHistoryClear?: () => void;
   onComplete?: () => void;
 }
 
-export function OptimizeButton({ onHistoryClear, onComplete }: OptimizeButtonProps = {}) {
+export function OptimizeButton({ customers, helpers, orders, unavailability, onHistoryClear, onComplete }: OptimizeButtonProps) {
   const { weekStart } = useScheduleContext();
-  const { customers, helpers, orders, unavailability } = useScheduleData(weekStart);
 
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/web/src/components/schedule/__tests__/OptimizeButton.test.tsx
+++ b/web/src/components/schedule/__tests__/OptimizeButton.test.tsx
@@ -30,20 +30,14 @@ vi.mock('@/contexts/ScheduleContext', () => ({
   }),
 }));
 
-// orders をテストごとに制御できるよう factory で提供する
+// props として渡すデフォルトデータ
 const mockOrders: Order[] = [];
-vi.mock('@/hooks/useScheduleData', () => ({
-  useScheduleData: () => ({
-    customers: new Map(),
-    helpers: new Map(),
-    orders: mockOrders,
-    unavailability: [],
-    loading: false,
-    ordersByDay: {},
-    daySchedules: [],
-    travelTimeLookup: new Map(),
-  }),
-}));
+const defaultProps = {
+  customers: new Map(),
+  helpers: new Map(),
+  orders: mockOrders,
+  unavailability: [] as import('@/types').StaffUnavailability[],
+};
 
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
@@ -103,7 +97,7 @@ describe('OptimizeButton 事前チェック', () => {
   it('警告なし → 直接最適化ダイアログが開く', () => {
     mockCheckAllowedStaff.mockReturnValue([]);
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('シフト最適化の実行')).toBeInTheDocument();
@@ -113,7 +107,7 @@ describe('OptimizeButton 事前チェック', () => {
   it('警告あり → 事前警告ダイアログが開く', () => {
     mockCheckAllowedStaff.mockReturnValue([WARNING_FIXTURE]);
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('最適化前の注意')).toBeInTheDocument();
@@ -123,7 +117,7 @@ describe('OptimizeButton 事前チェック', () => {
   it('警告ダイアログに利用者名・曜日・時間帯が表示される', () => {
     mockCheckAllowedStaff.mockReturnValue([WARNING_FIXTURE]);
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('山田太郎')).toBeInTheDocument();
@@ -135,7 +129,7 @@ describe('OptimizeButton 事前チェック', () => {
   it('警告ダイアログにallowedヘルパー名が表示される', () => {
     mockCheckAllowedStaff.mockReturnValue([WARNING_FIXTURE]);
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText(/佐藤一郎/)).toBeInTheDocument();
@@ -145,7 +139,7 @@ describe('OptimizeButton 事前チェック', () => {
   it('「戻って修正する」で警告ダイアログが閉じる', async () => {
     mockCheckAllowedStaff.mockReturnValue([WARNING_FIXTURE]);
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('最適化前の注意')).toBeInTheDocument();
@@ -161,7 +155,7 @@ describe('OptimizeButton 事前チェック', () => {
   it('「警告を無視して実行」で最適化ダイアログに遷移する', async () => {
     mockCheckAllowedStaff.mockReturnValue([WARNING_FIXTURE]);
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('最適化前の注意')).toBeInTheDocument();
@@ -187,7 +181,7 @@ describe('OptimizeButton 事前チェック', () => {
     };
     mockCheckAllowedStaff.mockReturnValue([WARNING_FIXTURE, warning2]);
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('山田太郎')).toBeInTheDocument();
@@ -205,7 +199,7 @@ describe('OptimizeButton 同行（OJT）設定の警告とクリア', () => {
   });
 
   it('同行設定なし → 直接最適化ダイアログが開き、同行警告は表示されない', () => {
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('シフト最適化の実行')).toBeInTheDocument();
@@ -215,7 +209,7 @@ describe('OptimizeButton 同行（OJT）設定の警告とクリア', () => {
   it('同行設定あり → 同行警告ダイアログが表示される', () => {
     mockOrders.push(makeOrderWithCompanion('O1'));
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('同行設定のリセット確認')).toBeInTheDocument();
@@ -226,7 +220,7 @@ describe('OptimizeButton 同行（OJT）設定の警告とクリア', () => {
     mockOrders.push(makeOrderWithCompanion('O1'));
     mockOrders.push(makeOrderWithCompanion('O2'));
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText(/同行設定が2件あります/)).toBeInTheDocument();
@@ -235,7 +229,7 @@ describe('OptimizeButton 同行（OJT）設定の警告とクリア', () => {
   it('同行警告でキャンセル → ダイアログが閉じ、最適化は実行されない', async () => {
     mockOrders.push(makeOrderWithCompanion('O1'));
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
     fireEvent.click(screen.getByText('キャンセル'));
 
@@ -249,7 +243,7 @@ describe('OptimizeButton 同行（OJT）設定の警告とクリア', () => {
   it('同行警告で「リセットして実行」→ 最適化ダイアログへ遷移する', async () => {
     mockOrders.push(makeOrderWithCompanion('O1'));
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
 
     expect(screen.getByText('同行設定のリセット確認')).toBeInTheDocument();
@@ -270,7 +264,7 @@ describe('OptimizeButton 同行（OJT）設定の警告とクリア', () => {
       solve_time_seconds: 1.2,
     });
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     // 同行警告を経由して最適化ダイアログを開く
     fireEvent.click(screen.getByText('最適化実行'));
     fireEvent.click(screen.getByText('リセットして実行'));
@@ -291,7 +285,7 @@ describe('OptimizeButton 同行（OJT）設定の警告とクリア', () => {
       solve_time_seconds: 0.8,
     });
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
     await waitFor(() => screen.getByText('シフト最適化の実行'));
     fireEvent.click(screen.getByText('実行'));
@@ -306,7 +300,7 @@ describe('OptimizeButton 同行（OJT）設定の警告とクリア', () => {
     mockOrders.push(makeOrderWithCompanion('O1'));
     mockRunOptimize.mockRejectedValue(new Error('network error'));
 
-    render(<OptimizeButton />);
+    render(<OptimizeButton {...defaultProps} />);
     fireEvent.click(screen.getByText('最適化実行'));
     fireEvent.click(screen.getByText('リセットして実行'));
     await waitFor(() => screen.getByText('シフト最適化の実行'));


### PR DESCRIPTION
## Summary
- OptimizeButton が独自に `useScheduleData()` を呼んでいた二重サブスクリプションを解消
- 親 SchedulePage から props でデータを受け取る方式に変更
- Firestore リアルタイムリスナー4本の重複が解消（helpers, customers, orders, unavailability）

Closes #272

## Test plan
- [x] tsc --noEmit PASS
- [x] 既存テスト1,086件全PASS（回帰なし）
- [x] OptimizeButton テスト15件全PASS（モック→props方式に更新）
- [x] ロジック変更なし（データ取得経路の変更のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)