### PR TITLE
fix: isValidSettings に note_import_sources 用の条件を追加

### DIFF
--- a/firebase/__tests__/firestore.rules.test.ts
+++ b/firebase/__tests__/firestore.rules.test.ts
@@ -1355,4 +1355,70 @@ describe('settings - デモモード（hasNoRole）', () => {
       setDoc(doc(authed.firestore(), 'settings', 'notification'), validSettingsData)
     );
   });
+
+  it('デモモードユーザーは note_import_sources を作成できる', async () => {
+    const authed = testEnv.authenticatedContext('demo-user');
+    await assertSucceeds(
+      setDoc(doc(authed.firestore(), 'settings', 'note_import_sources'), {
+        cura_note: 'spreadsheet-id-1',
+        updated_at: serverTimestamp(),
+      })
+    );
+  });
+});
+
+// ============================================================
+// settings/note_import_sources: 複数インポートソース設定
+// ============================================================
+
+describe('settings/note_import_sources - admin 書き込み', () => {
+  it('admin は note_import_sources を新規作成できる', async () => {
+    const admin = testEnv.authenticatedContext('admin-1', { role: 'admin' });
+    await assertSucceeds(
+      setDoc(doc(admin.firestore(), 'settings', 'note_import_sources'), {
+        cura_note: 'spreadsheet-id-1',
+        updated_at: serverTimestamp(),
+      })
+    );
+  });
+
+  it('admin は note_import_sources を更新できる（merge）', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await setDoc(doc(context.firestore(), 'settings', 'note_import_sources'), {
+        cura_note: 'spreadsheet-id-1',
+        updated_at: serverTimestamp(),
+      });
+    });
+    const admin = testEnv.authenticatedContext('admin-1', { role: 'admin' });
+    await assertSucceeds(
+      setDoc(doc(admin.firestore(), 'settings', 'note_import_sources'), {
+        fusen: 'spreadsheet-id-2',
+        updated_at: serverTimestamp(),
+      }, { merge: true })
+    );
+  });
+
+  it('admin は 3ソース全てを設定できる', async () => {
+    const admin = testEnv.authenticatedContext('admin-1', { role: 'admin' });
+    await assertSucceeds(
+      setDoc(doc(admin.firestore(), 'settings', 'note_import_sources'), {
+        cura_note: 'spreadsheet-id-1',
+        fusen: 'spreadsheet-id-2',
+        checklist: 'spreadsheet-id-3',
+        updated_at: serverTimestamp(),
+      })
+    );
+  });
+});
+
+describe('settings/note_import_sources - バリデーション', () => {
+  it('ソースキーなしのデータは書き込み拒否される', async () => {
+    const admin = testEnv.authenticatedContext('admin-1', { role: 'admin' });
+    await assertFails(
+      setDoc(doc(admin.firestore(), 'settings', 'note_import_sources'), {
+        invalid_key: 'some-value',
+        updated_at: serverTimestamp(),
+      })
+    );
+  });
 });

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -126,8 +126,10 @@ service cloud.firestore {
       let data = request.resource.data;
       // settings/notification: sender_email必須
       // settings/cura_import: spreadsheet_id必須
+      // settings/note_import_sources: cura_note/fusen/checklist いずれかのキー必須
       return (data.keys().hasAny(['sender_email']) && data.sender_email is string)
-          || (data.keys().hasAny(['spreadsheet_id']) && data.spreadsheet_id is string);
+          || (data.keys().hasAny(['spreadsheet_id']) && data.spreadsheet_id is string)
+          || (data.keys().hasAny(['cura_note', 'fusen', 'checklist']));
     }
 
     // ── コレクションルール ──────────────────────────


### PR DESCRIPTION
## Summary
- Phase 6d（#313）で複数ソース対応を追加した際、Firestoreルールの `isValidSettings()` を更新し忘れたため、ノート取込設定の保存が拒否されていたバグを修正
- `cura_note`/`fusen`/`checklist` キーを許可する条件を追加
- テスト6件追加（121件全パス）

## Test plan
- [x] Firestoreルールテスト 121件全パス
- [x] 本番デプロイ済み（`firebase deploy --only firestore:rules`）
- [x] 本番環境でCURAノートのスプレッドシートID保存を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)